### PR TITLE
Verify Fedora &amp; Arch builds; document per-distro prerequisites

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,3 +63,48 @@ jobs:
 
       - name: Test
         run: cargo test --workspace --locked
+
+  # Build + test inside Fedora and Arch containers so the README's per-distro
+  # package lists are verified, not assumed, and a distro-specific build break is
+  # caught here. Linux is distro-neutral (sysfs/hidraw + PC/SC), so this is a
+  # smoke build, not a second clippy pass — the os matrix above already enforces
+  # lints. Distro toolchains (both well past our 1.75 MSRV) stand in for rustup.
+  linux-distros:
+    name: build + test (${{ matrix.distro }})
+    runs-on: ubuntu-latest
+    container: ${{ matrix.image }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - distro: fedora
+            image: fedora:latest
+          - distro: arch
+            image: archlinux:latest
+    steps:
+      # Deps don't need the repo, so install them (incl. git for checkout and the
+      # distro Rust) before checking out.
+      - name: Install dependencies (Fedora)
+        if: matrix.distro == 'fedora'
+        run: |
+          dnf install -y git gcc pkgconf-pkg-config \
+            pcsc-lite-devel \
+            libxkbcommon-devel libxkbcommon-x11-devel wayland-devel \
+            libxcb-devel mesa-libGL-devel \
+            rust cargo
+
+      - name: Install dependencies (Arch)
+        if: matrix.distro == 'arch'
+        run: |
+          pacman -Sy --noconfirm --needed git gcc pkgconf \
+            pcsclite ccid \
+            libxkbcommon libxcb wayland mesa \
+            rust
+
+      - uses: actions/checkout@v4
+
+      - name: Build
+        run: cargo build --workspace --locked
+
+      - name: Test
+        run: cargo test --workspace --locked

--- a/README.md
+++ b/README.md
@@ -93,16 +93,37 @@ cargo install --git https://github.com/framefilter/keyroost keyroostctl keyroost
 
 ### Linux prerequisite
 
-PC/SC needs the system library and daemon:
+keyroost is distro-neutral — it talks to the kernel's `hidraw`/`sysfs` and to
+PC/SC, both of which every mainstream distribution provides. Only the package
+names differ. The CLI needs the PC/SC library + daemon; the GUI additionally
+needs the X11/Wayland/GL libraries that `eframe`/`egui` link against.
 
 ```bash
-sudo apt install libpcsclite-dev pcscd      # Debian / Ubuntu
-sudo dnf install pcsc-lite-devel pcsc-lite  # Fedora
+# Debian / Ubuntu
+sudo apt install libpcsclite-dev pcscd \
+  libxkbcommon-dev libwayland-dev libxcb1-dev libgl1-mesa-dev
+
+# Fedora / RHEL
+sudo dnf install pcsc-lite-devel pcsc-lite pkgconf-pkg-config gcc \
+  libxkbcommon-devel libxkbcommon-x11-devel wayland-devel libxcb-devel \
+  mesa-libGL-devel
+
+# Arch
+sudo pacman -S pcsclite ccid pkgconf gcc \
+  libxkbcommon libxcb wayland mesa
+
 sudo systemctl enable --now pcscd
 ```
 
-macOS and Windows have PC/SC built in. (HID enumeration is currently Linux-only;
-cross-platform support is planned.)
+(For the **CLI only** you can drop the `libxkbcommon`/`wayland`/`xcb`/`mesa`
+packages — those are just for the GUI.) macOS and Windows have PC/SC built in,
+and the FIDO HID backend uses `hidapi` (IOKit / hid.dll) automatically — no extra
+packages. macOS/Windows are tier-2 (best-effort, not yet hardware-verified).
+
+> **Prebuilt binaries:** the release artifacts are built on Ubuntu and linked
+> against its glibc, so they run on glibc-current distros (Arch, recent Fedora)
+> but may fail on older ones (e.g. RHEL 9) with a `GLIBC_…` error. When in doubt,
+> build from source with the commands above — `cargo install` handles the rest.
 
 ### FIDO HID access (Linux udev rules)
 


### PR DESCRIPTION
## What this is

Makes Fedora and Arch first-class verified Linux targets — with evidence, not assumptions — and documents how to build on each.

keyroost's code is already distro-neutral (kernel `hidraw`/`sysfs` + PC/SC); only package names differ. This PR pins that down:

- **README** — split per-distro prerequisite blocks for **Debian/Ubuntu**, **Fedora/RHEL**, and **Arch**, separating the PC/SC deps (CLI) from the X11/Wayland/GL deps (GUI). Fixed the stale *"HID enumeration is currently Linux-only"* line (the hidapi backend now covers macOS/Windows), and added a note that prebuilt release binaries are glibc-Ubuntu-linked (build from source on older distros like RHEL 9).
- **CI** — a new `linux-distros` job builds + tests inside `fedora:latest` and `archlinux:latest` containers (`fail-fast: false`). This verifies the README's package lists on every push and catches any distro-specific build break. It's a smoke build, not a second clippy pass — the OS matrix already enforces lints.

## Verified locally

Built the CLI **and** the egui GUI from source in clean containers using exactly the documented package lists:

| Distro | Result |
|---|---|
| `archlinux:latest` (rustc 1.96) | ✅ `keyroostctl` + GUI compiled |
| `fedora:latest` (rustc 1.96) | ✅ `keyroostctl` + GUI compiled |

## Notes

- Distro toolchains (both well past the 1.75 MSRV) stand in for rustup in the container jobs — also a realistic test of "can a user just use their package-manager Rust."
- No code changes; docs + CI only.

https://claude.ai/code/session_01EPpuj3EnF31wBm1jYoNckm

---
_Generated by [Claude Code](https://claude.ai/code/session_01EPpuj3EnF31wBm1jYoNckm)_