### PR TITLE
Publish a GitHub Release with artifacts on tag push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,11 +1,11 @@
 name: Release binaries
 
 # Builds the CLI + GUI release binaries for Linux, macOS, and Windows when a
-# version tag is pushed (e.g. `git tag v0.3.0 && git push origin v0.3.0`) and
-# attaches them to the workflow run. `workflow_dispatch` lets you run the same
-# build manually (off a branch) to smoke-test packaging without cutting a tag.
-# Publishing a public GitHub Release is left as an explicit opt-in (see the
-# commented step in the `publish` job) so a tag push never auto-publishes.
+# version tag is pushed (e.g. `git tag v0.3.0 && git push origin v0.3.0`), then
+# publishes a public GitHub Release with the three archives attached.
+# `workflow_dispatch` runs the same build manually (off a branch) to smoke-test
+# packaging without cutting a tag — it builds and collects but never publishes,
+# since the publish step is guarded on a tag ref.
 
 on:
   push:
@@ -116,9 +116,12 @@ jobs:
           path: dist/*.zip
 
   publish:
-    name: Collect artifacts
+    name: Collect & publish
     needs: [linux-x86_64, macos-universal2, windows-x86_64]
     runs-on: ubuntu-latest
+    # `gh release create` writes a Release, so the default token needs write.
+    permissions:
+      contents: write
     steps:
       - name: Download all build artifacts
         uses: actions/download-artifact@v4
@@ -129,11 +132,12 @@ jobs:
       - name: List artifacts
         run: ls -lR dist
 
-      # To publish a public GitHub Release on tag, uncomment this step. It uses
-      # the built-in token (no third-party action). Runs only on a tag push, so
-      # a manual workflow_dispatch never publishes. GITHUB_REF_NAME is the tag.
-      # - name: Publish GitHub Release
-      #   if: startsWith(github.ref, 'refs/tags/')
-      #   env:
-      #     GH_TOKEN: ${{ github.token }}
-      #   run: gh release create "${GITHUB_REF_NAME}" dist/* --generate-notes
+      # Publish a public GitHub Release with the three archives attached. Guarded
+      # on a tag ref, so a manual workflow_dispatch still builds + collects but
+      # never publishes. Uses the built-in token (no third-party action);
+      # --generate-notes writes the notes from commits/PRs since the last tag.
+      - name: Publish GitHub Release
+        if: startsWith(github.ref, 'refs/tags/')
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release create "${GITHUB_REF_NAME}" dist/*.tar.gz dist/*.zip --generate-notes


### PR DESCRIPTION
## What this is

Finishes Phase C: a tag push now **publishes a GitHub Release** instead of just building artifacts into the workflow run.

Pushing `vX.Y.Z` builds the Linux/macOS/Windows archives (already verified) and the `publish` job attaches all three to a new public Release with auto-generated notes.

- **Tag-guarded** — `if: startsWith(github.ref, 'refs/tags/')`, so a manual `workflow_dispatch` still builds + collects but never publishes.
- **`contents: write`** on the publish job — the default `GITHUB_TOKEN` is read-only, and `gh release create` needs write.
- Uploads the archives explicitly (`dist/*.tar.gz dist/*.zip`) rather than a bare glob.
- No third-party actions — uses the runner's built-in `gh` and token.

## Verification note

The build/collect path was proven green by the manual run on main (all three artifacts produced). The publish step itself can only execute on a real tag push — by design it's skipped on `workflow_dispatch` — so it'll first exercise when you cut `v0.3.0`.

If you'd prefer a human gate on that first release, it's a one-word change: add `--draft` to `gh release create` so the tag creates a draft with artifacts attached for you to review and publish. Say the word and I'll switch it.

https://claude.ai/code/session_01EPpuj3EnF31wBm1jYoNckm

---
_Generated by [Claude Code](https://claude.ai/code/session_01EPpuj3EnF31wBm1jYoNckm)_