### PR TITLE
Cross-platform port (macOS/Windows) + three-OS CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,16 +14,29 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  # One source tree, compiled and tested three ways. This matrix is what keeps
+  # the macOS/Windows code (the cfg-gated hidapi HID backend) from rotting: a
+  # Linux-only change that breaks another platform fails the PR here, so we never
+  # need separate per-OS branches. `fail-fast: false` so one platform failing
+  # still lets the others report.
   test:
-    name: clippy + test (Linux, stable)
-    runs-on: ubuntu-latest
+    name: clippy + test (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@v4
 
-      # System libraries the workspace links against:
-      #  - libpcsclite-dev: the `pcsc` crate (keyroost-transport).
+      # Linux links against system libraries the other platforms provide natively:
+      #  - libpcsclite-dev: the `pcsc` crate (keyroost-transport). macOS uses the
+      #    PCSC framework and Windows uses WinSCard, both already present.
       #  - the X11/Wayland/XKB/GL set: eframe/egui/winit/glow (the `keyroost` GUI).
-      - name: Install system dependencies
+      #    macOS (Cocoa) and Windows (Win32) need no extra packages.
+      # The Linux build uses the dependency-free sysfs HID backend, so no libudev.
+      - name: Install Linux system dependencies
+        if: runner.os == 'Linux'
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
@@ -38,9 +51,13 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
 
+      # Formatting is platform-independent; check it once on Linux.
       - name: Format check
+        if: runner.os == 'Linux'
         run: cargo fmt --all --check
 
+      # On macOS/Windows this compiles the cfg(not(target_os = "linux")) hidapi
+      # backend for real — the coverage the `hidapi-backend` feature only fakes.
       - name: Clippy (deny warnings)
         run: cargo clippy --workspace --all-targets --locked -- -D warnings
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1295,6 +1295,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
 
 [[package]]
+name = "hidapi"
+version = "2.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c78dadfc12f865bc3fcac3897e64533b930737ceb9ef245c8277de98d0b010e9"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "pkg-config",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "hkdf"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1563,6 +1576,7 @@ version = "0.2.0"
 dependencies = [
  "aes",
  "cbc",
+ "hidapi",
  "hmac",
  "keyroost-hid",
  "p256",
@@ -1573,6 +1587,9 @@ dependencies = [
 [[package]]
 name = "keyroost-hid"
 version = "0.2.0"
+dependencies = [
+ "hidapi",
+]
 
 [[package]]
 name = "keyroost-import"

--- a/PLAN.md
+++ b/PLAN.md
@@ -41,9 +41,10 @@ read foundation landed, the agreed next items, in priority order:
    (live click-test the GUI panes; force the OpenPGP decrypt command-chaining
    path on hardware); add a CHANGELOG; document the udev-rules install in the
    README; then tag `v0.1.0`.
-2. **Cross-platform.** macOS/Windows — the HID layer (`keyroost-hid`) is
-   Linux-sysfs only and parts of the PC/SC plumbing assume Linux. Broadens reach
-   but touches the lowest transport layers.
+2. **Cross-platform.** macOS/Windows — **in progress.** The hidapi HID backend
+   has landed behind `cfg(not(target_os = "linux"))` and the PC/SC wording is
+   platform-neutral; what remains is CI/release coverage and hardware sign-off.
+   See the **Cross-platform roadmap** section below for the agreed plan.
 3. **UI/UX design pass.** The GUI grew pane-by-pane (Molto2 profiles, Security
    Keys, OATH, OpenPGP) without a holistic design pass. Revisit information
    architecture, consistency across panes, empty/error states, and the
@@ -51,6 +52,51 @@ read foundation landed, the agreed next items, in priority order:
 
 Further out: finish the **PIV write/auth** surface (see the PIV entry under
 Phase 3+), and the YubiKey-OATH/other deferred compatibility notes below.
+
+## Cross-platform roadmap (Linux / macOS / Windows)
+
+Decisions agreed for extending keyroost beyond Linux:
+
+- **One `main`, not per-OS branches.** A single source tree with `cfg`-gated
+  backends (`HidIo`, `enumerate_*`). Three long-lived platform branches would
+  force every fix to be cherry-picked 3× and would drift; the shared 90%
+  (protocol, CBOR, OATH/OpenPGP/PIV, GUI) is identical, and only the thin
+  HID/PC-SC backend differs. The **CI matrix is the cross-platform guarantee** —
+  the same commit compiled and tested on all three OSes — not branch isolation.
+- **HID backend: hybrid (hidapi now, native later).** macOS (IOKit) and Windows
+  (hid.dll) use the `hidapi` crate, auto-selected off Linux. This is the one
+  accepted C dependency for this scope (cf. `keyroost-rsakey`'s scoped
+  exception); a hand-vendored IOKit/SetupAPI backend behind the same seam stays
+  a future option, taken only if hidapi becomes a liability. **The Linux release
+  never links hidapi** — it keeps the dependency-free sysfs/hidraw backend. The
+  `hidapi-backend` feature is a Linux-only test hook (needs `libudev-dev`) and
+  must never be enabled in a Linux release build.
+- **Support tiers.** Linux is **tier-1** (fully supported, hardware-verified).
+  macOS/Windows are **tier-2** (best-effort, community-tested); until the
+  hardware sign-off below, they are *experimental/unverified* in user docs.
+
+Phases:
+
+- **A — Honesty pass (done).** Corrected the misleading `hidapi-backend`
+  smoke-test comments (libudev prereq, never-in-release), and the macOS PC/SC
+  error wording (macOS has no user-run pcscd).
+- **B — CI matrix (done).** `ci.yml` builds + clippy + tests on
+  `ubuntu-latest`, `macos-latest`, and `windows-latest` (`fail-fast: false`).
+  This compiles the real hidapi backend on macOS/Windows — coverage the
+  `hidapi-backend` feature only faked — so the non-Linux path can't rot uncaught.
+- **C — Release matrix.** Extend `release.yml` to produce macOS (arm64 +
+  x86_64) and Windows x86_64 artifacts (`.zip` on Windows). GUI niceties:
+  `#![windows_subsystem = "windows"]` so the Windows GUI spawns no console.
+- **D — Functional parity gaps.** Document the macOS/Windows degradation in the
+  HID↔CCID topology correlation (`keyroost-resolve::ccid_serial_for`): hidapi
+  exposes no USB bus/address, so two serial-less YubiKeys can't be
+  disambiguated and naming falls back to the single-reader case.
+- **E — Hardware sign-off (gates the tier-2 claim).** One real run each on a Mac
+  and a Windows box with a YubiKey: enumerate → `getInfo` → an OATH/OpenPGP op
+  over PC/SC. Until this passes, user docs say "experimental," not "tier-2."
+- **F — Native HID backend (deferred, not scheduled).** Spike hand-written
+  IOKit + SetupAPI backends behind the existing `HidIo`/`enumerate_*` seam only
+  if hidapi proves a liability; would need an `unsafe_code` scoped exception.
 
 ## Phases
 

--- a/crates/keyroost-ctap/Cargo.toml
+++ b/crates/keyroost-ctap/Cargo.toml
@@ -11,8 +11,11 @@ description = "CTAP HID transport, CBOR codec, and high-level CTAP2 commands for
 workspace = true
 
 [features]
-# Force the hidapi I/O backend on (also auto-selected on non-Linux). Lets the
-# cross-platform CTAP transport be built and smoke-tested on Linux.
+# Test/dev hook ONLY — never enable this for a Linux release. It forces the
+# hidapi I/O backend on so the cross-platform CTAP transport can be built and
+# smoke-tested on Linux; real macOS/Windows coverage comes from the CI matrix,
+# not this flag. Building it on Linux needs `libudev-dev` (see keyroost-hid).
+# The default Linux build never touches it and stays dependency-free.
 hidapi-backend = ["dep:hidapi", "keyroost-hid/hidapi-backend"]
 
 [dependencies]

--- a/crates/keyroost-ctap/Cargo.toml
+++ b/crates/keyroost-ctap/Cargo.toml
@@ -10,8 +10,20 @@ description = "CTAP HID transport, CBOR codec, and high-level CTAP2 commands for
 [lints]
 workspace = true
 
+[features]
+# Force the hidapi I/O backend on (also auto-selected on non-Linux). Lets the
+# cross-platform CTAP transport be built and smoke-tested on Linux.
+hidapi-backend = ["dep:hidapi", "keyroost-hid/hidapi-backend"]
+
 [dependencies]
 keyroost-hid = { path = "../keyroost-hid", version = "0.2.0" }
+# Optional so a default Linux build pulls nothing (the hidraw File backend is
+# dependency-free); enabled by `hidapi-backend` for testing.
+hidapi = { version = "2.6", optional = true, default-features = false, features = [
+    "linux-static-hidraw",
+    "macos-shared-device",
+    "windows-native",
+] }
 # Phase 2 crypto: PIN protocol uses P-256 ECDH, AES-256-CBC, HMAC-SHA-256.
 # Vendoring all of this would be ~1500 LOC of unaudited primitives; sha2 is
 # already pulled in transitively by p256, so adding the rest explicitly costs
@@ -24,3 +36,11 @@ p256 = { version = "0.13", default-features = false, features = ["arithmetic", "
 # OsRng for ephemeral keypair + AES IVs. p256 re-exports rand_core but the
 # OsRng inside it is gated behind rand_core's `getrandom` feature.
 rand_core = { version = "0.6", default-features = false, features = ["getrandom"] }
+
+# Auto-select the hidapi I/O backend on macOS / Windows (Linux keeps the
+# dependency-free hidraw File backend).
+[target.'cfg(not(target_os = "linux"))'.dependencies]
+hidapi = { version = "2.6", default-features = false, features = [
+    "macos-shared-device",
+    "windows-native",
+] }

--- a/crates/keyroost-ctap/src/hid.rs
+++ b/crates/keyroost-ctap/src/hid.rs
@@ -53,12 +53,21 @@ pub const CAPABILITY_NMSG: u8 = 0x08;
 pub enum HidTransportError {
     Io(io::Error),
     Timeout,
-    UnexpectedCommand { expected: u8, got: u8 },
+    UnexpectedCommand {
+        expected: u8,
+        got: u8,
+    },
     InitResponseTooShort,
     PayloadTooLarge(usize),
-    OutOfSequence { expected: u8, got: u8 },
+    OutOfSequence {
+        expected: u8,
+        got: u8,
+    },
     DeviceError(u8),
     NonceMismatch,
+    /// This platform has no HID I/O backend yet (macOS / Windows pending). Only
+    /// Linux (hidraw) is implemented; see `keyroost_hid::hid_supported`.
+    Unsupported,
 }
 
 impl std::fmt::Display for HidTransportError {
@@ -85,6 +94,12 @@ impl std::fmt::Display for HidTransportError {
             }
             HidTransportError::NonceMismatch => {
                 write!(f, "CTAPHID_INIT response carried the wrong nonce")
+            }
+            HidTransportError::Unsupported => {
+                write!(
+                    f,
+                    "FIDO HID is not supported on this platform yet (only Linux/hidraw)"
+                )
             }
         }
     }
@@ -131,6 +146,12 @@ pub struct CtapHidDevice {
 impl CtapHidDevice {
     /// Open a hidraw device and allocate a CTAPHID channel.
     pub fn open(path: &Path) -> Result<(Self, InitResponse), HidTransportError> {
+        // hidraw read/write is the Linux backend; macOS/Windows need IOKit /
+        // hid.dll, which aren't wired yet. Fail clearly rather than with a
+        // confusing "no such file" on a path that can't exist off Linux.
+        if !cfg!(target_os = "linux") {
+            return Err(HidTransportError::Unsupported);
+        }
         let file = OpenOptions::new().read(true).write(true).open(path)?;
         let mut dev = Self {
             file,

--- a/crates/keyroost-ctap/src/hid.rs
+++ b/crates/keyroost-ctap/src/hid.rs
@@ -1,4 +1,7 @@
-//! CTAP HID transport over a Linux `/dev/hidraw*` device.
+//! CTAP HID transport. Linux uses a dependency-free `/dev/hidraw*` `File`
+//! backend; macOS and Windows use hidapi (IOKit / hid.dll) behind the same
+//! `write_report` / `read_report` interface. The `hidapi-backend` feature forces
+//! the hidapi path on for building/testing it on Linux too.
 //!
 //! Implements the wire framing from the FIDO CTAP HID spec: 64-byte reports,
 //! init frame with a 7-byte header (CID + CMD + BCNT), continuation frames
@@ -13,8 +16,11 @@
 //! KEEPALIVE frames, so a true hang only happens for an unplugged or broken
 //! device.
 
+#[cfg(all(target_os = "linux", not(feature = "hidapi-backend")))]
 use std::fs::{File, OpenOptions};
-use std::io::{self, Read, Write};
+use std::io;
+#[cfg(all(target_os = "linux", not(feature = "hidapi-backend")))]
+use std::io::{Read, Write};
 use std::path::Path;
 use std::time::{Duration, Instant};
 
@@ -65,9 +71,10 @@ pub enum HidTransportError {
     },
     DeviceError(u8),
     NonceMismatch,
-    /// This platform has no HID I/O backend yet (macOS / Windows pending). Only
-    /// Linux (hidraw) is implemented; see `keyroost_hid::hid_supported`.
-    Unsupported,
+    /// The hidapi I/O backend (macOS / Windows, or Linux under the
+    /// `hidapi-backend` feature) reported an error opening or talking to the
+    /// device.
+    Backend(String),
 }
 
 impl std::fmt::Display for HidTransportError {
@@ -95,12 +102,7 @@ impl std::fmt::Display for HidTransportError {
             HidTransportError::NonceMismatch => {
                 write!(f, "CTAPHID_INIT response carried the wrong nonce")
             }
-            HidTransportError::Unsupported => {
-                write!(
-                    f,
-                    "FIDO HID is not supported on this platform yet (only Linux/hidraw)"
-                )
-            }
+            HidTransportError::Backend(s) => write!(f, "HID backend error: {}", s),
         }
     }
 }
@@ -136,31 +138,83 @@ impl InitResponse {
     }
 }
 
+/// Platform HID I/O backend. Linux uses the dependency-free hidraw `File`;
+/// macOS/Windows (and Linux under `hidapi-backend`) use hidapi. Exactly one
+/// variant exists per build.
+enum HidIo {
+    #[cfg(all(target_os = "linux", not(feature = "hidapi-backend")))]
+    Hidraw(File),
+    #[cfg(any(not(target_os = "linux"), feature = "hidapi-backend"))]
+    Hidapi(hidapi::HidDevice),
+}
+
 /// An open CTAP HID channel ready to dispatch commands.
 pub struct CtapHidDevice {
-    file: File,
+    io: HidIo,
     channel_id: u32,
     timeout: Duration,
 }
 
 impl CtapHidDevice {
-    /// Open a hidraw device and allocate a CTAPHID channel.
+    /// Open a HID device by path and allocate a CTAPHID channel.
     pub fn open(path: &Path) -> Result<(Self, InitResponse), HidTransportError> {
-        // hidraw read/write is the Linux backend; macOS/Windows need IOKit /
-        // hid.dll, which aren't wired yet. Fail clearly rather than with a
-        // confusing "no such file" on a path that can't exist off Linux.
-        if !cfg!(target_os = "linux") {
-            return Err(HidTransportError::Unsupported);
-        }
-        let file = OpenOptions::new().read(true).write(true).open(path)?;
+        let io = Self::open_io(path)?;
         let mut dev = Self {
-            file,
+            io,
             channel_id: CTAPHID_BROADCAST_CID,
             timeout: Duration::from_secs(2),
         };
         let init = dev.do_init()?;
         dev.channel_id = init.channel_id;
         Ok((dev, init))
+    }
+
+    /// Linux backend: open the `/dev/hidraw*` node read/write.
+    #[cfg(all(target_os = "linux", not(feature = "hidapi-backend")))]
+    fn open_io(path: &Path) -> Result<HidIo, HidTransportError> {
+        let file = OpenOptions::new().read(true).write(true).open(path)?;
+        Ok(HidIo::Hidraw(file))
+    }
+
+    /// hidapi backend (macOS / Windows): open by the platform device path.
+    #[cfg(any(not(target_os = "linux"), feature = "hidapi-backend"))]
+    fn open_io(path: &Path) -> Result<HidIo, HidTransportError> {
+        let api = hidapi::HidApi::new().map_err(|e| HidTransportError::Backend(e.to_string()))?;
+        let cpath = std::ffi::CString::new(path.to_string_lossy().as_bytes())
+            .map_err(|_| HidTransportError::Backend("device path contained a NUL byte".into()))?;
+        let dev = api
+            .open_path(&cpath)
+            .map_err(|e| HidTransportError::Backend(e.to_string()))?;
+        Ok(HidIo::Hidapi(dev))
+    }
+
+    /// Write one 65-byte output report (leading 0x00 report ID) to the device.
+    fn write_report(&mut self, frame: &[u8]) -> Result<(), HidTransportError> {
+        match &mut self.io {
+            #[cfg(all(target_os = "linux", not(feature = "hidapi-backend")))]
+            HidIo::Hidraw(f) => f.write_all(frame)?,
+            #[cfg(any(not(target_os = "linux"), feature = "hidapi-backend"))]
+            HidIo::Hidapi(d) => {
+                d.write(frame)
+                    .map_err(|e| HidTransportError::Backend(e.to_string()))?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Read one 64-byte input report into `buf`.
+    fn read_report(&mut self, buf: &mut [u8]) -> Result<(), HidTransportError> {
+        match &mut self.io {
+            #[cfg(all(target_os = "linux", not(feature = "hidapi-backend")))]
+            HidIo::Hidraw(f) => f.read_exact(buf)?,
+            #[cfg(any(not(target_os = "linux"), feature = "hidapi-backend"))]
+            HidIo::Hidapi(d) => {
+                buf.fill(0);
+                d.read(buf)
+                    .map_err(|e| HidTransportError::Backend(e.to_string()))?;
+            }
+        }
+        Ok(())
     }
 
     pub fn channel_id(&self) -> u32 {
@@ -226,7 +280,7 @@ impl CtapHidDevice {
         frame[7] = (payload.len() & 0xFF) as u8;
         let first_chunk = payload.len().min(INIT_FRAME_DATA);
         frame[8..8 + first_chunk].copy_from_slice(&payload[..first_chunk]);
-        self.file.write_all(&frame)?;
+        self.write_report(&frame)?;
 
         // Continuation frames.
         let mut offset = first_chunk;
@@ -238,7 +292,7 @@ impl CtapHidDevice {
             frame[1..5].copy_from_slice(&cid_be);
             frame[5] = seq & 0x7F;
             frame[6..6 + chunk].copy_from_slice(&payload[offset..offset + chunk]);
-            self.file.write_all(&frame)?;
+            self.write_report(&frame)?;
             offset += chunk;
             seq = seq.wrapping_add(1);
         }
@@ -250,7 +304,7 @@ impl CtapHidDevice {
         let mut buf = [0u8; CTAPHID_REPORT_SIZE];
 
         loop {
-            self.file.read_exact(&mut buf)?;
+            self.read_report(&mut buf)?;
             let cid = u32::from_be_bytes([buf[0], buf[1], buf[2], buf[3]]);
             let cmd = buf[4];
             if cid != expected_cid {
@@ -280,7 +334,7 @@ impl CtapHidDevice {
 
             let mut seq: u8 = 0;
             while payload.len() < bcnt {
-                self.file.read_exact(&mut buf)?;
+                self.read_report(&mut buf)?;
                 let cid2 = u32::from_be_bytes([buf[0], buf[1], buf[2], buf[3]]);
                 if cid2 != expected_cid {
                     continue;

--- a/crates/keyroost-hid/Cargo.toml
+++ b/crates/keyroost-hid/Cargo.toml
@@ -10,4 +10,24 @@ description = "USB HID enumeration for FIDO / security-key devices on Linux."
 [lints]
 workspace = true
 
+[features]
+# Force the hidapi backend on (also auto-selected on non-Linux). Lets the
+# cross-platform backend be built and smoke-tested on Linux.
+hidapi-backend = ["dep:hidapi"]
+
 [dependencies]
+# Optional so a default Linux build pulls nothing (the vendored sysfs backend
+# stays dependency-free); enabled by the `hidapi-backend` feature for testing.
+hidapi = { version = "2.6", optional = true, default-features = false, features = [
+    "linux-static-hidraw",
+    "macos-shared-device",
+    "windows-native",
+] }
+
+# Auto-select the hidapi backend on macOS / Windows (Linux keeps the vendored
+# sysfs backend with no dependency).
+[target.'cfg(not(target_os = "linux"))'.dependencies]
+hidapi = { version = "2.6", default-features = false, features = [
+    "macos-shared-device",
+    "windows-native",
+] }

--- a/crates/keyroost-hid/Cargo.toml
+++ b/crates/keyroost-hid/Cargo.toml
@@ -11,8 +11,12 @@ description = "USB HID enumeration for FIDO / security-key devices on Linux."
 workspace = true
 
 [features]
-# Force the hidapi backend on (also auto-selected on non-Linux). Lets the
-# cross-platform backend be built and smoke-tested on Linux.
+# Test/dev hook ONLY — never enable this for a Linux release. It forces the
+# hidapi backend on so the cross-platform path can be built and smoke-tested on
+# Linux; real macOS/Windows coverage comes from the CI matrix, not this flag.
+# Building it on Linux needs `libudev-dev` (hidapi's Linux build links libudev
+# even with `linux-static-hidraw`). The default Linux build never touches it and
+# stays dependency-free.
 hidapi-backend = ["dep:hidapi"]
 
 [dependencies]

--- a/crates/keyroost-hid/src/lib.rs
+++ b/crates/keyroost-hid/src/lib.rs
@@ -117,11 +117,21 @@ pub fn bootloader_device_present() -> Option<&'static str> {
         .find_map(HidDevice::bootloader_label)
 }
 
+/// Whether this platform has a HID backend. Today only Linux (sysfs) is
+/// implemented; macOS (IOKit) and Windows (hid.dll) backends are pending. When
+/// this is `false`, [`enumerate`] returns an empty list and FIDO/CTAP is
+/// unavailable — front-ends should say so explicitly rather than reporting "no
+/// FIDO devices", which would imply none are plugged in.
+#[must_use]
+pub fn hid_supported() -> bool {
+    cfg!(target_os = "linux")
+}
+
 /// List all `/dev/hidraw*` devices visible to the current user via sysfs.
 ///
 /// Devices the caller lacks permission to *open* are still returned —
-/// enumeration reads sysfs only. Returns an empty list on non-Linux
-/// platforms.
+/// enumeration reads sysfs only. Returns an empty list on platforms without a
+/// HID backend (see [`hid_supported`]).
 pub fn enumerate() -> Result<Vec<HidDevice>, HidError> {
     if !cfg!(target_os = "linux") {
         return Ok(Vec::new());

--- a/crates/keyroost-hid/src/lib.rs
+++ b/crates/keyroost-hid/src/lib.rs
@@ -1,18 +1,22 @@
 //! USB HID enumeration for FIDO / security-key devices.
 //!
-//! Phase 0 of extending keyroost toward FIDO2/U2F support. This crate
-//! enumerates `/dev/hidraw*` device nodes by reading sysfs metadata — no
-//! external dependencies, no ioctls, no device-open required. That keeps
-//! enumeration root-free and means it works even when the user has not yet
-//! installed the udev rules in `udev/70-keyroost-fido.rules`.
+//! On **Linux** this enumerates `/dev/hidraw*` device nodes by reading sysfs
+//! metadata — no external dependencies, no ioctls, no device-open required.
+//! That keeps enumeration root-free and means it works even when the user has
+//! not yet installed the udev rules in `udev/70-keyroost-fido.rules`.
 //!
-//! On non-Linux targets [`enumerate`] returns an empty list. macOS and
-//! Windows backends are deferred to a later phase.
+//! On **macOS and Windows** it uses the `hidapi` crate (IOKit / hid.dll),
+//! selected automatically off Linux. The `hidapi-backend` feature forces that
+//! path on for building/testing the cross-platform backend on Linux too. USB
+//! topology (`usb_bus`/`usb_address`) is only available via the sysfs backend.
 
 use std::fmt;
+#[cfg(all(target_os = "linux", not(feature = "hidapi-backend")))]
 use std::fs;
 use std::io;
-use std::path::{Path, PathBuf};
+#[cfg(all(target_os = "linux", not(feature = "hidapi-backend")))]
+use std::path::Path;
+use std::path::PathBuf;
 
 /// HID usage page assigned to FIDO U2F / CTAP HID by usb.org.
 pub const HID_USAGE_PAGE_FIDO: u16 = 0xF1D0;
@@ -26,6 +30,8 @@ pub enum HidError {
     Io(io::Error),
     /// A sysfs file existed but was structured unexpectedly.
     Parse(&'static str),
+    /// The platform HID backend (hidapi, on macOS/Windows) reported an error.
+    Backend(String),
 }
 
 impl fmt::Display for HidError {
@@ -33,6 +39,7 @@ impl fmt::Display for HidError {
         match self {
             HidError::Io(e) => write!(f, "HID I/O error: {}", e),
             HidError::Parse(s) => write!(f, "HID parse error: {}", s),
+            HidError::Backend(s) => write!(f, "HID backend error: {}", s),
         }
     }
 }
@@ -41,7 +48,7 @@ impl std::error::Error for HidError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
             HidError::Io(e) => Some(e),
-            HidError::Parse(_) => None,
+            HidError::Parse(_) | HidError::Backend(_) => None,
         }
     }
 }
@@ -117,14 +124,18 @@ pub fn bootloader_device_present() -> Option<&'static str> {
         .find_map(HidDevice::bootloader_label)
 }
 
-/// Whether this platform has a HID backend. Today only Linux (sysfs) is
-/// implemented; macOS (IOKit) and Windows (hid.dll) backends are pending. When
-/// this is `false`, [`enumerate`] returns an empty list and FIDO/CTAP is
-/// unavailable — front-ends should say so explicitly rather than reporting "no
-/// FIDO devices", which would imply none are plugged in.
+/// Whether this platform has a HID backend: Linux (sysfs), macOS (IOKit via
+/// hidapi), and Windows (hid.dll via hidapi). When `false`, [`enumerate`]
+/// returns an empty list and FIDO/CTAP is unavailable — front-ends should say
+/// so explicitly rather than reporting "no FIDO devices", which would imply none
+/// are plugged in.
 #[must_use]
 pub fn hid_supported() -> bool {
-    cfg!(target_os = "linux")
+    cfg!(any(
+        target_os = "linux",
+        target_os = "macos",
+        target_os = "windows"
+    ))
 }
 
 /// List all `/dev/hidraw*` devices visible to the current user via sysfs.
@@ -133,9 +144,47 @@ pub fn hid_supported() -> bool {
 /// enumeration reads sysfs only. Returns an empty list on platforms without a
 /// HID backend (see [`hid_supported`]).
 pub fn enumerate() -> Result<Vec<HidDevice>, HidError> {
-    if !cfg!(target_os = "linux") {
-        return Ok(Vec::new());
+    // Linux uses the dependency-free sysfs backend; macOS/Windows use hidapi.
+    // The `hidapi-backend` feature forces hidapi on (for building/testing the
+    // cross-platform path on Linux too).
+    #[cfg(any(not(target_os = "linux"), feature = "hidapi-backend"))]
+    {
+        enumerate_hidapi()
     }
+    #[cfg(all(target_os = "linux", not(feature = "hidapi-backend")))]
+    {
+        enumerate_sysfs()
+    }
+}
+
+/// hidapi-backed enumeration for macOS / Windows (and Linux under the
+/// `hidapi-backend` feature). USB topology (`usb_bus` / `usb_address`) isn't
+/// exposed portably by hidapi, so it's left `None` — the HID↔CCID correlation
+/// that uses it degrades gracefully to serial/identity matching.
+#[cfg(any(not(target_os = "linux"), feature = "hidapi-backend"))]
+fn enumerate_hidapi() -> Result<Vec<HidDevice>, HidError> {
+    let api = hidapi::HidApi::new().map_err(|e| HidError::Backend(e.to_string()))?;
+    let mut devices: Vec<HidDevice> = api
+        .device_list()
+        .map(|info| HidDevice {
+            path: PathBuf::from(info.path().to_string_lossy().into_owned()),
+            vendor_id: info.vendor_id(),
+            product_id: info.product_id(),
+            product_name: info.product_string().unwrap_or_default().to_string(),
+            usage_page: info.usage_page(),
+            usage: info.usage(),
+            serial_number: info.serial_number().map(str::to_owned),
+            usb_bus: None,
+            usb_address: None,
+        })
+        .collect();
+    devices.sort_by(|a, b| a.path.cmp(&b.path));
+    Ok(devices)
+}
+
+/// Dependency-free Linux backend: enumerate `/dev/hidraw*` via sysfs metadata.
+#[cfg(all(target_os = "linux", not(feature = "hidapi-backend")))]
+fn enumerate_sysfs() -> Result<Vec<HidDevice>, HidError> {
     let entries = match fs::read_dir("/sys/class/hidraw") {
         Ok(e) => e,
         Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok(Vec::new()),
@@ -160,6 +209,7 @@ pub fn enumerate() -> Result<Vec<HidDevice>, HidError> {
     Ok(devices)
 }
 
+#[cfg(all(target_os = "linux", not(feature = "hidapi-backend")))]
 fn read_one(name: &str, sysfs: &Path) -> Result<HidDevice, HidError> {
     let uevent = fs::read_to_string(sysfs.join("device/uevent"))?;
     let mut vendor_id: u16 = 0;
@@ -207,6 +257,7 @@ fn read_one(name: &str, sysfs: &Path) -> Result<HidDevice, HidError> {
 /// Walk up the sysfs tree from a HID device link to the first ancestor carrying
 /// an `idVendor` file — that's the backing USB device node. Returns `None` on a
 /// non-USB transport (e.g. Bluetooth) or any read error.
+#[cfg(all(target_os = "linux", not(feature = "hidapi-backend")))]
 fn usb_device_dir(device_link: &Path) -> Option<PathBuf> {
     let mut dir = fs::canonicalize(device_link).ok()?;
     loop {
@@ -220,6 +271,7 @@ fn usb_device_dir(device_link: &Path) -> Option<PathBuf> {
 /// Read the USB device serial (`iSerialNumber`) from a USB device node.
 /// Returns `None` when the descriptor carries no serial (many YubiKeys) or the
 /// attribute can't be read.
+#[cfg(all(target_os = "linux", not(feature = "hidapi-backend")))]
 fn read_usb_serial(usb_dir: &Path) -> Option<String> {
     let serial = fs::read_to_string(usb_dir.join("serial")).ok()?;
     let serial = serial.trim();
@@ -227,10 +279,16 @@ fn read_usb_serial(usb_dir: &Path) -> Option<String> {
 }
 
 /// Read a small decimal sysfs attribute (e.g. `busnum`, `devnum`) as a `u8`.
+#[cfg(all(target_os = "linux", not(feature = "hidapi-backend")))]
 fn read_sysfs_u8(path: &Path) -> Option<u8> {
     fs::read_to_string(path).ok()?.trim().parse().ok()
 }
 
+// Used by the sysfs backend and the tests; dead on the hidapi-only build.
+#[cfg_attr(
+    any(not(target_os = "linux"), feature = "hidapi-backend"),
+    allow(dead_code)
+)]
 fn parse_hex_u16(s: &str) -> Option<u16> {
     // Sysfs HID_ID fields are 8 hex chars wide; only the low 16 bits are the VID/PID.
     let v = u32::from_str_radix(s.trim(), 16).ok()?;
@@ -240,6 +298,11 @@ fn parse_hex_u16(s: &str) -> Option<u16> {
 /// Walk a HID report descriptor and return the first
 /// `(usage_page, usage)` pair, which describes the device's top-level
 /// application collection.
+// Used by the sysfs backend and the tests; dead on the hidapi-only build.
+#[cfg_attr(
+    any(not(target_os = "linux"), feature = "hidapi-backend"),
+    allow(dead_code)
+)]
 fn parse_top_usage(desc: &[u8]) -> Option<(u16, u16)> {
     let mut i = 0;
     let mut usage_page: Option<u16> = None;

--- a/crates/keyroost-resolve/src/lib.rs
+++ b/crates/keyroost-resolve/src/lib.rs
@@ -103,7 +103,7 @@ pub fn read_effective_serial(d: &HidDevice) -> Result<(String, IdSource), String
         }
         return Err(format!(
             "{} ({}) is a YubiKey, but its serial couldn't be read over CCID. \
-             Check that pcscd is running and that this key's CCID reader is \
+             Check that the smart-card (PC/SC) service is running and that this key's CCID reader is \
              present (`keyroostctl list` shows connected readers).",
             d.path.display(),
             d.product_name

--- a/crates/keyroost-transport/src/lib.rs
+++ b/crates/keyroost-transport/src/lib.rs
@@ -42,7 +42,7 @@ pub use piv::{PivSession, PivSlotStatus, PivStatus};
 /// Things that can go wrong talking to a Molto2.
 #[derive(Debug)]
 pub enum TransportError {
-    /// PC/SC service unavailable (pcscd not running on Linux, or service stopped).
+    /// PC/SC service unavailable (the smart-card service is not running).
     PcscUnavailable(pcsc::Error),
     /// No connected reader matches the Molto2 name hint.
     NoMolto2Reader,
@@ -87,7 +87,7 @@ impl fmt::Display for TransportError {
             TransportError::PcscUnavailable(e) => {
                 write!(
                     f,
-                    "PC/SC service is unavailable ({}). On Linux make sure pcscd is running.",
+                    "PC/SC service is unavailable ({}). Make sure the smart-card service is running (pcscd on Linux/macOS; the Smart Card service on Windows).",
                     e
                 )
             }

--- a/crates/keyroost-transport/src/lib.rs
+++ b/crates/keyroost-transport/src/lib.rs
@@ -87,7 +87,7 @@ impl fmt::Display for TransportError {
             TransportError::PcscUnavailable(e) => {
                 write!(
                     f,
-                    "PC/SC service is unavailable ({}). Make sure the smart-card service is running (pcscd on Linux/macOS; the Smart Card service on Windows).",
+                    "PC/SC service is unavailable ({}). Make sure the smart-card service is running (pcscd on Linux; built in on macOS; the Smart Card service on Windows).",
                     e
                 )
             }

--- a/crates/keyroost/src/main.rs
+++ b/crates/keyroost/src/main.rs
@@ -3462,6 +3462,19 @@ impl App {
                             ui::help::learn_url("/devices"),
                         );
                     });
+                    // Be honest on platforms without a HID backend yet: a plugged-in
+                    // FIDO key simply won't appear, so say why rather than letting
+                    // the user think it's broken.
+                    if !keyroost_hid::hid_supported() {
+                        ui.add_space(16.0);
+                        ui.label(
+                            egui::RichText::new(
+                                "Note: FIDO / passkey security keys aren't supported on this platform yet. Smart-card features (OATH, OpenPGP, PIV, Token2 Molto2) work over PC/SC.",
+                            )
+                            .font(theme::f_reg(12.5))
+                            .color(p.txt3),
+                        );
+                    }
                 },
             );
         });

--- a/crates/keyroostctl/src/main.rs
+++ b/crates/keyroostctl/src/main.rs
@@ -1490,7 +1490,7 @@ fn resolve_reader(
     if readers.is_empty() {
         return Err(format!(
             "no {kind}-capable security key found (no reader's {kind} applet \
-             responded). Plug a key in, and check pcscd is running."
+             responded). Plug a key in, and check the smart-card (PC/SC) service is running."
         )
         .into());
     }


### PR DESCRIPTION
## What this is

Brings the macOS/Windows HID port together with the CI that keeps it honest, and records the agreed cross-platform strategy. `main` doesn't have the port yet, so this PR carries both:

- **The port** (previously on `feature/macos-port`): a `hidapi` HID backend for macOS (IOKit) and Windows (hid.dll), auto-selected off Linux behind `cfg(not(target_os = "linux"))`. Linux keeps its dependency-free sysfs/hidraw backend untouched. A `HidIo` enum and `enumerate_*` split give one uniform seam per platform; CTAP framing above it is unchanged.
- **CI matrix + honesty pass** (new): builds, clippy, and tests on Linux **and** macOS **and** Windows.

## Why the matrix matters

The port landed but **nothing ever compiled the non-Linux path** — "builds on Windows" was hypothetical. `ci.yml` now runs `ubuntu-latest` / `macos-latest` / `windows-latest` (`fail-fast: false`), so this is the first real compile of the hidapi backend on those OSes. This is also what lets us keep a **single `main`** instead of per-OS branches: a Linux-only change that breaks another platform now fails the PR.

## Decisions recorded in PLAN.md

- **One main, cfg-gated backends** — not three platform branches; CI is the cross-platform guarantee.
- **HID backend: hybrid** — `hidapi` now (the one accepted C dep for this scope), a hand-vendored IOKit/SetupAPI backend stays a deferred option behind the same seam.
- **Tiers** — Linux **tier-1** (hardware-verified); macOS/Windows **tier-2**, and *experimental/unverified* until hardware sign-off.

## Scope notes / not in this PR

- **No hardware sign-off yet.** macOS/Windows are unproven on a real key (enumerate → getInfo → an OATH/OpenPGP op). That's the gate before claiming tier-2 in user docs (PLAN.md phase E).
- **HID↔CCID topology degrades on macOS/Windows** by design — hidapi exposes no USB bus/address, so two serial-less YubiKeys can't be disambiguated (falls back to single-reader). Documented, not yet addressed.
- **Release artifacts stay Linux-only** here; the macOS/Windows release matrix is a follow-up (PLAN.md phase C).
- The Linux release **never** links hidapi; the `hidapi-backend` feature is a Linux-only test hook (needs `libudev-dev`) and must not enter a release build.

## Verified locally (Linux)

`cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` all green; the hidapi backend compiles when its feature is forced on.

https://claude.ai/code/session_01EPpuj3EnF31wBm1jYoNckm

---
_Generated by [Claude Code](https://claude.ai/code/session_01EPpuj3EnF31wBm1jYoNckm)_