### PR TITLE
Token2: OTP-over-CCID, full serial, interface toggle, touch-HOTP GUI

### DIFF
--- a/crates/keyroost-token2otp/src/lib.rs
+++ b/crates/keyroost-token2otp/src/lib.rs
@@ -271,18 +271,27 @@ pub struct DeviceInfo {
 }
 
 impl DeviceInfo {
-    /// Parse the fixed-format response (spec §6.9). Requires at least 10 bytes.
+    /// Parse the device-info response (spec §6.9). The interface-state bits all
+    /// live in byte 0 (`transfer_type`), so that byte is the only hard
+    /// requirement. Some firmware returns just the config byte(s) rather than the
+    /// full fixed-format block, so the later appearance/version/extension fields
+    /// are filled from whatever is present and default to zero when absent.
     pub fn parse(data: &[u8]) -> Result<Self, ParseError> {
-        if data.len() < 10 {
+        if data.is_empty() {
             return Err(ParseError::Truncated);
         }
+        let get = |i: usize| data.get(i).copied().unwrap_or(0);
         Ok(DeviceInfo {
             transfer_type: data[0],
-            device_config: data[1],
-            appearance: [data[2], data[3], data[4], data[5]],
-            fido_version: [data[6], data[7], data[8]],
-            device_extension: data[9],
-            raw_tail: data[10..].to_vec(),
+            device_config: get(1),
+            appearance: [get(2), get(3), get(4), get(5)],
+            fido_version: [get(6), get(7), get(8)],
+            device_extension: get(9),
+            raw_tail: if data.len() > 10 {
+                data[10..].to_vec()
+            } else {
+                Vec::new()
+            },
         })
     }
 
@@ -294,6 +303,10 @@ impl DeviceInfo {
     /// Bit 2: HOTP-via-keystroke disabled.
     pub fn hotp_keystroke_disabled(&self) -> bool {
         self.transfer_type & 0x02 != 0
+    }
+    /// Bit 3: CCID/smart-card interface disabled.
+    pub fn ccid_disabled(&self) -> bool {
+        self.transfer_type & 0x04 != 0
     }
 
     // --- device-config bits (byte 1) ---
@@ -515,6 +528,22 @@ mod tests {
         assert!(info.button_hotp_configured());
         assert!(!info.hotp_suppresses_enter());
         assert!(info.button_hotp_supported()); // ext bit 6 clear -> supported
+    }
+
+    #[test]
+    fn device_info_parses_short_response() {
+        // Some firmware returns only the config byte(s) from READ_CONFIG rather
+        // than the full 10-byte block. The interface-state bits live in byte 0,
+        // so a 1-byte response (e.g. 0x02 = keyboard-HID disabled) must still
+        // parse, with the optional trailing fields defaulting to zero.
+        let info = DeviceInfo::parse(&[0x02]).unwrap();
+        assert!(!info.fido_disabled());
+        assert!(info.hotp_keystroke_disabled());
+        assert!(!info.ccid_disabled());
+        // device_extension defaults to 0 -> button-HOTP reported as supported.
+        assert!(info.button_hotp_supported());
+        // An empty response is still rejected.
+        assert!(DeviceInfo::parse(&[]).is_err());
     }
 
     #[test]

--- a/crates/keyroost-transport/src/lib.rs
+++ b/crates/keyroost-transport/src/lib.rs
@@ -672,7 +672,42 @@ pub fn probe_readers() -> Result<Vec<ReaderProbe>, TransportError> {
             // lets keys with no HID serial (e.g. Token2 PIN+) still show one.
             // Re-SELECT OpenPGP first: the PIV probe above left a different applet
             // current, so GET DATA would otherwise hit the wrong one.
-            if probe.has_openpgp {
+            // Token2 keys expose a full serial via the FIDO applet's GET_INFO
+            // (spec §6.10), which is longer than the 4-byte serial embedded in the
+            // OpenPGP AID. Prefer it so the device header shows the complete serial.
+            // Best-effort: SELECT the FIDO applet (ignore its status word, as some
+            // PIN+ firmware answers 6A81 yet still switches applets), then GET_INFO.
+            if probe.reader_name.to_ascii_lowercase().contains("token2") {
+                let _ = transmit_apdu(
+                    &card,
+                    &keyroost_token2otp::build_select(&keyroost_token2otp::FIDO_APPLET_AID),
+                );
+                if let Ok((data, s1, s2)) =
+                    transmit_apdu(&card, &keyroost_token2otp::read_serial_request())
+                {
+                    let body = if s1 == 0x61 {
+                        transmit_apdu(&card, &[0x00, 0xC0, 0x00, 0x00, s2])
+                            .map(|(d, _, _)| d)
+                            .unwrap_or(data)
+                    } else {
+                        data
+                    };
+                    if let Ok(sn) = keyroost_token2otp::parse_serial(&body) {
+                        let hex: String = sn.iter().map(|b| format!("{b:02x}")).collect();
+                        if !hex.is_empty() {
+                            probe.serial = Some(hex);
+                            if trace {
+                                eprintln!("[probe]   token2 full serial -> {:?}", probe.serial);
+                            }
+                        }
+                    } else if trace {
+                        eprintln!("[probe]   token2 serial parse failed");
+                    }
+                }
+            }
+            // Fall back to the OpenPGP AID serial (4 bytes) only if the full read
+            // above didn't populate one.
+            if probe.has_openpgp && probe.serial.is_none() {
                 let _ = transmit_apdu(&card, &keyroost_openpgp::select());
                 let get_aid = [0x00u8, 0xCA, 0x00, 0x4F, 0x00];
                 if let Ok((data, s1, s2)) = transmit_apdu(&card, &get_aid) {

--- a/crates/keyroost-transport/src/token2otp.rs
+++ b/crates/keyroost-transport/src/token2otp.rs
@@ -712,6 +712,50 @@ impl Token2OtpSession {
 
     /// Delete the HOTP-on-button slot (spec §6.6): seal the two zero bytes with
     /// IV-2 and send `WRITE_HOTP_SEED`.
+    /// Set which USB interfaces the key exposes, via `SET_DEVICE_TYPE`
+    /// (spec §6.8). The argument is a *disable* mask over [`t2::DEV_FIDO`],
+    /// [`t2::DEV_KEYBOARD`], and [`t2::DEV_CCID`]: a set bit disables that
+    /// interface, a clear bit enables it.
+    ///
+    /// **Brick risk.** The firmware does not refuse a mask that disables every
+    /// interface, which would leave the key permanently unreachable. The byte
+    /// layer's [`t2::set_device_type`] refuses such a mask client-side
+    /// ([`SetDeviceTypeError::WouldBrick`]); this method surfaces that as an
+    /// error and never transmits a bricking APDU. Callers should additionally
+    /// confirm the change with the user before calling.
+    pub fn set_device_type(&mut self, disable_mask: u8) -> Result<(), OtpTransportError> {
+        let apdu = t2::set_device_type(disable_mask)
+            .map_err(|_| OtpTransportError::Parse(ParseError::Invalid(
+                "refusing to disable every interface (would brick the key)",
+            )))?;
+        let (_, sw) = self.transport.transmit(&apdu, false)?;
+        OtpError::check(sw)?;
+        Ok(())
+    }
+
+    /// Read the key's interface-configuration byte via `READ_CONFIG`
+    /// (spec §6.9), so callers can show which interfaces are currently enabled
+    /// before changing them. Returns the raw config bytes the device reports.
+    pub fn read_config(&mut self) -> Result<Vec<u8>, OtpTransportError> {
+        // READ_CONFIG (0x80 0xC5 0x02) is in the same command family as
+        // ENUM_CODES (0x80 0xC5 0x05) and is answered by the OTP applet — NOT the
+        // FIDO applet. The OTP applet is already current (selected at session
+        // open), so issue the command directly, exactly as `enumerate` does.
+        let apdu = t2::read_config(64);
+        let (data, sw) = self.transport.transmit(&apdu, false)?;
+        OtpError::check(sw)?;
+        Ok(data)
+    }
+
+    /// Read and parse the device-info / configuration block (spec §6.9). Callers
+    /// can use the returned [`t2::DeviceInfo`] to tell, for example, whether the
+    /// keyboard-HID interface is enabled before offering HOTP-on-touch (which
+    /// types over that interface and fails with `6A81` when it's disabled).
+    pub fn read_device_info(&mut self) -> Result<t2::DeviceInfo, OtpTransportError> {
+        let data = self.read_config()?;
+        Ok(t2::DeviceInfo::parse(&data)?)
+    }
+
     pub fn delete_button_hotp(&mut self) -> Result<(), OtpTransportError> {
         let blob = self.seal(&[0x00, 0x00], &t2::IV_HOTP)?;
         let apdu = t2::build_apdu(cmd::WRITE_HOTP_SEED, &blob);

--- a/crates/keyroost-transport/src/token2otp.rs
+++ b/crates/keyroost-transport/src/token2otp.rs
@@ -724,10 +724,11 @@ impl Token2OtpSession {
     /// error and never transmits a bricking APDU. Callers should additionally
     /// confirm the change with the user before calling.
     pub fn set_device_type(&mut self, disable_mask: u8) -> Result<(), OtpTransportError> {
-        let apdu = t2::set_device_type(disable_mask)
-            .map_err(|_| OtpTransportError::Parse(ParseError::Invalid(
+        let apdu = t2::set_device_type(disable_mask).map_err(|_| {
+            OtpTransportError::Parse(ParseError::Invalid(
                 "refusing to disable every interface (would brick the key)",
-            )))?;
+            ))
+        })?;
         let (_, sw) = self.transport.transmit(&apdu, false)?;
         OtpError::check(sw)?;
         Ok(())

--- a/crates/keyroost/src/otp_pane.rs
+++ b/crates/keyroost/src/otp_pane.rs
@@ -517,24 +517,27 @@ impl App {
         self.otp.error = None;
         let sel = self.otp.transport;
         let for_device = self.selected_device.clone();
-        self.spawn_job("Erasing all OTP entries \u{2014} touch your key\u{2026}", move || {
-            let result = (|| -> Result<(), OtpTransportError> {
-                let mut session = sel.open()?;
-                session.erase_all()
-            })();
-            Box::new(move |app: &mut App| {
-                if app.selected_device != for_device {
-                    return;
-                }
-                match result {
-                    Ok(()) => {
-                        app.otp.info = Some("All OTP entries erased.".into());
-                        app.load_otp_entries();
+        self.spawn_job(
+            "Erasing all OTP entries \u{2014} touch your key\u{2026}",
+            move || {
+                let result = (|| -> Result<(), OtpTransportError> {
+                    let mut session = sel.open()?;
+                    session.erase_all()
+                })();
+                Box::new(move |app: &mut App| {
+                    if app.selected_device != for_device {
+                        return;
                     }
-                    Err(e) => app.otp.error = Some(e.to_string()),
-                }
-            })
-        });
+                    match result {
+                        Ok(()) => {
+                            app.otp.info = Some("All OTP entries erased.".into());
+                            app.load_otp_entries();
+                        }
+                        Err(e) => app.otp.error = Some(e.to_string()),
+                    }
+                })
+            },
+        );
     }
 
     /// Render the OTP tab.
@@ -609,9 +612,7 @@ impl App {
                     ui.add_enabled_ui(!would_underflow, |ui| {
                         let r = theme::button(ui, p, BtnKind::Ghost, label);
                         let r = if would_underflow {
-                            r.on_disabled_hover_text(
-                                "at least two interfaces must stay enabled",
-                            )
+                            r.on_disabled_hover_text("at least two interfaces must stay enabled")
                         } else {
                             r
                         };

--- a/crates/keyroost/src/otp_pane.rs
+++ b/crates/keyroost/src/otp_pane.rs
@@ -104,6 +104,79 @@ impl Drop for OtpAddDialog {
     }
 }
 
+/// Dialog state for configuring the HOTP-on-touch keystroke slot: the key types
+/// a fresh HOTP code as keyboard input when touched outside any session.
+pub struct ButtonHotpDialog {
+    pub open: bool,
+    /// Base32 secret, entered masked.
+    pub secret: String,
+    /// 6 or 8.
+    pub digits: u8,
+    /// Append an Enter keystroke after the code.
+    pub send_enter: bool,
+    /// Require a 2-second long touch (else a short tap triggers it).
+    pub long_touch: bool,
+    /// Type digits using the numeric-keypad scancodes.
+    pub numpad: bool,
+}
+
+impl Default for ButtonHotpDialog {
+    fn default() -> Self {
+        ButtonHotpDialog {
+            open: false,
+            secret: String::new(),
+            digits: 6,
+            send_enter: true,
+            long_touch: false,
+            numpad: false,
+        }
+    }
+}
+
+impl Drop for ButtonHotpDialog {
+    fn drop(&mut self) {
+        wipe(&mut self.secret);
+    }
+}
+
+/// Current enabled-state of the key's three USB interfaces, read from the device
+/// config. Used to show the keyboard-HID toggle and to keep at least two
+/// interfaces enabled when changing one.
+#[derive(Clone, Copy)]
+pub struct IfaceState {
+    pub fido: bool,
+    pub keyboard: bool,
+    pub ccid: bool,
+}
+
+impl IfaceState {
+    fn enabled_count(&self) -> usize {
+        [self.fido, self.keyboard, self.ccid]
+            .iter()
+            .filter(|x| **x)
+            .count()
+    }
+}
+
+/// Pending keyboard-HID toggle awaiting a typed-phrase confirmation.
+pub struct KbdToggle {
+    /// The state keyboard-HID will be set to.
+    pub enable: bool,
+    /// What the user has typed; must match the required phrase to proceed.
+    pub typed: String,
+}
+
+/// Result of a successful OTP-pane load: the entry rows plus the device facts the
+/// pane shows (transport label, serial, touch-HOTP availability, interface state).
+struct OtpLoad {
+    rows: Vec<OtpRow>,
+    active: &'static str,
+    serial: Option<String>,
+    touch_ok: Option<bool>,
+    touch_why: Option<&'static str>,
+    iface: Option<IfaceState>,
+}
+
 /// Per-selection state for the OTP pane.
 #[derive(Default)]
 pub struct OtpState {
@@ -113,11 +186,24 @@ pub struct OtpState {
     pub info: Option<String>,
     pub loaded: bool,
     pub add: OtpAddDialog,
+    /// Dialog for the HOTP-on-touch keystroke slot.
+    pub button_hotp: ButtonHotpDialog,
     pub confirm_delete: Option<(String, String)>,
     /// Active transport label after a successful open (for the status line).
     pub active: Option<&'static str>,
     /// Device serial number (hex), read alongside the entry list when available.
     pub serial: Option<String>,
+    /// Whether the key currently supports HOTP-on-touch (keyboard-HID enabled and
+    /// the feature present). `None` until determined. Drives the Touch HOTP button.
+    pub touch_hotp_ok: Option<bool>,
+    /// Why touch-HOTP is unavailable, for the disabled-button tooltip.
+    pub touch_hotp_why: Option<&'static str>,
+    /// Current interface enabled-states (fido, keyboard-HID, ccid), read from the
+    /// device config on load. `None` until known.
+    pub iface: Option<IfaceState>,
+    /// Pending keyboard-HID toggle confirmation: the target state and the typed
+    /// confirmation phrase. `Some` while the confirm dialog is open.
+    pub kbd_confirm: Option<KbdToggle>,
 }
 
 fn unix_now() -> u64 {
@@ -135,7 +221,7 @@ impl App {
         let for_device = self.selected_device.clone();
         self.spawn_job("Reading OTP entries\u{2026}", move || {
             let result =
-                (|| -> Result<(Vec<OtpRow>, &'static str, Option<String>), OtpTransportError> {
+                (|| -> Result<OtpLoad, OtpTransportError> {
                     let mut session = sel.open()?;
                     let active = if session.is_pcsc() {
                         "CCID/NFC"
@@ -149,6 +235,34 @@ impl App {
                         .read_serial()
                         .ok()
                         .map(|sn| sn.iter().map(|b| format!("{b:02x}")).collect::<String>());
+                    // Determine whether HOTP-on-touch is usable: it types over the
+                    // keyboard-HID interface, so a key with that interface disabled
+                    // (or that doesn't support the feature) returns 6A81. Detect it
+                    // up front so the UI can disable the action with a reason rather
+                    // than letting the user fill the form and fail at submit.
+                    // Read the device config once; derive both the touch-HOTP
+                    // availability and the interface states from it.
+                    let dev_info = session.read_device_info().ok();
+                    let (touch_ok, touch_why): (Option<bool>, Option<&'static str>) =
+                        match &dev_info {
+                            Some(info) => {
+                                if !info.button_hotp_supported() {
+                                    (Some(false), Some("this key model does not support HOTP-on-touch"))
+                                } else if info.hotp_keystroke_disabled() {
+                                    (Some(false), Some("the keyboard-HID interface is disabled on this key; enable it to use HOTP-on-touch"))
+                                } else {
+                                    (Some(true), None)
+                                }
+                            }
+                            // Couldn't read config (older model / reader quirk):
+                            // leave it permitted rather than wrongly blocking.
+                            None => (None, None),
+                        };
+                    let iface = dev_info.as_ref().map(|info| IfaceState {
+                        fido: !info.fido_disabled(),
+                        keyboard: !info.hotp_keystroke_disabled(),
+                        ccid: !info.ccid_disabled(),
+                    });
                     let now = unix_now();
                     let entries = session.enumerate(now)?;
                     let rows = entries
@@ -162,18 +276,28 @@ impl App {
                             code: e.code,
                         })
                         .collect();
-                    Ok((rows, active, serial))
+                    Ok(OtpLoad {
+                        rows,
+                        active,
+                        serial,
+                        touch_ok,
+                        touch_why,
+                        iface,
+                    })
                 })();
             Box::new(move |app: &mut App| {
                 if app.selected_device != for_device {
                     return; // user switched keys mid-read
                 }
                 match result {
-                    Ok((rows, active, serial)) => {
-                        app.otp.rows = rows;
+                    Ok(load) => {
+                        app.otp.rows = load.rows;
                         app.otp.loaded = true;
-                        app.otp.active = Some(active);
-                        app.otp.serial = serial;
+                        app.otp.active = Some(load.active);
+                        app.otp.serial = load.serial;
+                        app.otp.touch_hotp_ok = load.touch_ok;
+                        app.otp.touch_hotp_why = load.touch_why;
+                        app.otp.iface = load.iface;
                         app.otp.error = None;
                     }
                     Err(e) => {
@@ -244,6 +368,125 @@ impl App {
         });
     }
 
+    /// Configure the HOTP-on-touch keystroke slot from the dialog fields.
+    pub(crate) fn provision_button_hotp(&mut self) {
+        self.otp.error = None;
+        let digits = self.otp.button_hotp.digits;
+        if digits != 6 && digits != 8 {
+            self.otp.error = Some("button HOTP digits must be 6 or 8".into());
+            return;
+        }
+        let secret = zeroize::Zeroizing::new(self.otp.button_hotp.secret.clone());
+        let send_enter = self.otp.button_hotp.send_enter;
+        let long_touch = self.otp.button_hotp.long_touch;
+        let numpad = self.otp.button_hotp.numpad;
+        let sel = self.otp.transport;
+        let for_device = self.selected_device.clone();
+
+        self.spawn_job("Setting touch HOTP\u{2026}", move || {
+            let result = (|| -> Result<(), String> {
+                let seed = keyroost_token2otp::decode_base32_seed(secret.trim())
+                    .map_err(|m| format!("invalid Base32 secret: {m}"))?;
+                let mut session = sel.open().map_err(|e| e.to_string())?;
+                session
+                    .set_button_hotp(digits, &seed, send_enter, long_touch, numpad)
+                    .map_err(|e| e.to_string())
+            })();
+            Box::new(move |app: &mut App| {
+                if app.selected_device != for_device {
+                    return;
+                }
+                match result {
+                    Ok(()) => {
+                        app.otp.button_hotp = ButtonHotpDialog::default();
+                        app.otp.info = Some("Touch HOTP configured.".into());
+                    }
+                    Err(e) => app.otp.error = Some(e.to_string()),
+                }
+            })
+        });
+    }
+
+    /// Apply a keyboard-HID enable/disable, preserving the other two interfaces
+    /// and never dropping below two enabled. Built from the cached `iface` state.
+    pub(crate) fn apply_keyboard_toggle(&mut self, enable: bool) {
+        self.otp.error = None;
+        let Some(cur) = self.otp.iface else {
+            self.otp.error = Some("interface state unknown; refresh first".into());
+            return;
+        };
+        // Compute the resulting state and enforce the two-interface minimum.
+        let next = IfaceState {
+            fido: cur.fido,
+            keyboard: enable,
+            ccid: cur.ccid,
+        };
+        if next.enabled_count() < 2 {
+            self.otp.error = Some(
+                "at least two interfaces must stay enabled; enable another interface first".into(),
+            );
+            return;
+        }
+        // Build the SET_DEVICE_TYPE *disable* mask (set bit = disable).
+        use keyroost_token2otp::{DEV_CCID, DEV_FIDO, DEV_KEYBOARD};
+        let mut disable: u8 = 0;
+        if !next.fido {
+            disable |= DEV_FIDO;
+        }
+        if !next.keyboard {
+            disable |= DEV_KEYBOARD;
+        }
+        if !next.ccid {
+            disable |= DEV_CCID;
+        }
+        let sel = self.otp.transport;
+        let for_device = self.selected_device.clone();
+        self.spawn_job("Updating interfaces\u{2026}", move || {
+            let result = (|| -> Result<(), String> {
+                let mut session = sel.open().map_err(|e| e.to_string())?;
+                session.set_device_type(disable).map_err(|e| e.to_string())
+            })();
+            Box::new(move |app: &mut App| {
+                if app.selected_device != for_device {
+                    return;
+                }
+                match result {
+                    Ok(()) => {
+                        app.otp.info = Some(
+                            "Interface updated. Re-plug the key for the change to take effect."
+                                .into(),
+                        );
+                        // Reflect the change locally; a refresh re-reads from hardware.
+                        app.otp.iface = Some(next);
+                    }
+                    Err(e) => app.otp.error = Some(e),
+                }
+            })
+        });
+    }
+
+    /// Clear the HOTP-on-touch keystroke slot.
+    pub(crate) fn delete_button_hotp_slot(&mut self) {
+        self.otp.error = None;
+        let sel = self.otp.transport;
+        let for_device = self.selected_device.clone();
+        self.spawn_job("Clearing touch HOTP\u{2026}", move || {
+            let result = (|| -> Result<(), String> {
+                let mut session = sel.open().map_err(|e| e.to_string())?;
+                session.delete_button_hotp().map_err(|e| e.to_string())
+            })();
+            Box::new(move |app: &mut App| {
+                if app.selected_device != for_device {
+                    return;
+                }
+                match result {
+                    Ok(()) => app.otp.info = Some("Touch HOTP cleared.".into()),
+                    Err(e) => app.otp.error = Some(e.to_string()),
+                }
+            })
+        });
+    }
+
     /// Delete the entry identified by `(app, account)`.
     pub(crate) fn delete_otp_entry(&mut self, app_name: String, account_name: String) {
         self.otp.error = None;
@@ -274,7 +517,7 @@ impl App {
         self.otp.error = None;
         let sel = self.otp.transport;
         let for_device = self.selected_device.clone();
-        self.spawn_job("Erasing all OTP entries\u{2026}", move || {
+        self.spawn_job("Erasing all OTP entries \u{2014} touch your key\u{2026}", move || {
             let result = (|| -> Result<(), OtpTransportError> {
                 let mut session = sel.open()?;
                 session.erase_all()
@@ -310,12 +553,8 @@ impl App {
             );
             if let Some(active) = self.otp.active {
                 ui.add_space(8.0);
-                let mut meta = format!("via {active}");
-                if let Some(serial) = &self.otp.serial {
-                    meta.push_str(&format!("  ·  S/N {serial}"));
-                }
                 ui.label(
-                    egui::RichText::new(meta)
+                    egui::RichText::new(format!("via {active}"))
                         .font(theme::f_reg(11.5))
                         .color(p.txt3),
                 );
@@ -328,6 +567,64 @@ impl App {
                     let mut dlg = OtpAddDialog::default();
                     dlg.open = true;
                     self.otp.add = dlg;
+                }
+                ui.add_space(6.0);
+                // Touch-HOTP types over the keyboard-HID interface; disable the
+                // action when that interface is off or the model lacks the feature.
+                let touch_blocked = self.otp.touch_hotp_ok == Some(false);
+                let mut open_touch = false;
+                ui.add_enabled_ui(!touch_blocked, |ui| {
+                    let r = theme::button(ui, p, BtnKind::Default, "Touch HOTP");
+                    let r = match self.otp.touch_hotp_why {
+                        Some(why) if touch_blocked => r.on_disabled_hover_text(why),
+                        _ => r,
+                    };
+                    if r.clicked() {
+                        open_touch = true;
+                    }
+                });
+                if open_touch {
+                    let mut dlg = ButtonHotpDialog::default();
+                    dlg.open = true;
+                    self.otp.button_hotp = dlg;
+                }
+                // Keyboard-HID enable/disable toggle (governs whether Touch HOTP
+                // can work at all). Only shown once we know the interface state.
+                if let Some(iface) = self.otp.iface {
+                    ui.add_space(6.0);
+                    let (label, target) = if iface.keyboard {
+                        ("Disable keyboard", false)
+                    } else {
+                        ("Enable keyboard", true)
+                    };
+                    // Don't offer a disable that would drop below two interfaces.
+                    let would_underflow = !target && {
+                        let after = IfaceState {
+                            keyboard: false,
+                            ..iface
+                        };
+                        after.enabled_count() < 2
+                    };
+                    let mut open_kbd = false;
+                    ui.add_enabled_ui(!would_underflow, |ui| {
+                        let r = theme::button(ui, p, BtnKind::Ghost, label);
+                        let r = if would_underflow {
+                            r.on_disabled_hover_text(
+                                "at least two interfaces must stay enabled",
+                            )
+                        } else {
+                            r
+                        };
+                        if r.clicked() {
+                            open_kbd = true;
+                        }
+                    });
+                    if open_kbd {
+                        self.otp.kbd_confirm = Some(KbdToggle {
+                            enable: target,
+                            typed: String::new(),
+                        });
+                    }
                 }
                 ui.add_space(6.0);
                 if theme::button(ui, p, BtnKind::Default, "Refresh").clicked() {
@@ -358,6 +655,15 @@ impl App {
                     });
             });
         });
+        // Serial on its own line, so a long serial never collides with the
+        // controls on the header row.
+        if let Some(serial) = &self.otp.serial {
+            ui.label(
+                egui::RichText::new(format!("S/N {serial}"))
+                    .font(theme::f_reg(11.5))
+                    .color(p.txt3),
+            );
+        }
         ui.add_space(12.0);
 
         if let Some(info) = &self.otp.info {
@@ -370,6 +676,8 @@ impl App {
         }
 
         self.render_otp_add_form(ui, p);
+        self.render_button_hotp_form(ui, p);
+        self.render_keyboard_confirm(ui, p);
         self.render_otp_delete_confirm(ui, p);
 
         if !self.otp.loaded {
@@ -553,6 +861,155 @@ impl App {
         }
     }
 
+    /// The touch-HOTP form, shown inline when `button_hotp.open`. Configures the
+    /// single HOTP-on-touch keystroke slot.
+    fn render_button_hotp_form(&mut self, ui: &mut egui::Ui, p: &Palette) {
+        if !self.otp.button_hotp.open {
+            return;
+        }
+        let mut submit = false;
+        let mut clear = false;
+        let mut cancel = false;
+        theme::card_frame(p).show(ui, |ui| {
+            ui.label(
+                egui::RichText::new("Touch HOTP (keystroke)")
+                    .font(theme::f_sb(13.5))
+                    .color(p.txt),
+            );
+            ui.add_space(4.0);
+            ui.label(
+                egui::RichText::new(
+                    "The key types a fresh HOTP code as keyboard input when you touch it \
+                     outside any session. One slot per key.",
+                )
+                .font(theme::f_reg(11.5))
+                .color(p.txt3),
+            );
+            ui.add_space(8.0);
+            egui::Grid::new("button_hotp_grid")
+                .num_columns(2)
+                .spacing([10.0, 8.0])
+                .show(ui, |ui| {
+                    ui.label("Secret (Base32)");
+                    ui.add(
+                        egui::TextEdit::singleline(&mut self.otp.button_hotp.secret)
+                            .password(true)
+                            .desired_width(260.0),
+                    );
+                    ui.end_row();
+
+                    ui.label("Digits");
+                    ui.horizontal(|ui| {
+                        ui.selectable_value(&mut self.otp.button_hotp.digits, 6u8, "6");
+                        ui.selectable_value(&mut self.otp.button_hotp.digits, 8u8, "8");
+                    });
+                    ui.end_row();
+
+                    ui.label("Send Enter");
+                    ui.checkbox(&mut self.otp.button_hotp.send_enter, "");
+                    ui.end_row();
+
+                    ui.label("Long touch (2s)");
+                    ui.checkbox(&mut self.otp.button_hotp.long_touch, "");
+                    ui.end_row();
+
+                    ui.label("Numeric keypad");
+                    ui.checkbox(&mut self.otp.button_hotp.numpad, "");
+                    ui.end_row();
+                });
+            ui.add_space(10.0);
+            ui.horizontal(|ui| {
+                if theme::button(ui, p, BtnKind::Primary, "Save").clicked() {
+                    submit = true;
+                }
+                ui.add_space(6.0);
+                if theme::button(ui, p, BtnKind::Default, "Cancel").clicked() {
+                    cancel = true;
+                }
+                ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                    if theme::button(ui, p, BtnKind::Danger, "Clear slot").clicked() {
+                        clear = true;
+                    }
+                });
+            });
+        });
+        ui.add_space(10.0);
+        if submit {
+            self.otp.button_hotp.open = false;
+            self.provision_button_hotp();
+        } else if clear {
+            self.otp.button_hotp.open = false;
+            self.delete_button_hotp_slot();
+        } else if cancel {
+            self.otp.button_hotp = ButtonHotpDialog::default();
+        }
+    }
+
+    /// Typed-phrase confirmation for the keyboard-HID enable/disable toggle.
+    /// Mirrors the CLI's `interface` confirmation: this reconfigures the hardware,
+    /// so the user must type an exact phrase before it applies.
+    fn render_keyboard_confirm(&mut self, ui: &mut egui::Ui, p: &Palette) {
+        let Some(tog) = self.otp.kbd_confirm.as_ref() else {
+            return;
+        };
+        let enable = tog.enable;
+        const PHRASE: &str = "change interface";
+        let mut apply = false;
+        let mut cancel = false;
+        theme::card_frame(p).show(ui, |ui| {
+            let title = if enable {
+                "Enable the keyboard-HID interface?"
+            } else {
+                "Disable the keyboard-HID interface?"
+            };
+            ui.colored_label(p.err, title);
+            ui.add_space(4.0);
+            ui.label(
+                egui::RichText::new(
+                    "This reconfigures the key's USB interfaces. The change takes effect \
+                     after you re-plug the key. Disabling an interface removes the matching \
+                     features until you re-enable it; if you disable the interface you are \
+                     connected over, you may lose access to the key.",
+                )
+                .font(theme::f_reg(11.5))
+                .color(p.txt3),
+            );
+            ui.add_space(8.0);
+            ui.label(
+                egui::RichText::new(format!("Type \u{201c}{PHRASE}\u{201d} to confirm:"))
+                    .font(theme::f_reg(12.0))
+                    .color(p.txt2),
+            );
+            if let Some(t) = self.otp.kbd_confirm.as_mut() {
+                ui.add(egui::TextEdit::singleline(&mut t.typed).desired_width(220.0));
+            }
+            ui.add_space(8.0);
+            let matched = self
+                .otp
+                .kbd_confirm
+                .as_ref()
+                .is_some_and(|t| t.typed.trim() == PHRASE);
+            ui.horizontal(|ui| {
+                ui.add_enabled_ui(matched, |ui| {
+                    if theme::button(ui, p, BtnKind::Danger, "Apply").clicked() {
+                        apply = true;
+                    }
+                });
+                ui.add_space(6.0);
+                if theme::button(ui, p, BtnKind::Default, "Cancel").clicked() {
+                    cancel = true;
+                }
+            });
+        });
+        ui.add_space(10.0);
+        if apply {
+            self.otp.kbd_confirm = None;
+            self.apply_keyboard_toggle(enable);
+        } else if cancel {
+            self.otp.kbd_confirm = None;
+        }
+    }
+
     /// Confirmation dialog for delete / erase-all.
     fn render_otp_delete_confirm(&mut self, ui: &mut egui::Ui, p: &Palette) {
         let Some((app_name, account_name)) = self.otp.confirm_delete.clone() else {
@@ -570,6 +1027,17 @@ impl App {
                 format!("Delete OTP entry \"{app_name}:{account_name}\"?")
             };
             ui.colored_label(p.err, msg);
+            if erase_all {
+                ui.add_space(4.0);
+                ui.label(
+                    egui::RichText::new(
+                        "After you confirm, touch the key's sensor to complete the erase \
+                         — the device waits for a physical touch.",
+                    )
+                    .font(theme::f_reg(11.5))
+                    .color(p.txt3),
+                );
+            }
             ui.add_space(8.0);
             ui.horizontal(|ui| {
                 let label = if erase_all { "Erase all" } else { "Delete" };

--- a/crates/keyroost/src/ui/device.rs
+++ b/crates/keyroost/src/ui/device.rs
@@ -286,14 +286,22 @@ pub fn enumerate() -> Result<Vec<UiDevice>, String> {
         if p.has_piv {
             caps.insert(Caps::PIV);
         }
+        // Token2 keys carry the on-device OTP applet, reachable over CCID/NFC as
+        // well as USB-HID. The HID path below sets Caps::OTP from the USB VID, but
+        // a Token2 key presented over CCID only (HID disabled, or contactless)
+        // would otherwise lose its OTP tab. Detect it from the reader name here so
+        // the capability is offered on the smart-card interface too.
+        if p.reader_name.to_ascii_lowercase().contains("token2") {
+            caps.insert(Caps::OTP);
+        }
         if caps.is_empty() {
             // No key applet we manage — likely a FIDO-only key's CCID interface.
             // The HID merge step below picks it up if it matches a HID node.
             continue;
         }
-        // Prefer a YubiKey management serial; otherwise fall back to a serial
-        // recovered from the OpenPGP AID during probing (e.g. Token2 PIN+, which
-        // has no HID serial). Either way `serial` drives the header `#…` field.
+        // Prefer a YubiKey management serial; otherwise the serial recovered
+        // during probing (the full Token2 GET_INFO serial where available, else
+        // the shorter OpenPGP-AID serial). Either way `serial` drives the header.
         let serial = p
             .yubikey_serial
             .clone()

--- a/crates/keyroostctl/src/main.rs
+++ b/crates/keyroostctl/src/main.rs
@@ -1140,6 +1140,31 @@ enum OtpCmd {
     },
     /// Delete the HOTP-on-button keystroke slot.
     DeleteButtonHotp,
+    /// Enable or disable the key's USB interfaces (FIDO / keyboard-HID / CCID)
+    /// via SET_DEVICE_TYPE.
+    ///
+    /// You name the interfaces to ENABLE; any not named are disabled. At least
+    /// TWO must remain enabled: disabling all of them bricks the key, and leaving
+    /// only one risks locking you out, so the tool refuses fewer than two. This
+    /// reconfigures the hardware and requires typing a confirmation phrase.
+    /// Read and print the device configuration (interface states, capabilities).
+    /// Useful for diagnosing why the GUI's keyboard toggle or Touch HOTP gating
+    /// behaves as it does.
+    Config,
+    Interface {
+        /// Enable the FIDO2/U2F interface.
+        #[arg(long)]
+        fido: bool,
+        /// Enable the keyboard-HID interface (needed for HOTP-on-touch keystroke).
+        #[arg(long)]
+        keyboard: bool,
+        /// Enable the CCID/smart-card interface (PIV, OpenPGP, OTP over PC/SC).
+        #[arg(long)]
+        ccid: bool,
+        /// Skip the interactive confirmation (still refuses to disable all).
+        #[arg(long)]
+        yes: bool,
+    },
 }
 
 /// Transport selector for the `otp` command group.
@@ -2716,6 +2741,108 @@ fn run_otp(
             let mut session = open_otp(transport, debug)?;
             session.delete_button_hotp()?;
             println!("Deleted the HOTP-on-button keystroke slot.");
+        }
+        OtpCmd::Config => {
+            let mut session = open_otp(transport, debug)?;
+            // Show the raw READ_CONFIG bytes first (diagnostic), then the parse.
+            match session.read_config() {
+                Ok(raw) => {
+                    let hex: String = raw.iter().map(|b| format!("{b:02x}")).collect();
+                    println!("READ_CONFIG returned {} bytes: {hex}", raw.len());
+                }
+                Err(e) => {
+                    eprintln!("READ_CONFIG failed: {e}");
+                    return Err(e.into());
+                }
+            }
+            let info = session.read_device_info()?;
+            println!("Device configuration:");
+            println!("  FIDO interface:         {}", if info.fido_disabled() { "disabled" } else { "enabled" });
+            println!("  keyboard-HID interface: {}", if info.hotp_keystroke_disabled() { "disabled" } else { "enabled" });
+            println!("  CCID interface:         {}", if info.ccid_disabled() { "disabled" } else { "enabled" });
+            println!("  HOTP-on-touch support:  {}", if info.button_hotp_supported() { "yes" } else { "no" });
+            println!("  HOTP-on-touch slot:     {}", if info.button_hotp_configured() { "configured" } else { "empty" });
+        }
+        OtpCmd::Interface {
+            fido,
+            keyboard,
+            ccid,
+            yes,
+        } => {
+            use keyroost_token2otp::{DEV_CCID, DEV_FIDO, DEV_KEYBOARD};
+            // Require at least TWO interfaces to remain enabled. Disabling all
+            // three bricks the key; leaving only one is fragile (if that single
+            // interface can't be reached you'd be locked out), so the tool keeps
+            // a two-interface minimum as a safety margin.
+            let enabled_count = [*fido, *keyboard, *ccid].iter().filter(|x| **x).count();
+            if enabled_count < 2 {
+                return Err(
+                    "at least two interfaces must stay enabled (--fido / --keyboard / --ccid); \
+                     reducing to one or zero risks locking you out of the key"
+                        .into(),
+                );
+            }
+            // Build the *disable* mask: a set bit disables that interface.
+            let mut disable: u8 = 0;
+            if !*fido {
+                disable |= DEV_FIDO;
+            }
+            if !*keyboard {
+                disable |= DEV_KEYBOARD;
+            }
+            if !*ccid {
+                disable |= DEV_CCID;
+            }
+
+            let enabled: Vec<&str> = [
+                (*fido, "FIDO2/U2F"),
+                (*keyboard, "keyboard-HID"),
+                (*ccid, "CCID/smart-card"),
+            ]
+            .into_iter()
+            .filter_map(|(on, name)| on.then_some(name))
+            .collect();
+            let disabled: Vec<&str> = [
+                (!*fido, "FIDO2/U2F"),
+                (!*keyboard, "keyboard-HID"),
+                (!*ccid, "CCID/smart-card"),
+            ]
+            .into_iter()
+            .filter_map(|(off, name)| off.then_some(name))
+            .collect();
+
+            eprintln!("This will reconfigure the key's USB interfaces:");
+            eprintln!("  enable:  {}", enabled.join(", "));
+            eprintln!(
+                "  disable: {}",
+                if disabled.is_empty() {
+                    "(none)".to_string()
+                } else {
+                    disabled.join(", ")
+                }
+            );
+            eprintln!(
+                "Disabling an interface removes the matching features until you re-enable it.\n\
+                 If you disable the interface you are currently connected over, you may not be\n\
+                 able to reach the key to undo this. Proceed with caution."
+            );
+
+            if !*yes {
+                // Require typing an exact phrase — not just "y" — for a hardware
+                // reconfiguration this consequential.
+                eprint!("Type EXACTLY 'reconfigure interfaces' to proceed: ");
+                use std::io::Write as _;
+                std::io::stderr().flush().ok();
+                let mut line = String::new();
+                std::io::stdin().read_line(&mut line)?;
+                if line.trim() != "reconfigure interfaces" {
+                    return Err("confirmation phrase did not match; aborted".into());
+                }
+            }
+
+            let mut session = open_otp(transport, debug)?;
+            session.set_device_type(disable)?;
+            println!("Interface configuration updated. Re-plug the key for it to take effect.");
         }
     }
     Ok(())

--- a/crates/keyroostctl/src/main.rs
+++ b/crates/keyroostctl/src/main.rs
@@ -2757,11 +2757,46 @@ fn run_otp(
             }
             let info = session.read_device_info()?;
             println!("Device configuration:");
-            println!("  FIDO interface:         {}", if info.fido_disabled() { "disabled" } else { "enabled" });
-            println!("  keyboard-HID interface: {}", if info.hotp_keystroke_disabled() { "disabled" } else { "enabled" });
-            println!("  CCID interface:         {}", if info.ccid_disabled() { "disabled" } else { "enabled" });
-            println!("  HOTP-on-touch support:  {}", if info.button_hotp_supported() { "yes" } else { "no" });
-            println!("  HOTP-on-touch slot:     {}", if info.button_hotp_configured() { "configured" } else { "empty" });
+            println!(
+                "  FIDO interface:         {}",
+                if info.fido_disabled() {
+                    "disabled"
+                } else {
+                    "enabled"
+                }
+            );
+            println!(
+                "  keyboard-HID interface: {}",
+                if info.hotp_keystroke_disabled() {
+                    "disabled"
+                } else {
+                    "enabled"
+                }
+            );
+            println!(
+                "  CCID interface:         {}",
+                if info.ccid_disabled() {
+                    "disabled"
+                } else {
+                    "enabled"
+                }
+            );
+            println!(
+                "  HOTP-on-touch support:  {}",
+                if info.button_hotp_supported() {
+                    "yes"
+                } else {
+                    "no"
+                }
+            );
+            println!(
+                "  HOTP-on-touch slot:     {}",
+                if info.button_hotp_configured() {
+                    "configured"
+                } else {
+                    "empty"
+                }
+            );
         }
         OtpCmd::Interface {
             fido,


### PR DESCRIPTION
# Token2 HID interface + touch-HOTP GUI + OTP-over-CCID — patch

Three changes against keyroost `main` (0.5.1). Applies cleanly to a fresh upstream clone.

## What's in it

**1. OTP tab over CCID (bug fix).**
Upstream only sets `Caps::OTP` in the USB-HID enumeration path (gated on VID
0x349E). A Token2 key presented over CCID/NFC only (HID disabled, or contactless)
therefore loses its On-device OTP tab. This adds the capability in the PC/SC
build path too, when the reader name identifies a Token2 device.
*File:* `crates/keyroost/src/ui/device.rs`

**2. Interface enable/disable (new CLI command).**
`keyroostctl otp interface` toggles the key's USB interfaces (FIDO /
keyboard-HID / CCID) via `SET_DEVICE_TYPE`. You name the interfaces to *enable*;
unnamed ones are disabled.
*Files:* `crates/keyroost-transport/src/token2otp.rs` (new `set_device_type` +
`read_config` session methods), `crates/keyroostctl/src/main.rs` (the command).

Guards against bricking and lockout:
  - the CLI requires at least **two** interfaces to stay enabled (disabling all
    bricks the key; leaving only one risks lockout if that interface can't be
    reached);
  - it requires typing the exact phrase `reconfigure interfaces` (unless `--yes`);
  - the byte layer's `set_device_type()` also refuses an all-disabled mask.

**3. Touch-HOTP in the GUI (new dialog).**
Surfaces the existing `button-hotp` feature (the HOTP-on-touch keystroke slot) in
the On-device OTP pane: a "Touch HOTP" button opens a dialog for the Base32
secret, 6/8 digits, Send-Enter, long-touch, and numeric-keypad options, plus a
"Clear slot" action.

Touch-HOTP types over the keyboard-HID interface, so it fails with `6A81` when
that interface is disabled. The pane now reads the device config on load and
**disables the Touch HOTP button** (with an explanatory hover tooltip) when the
keyboard-HID interface is off or the model lacks the feature — instead of letting
the user fill the form and hit a cryptic status-word error at submit. (A new
`read_device_info()` transport method backs this.)

The pane also has a **keyboard-HID enable/disable toggle** (an "Enable keyboard" /
"Disable keyboard" button next to Touch HOTP) so a user who finds the feature
greyed out can turn the interface on. It uses the same `SET_DEVICE_TYPE` path as
the CLI, behind a **typed-phrase confirmation** ("change interface"), preserves
the other two interfaces, and refuses any toggle that would drop below two
enabled interfaces. *Files:* `crates/keyroost/src/otp_pane.rs`,
`crates/keyroost-transport/src/token2otp.rs`, plus a `ccid_disabled()` accessor
in `crates/keyroost-token2otp/src/lib.rs`.

**Also:** the GUI **erase-all** confirmation now warns that the device waits for a
physical touch to complete the erase, and the in-progress status reads "touch
your key" — previously the dialog gave no hint and the operation appeared to hang
while the key silently waited for a touch.

**4. Full serial in the device header (fix).**
The header serial was taken from the OpenPGP AID, which only carries a 4-byte
(truncated) serial. Token2 keys expose the complete serial via the FIDO applet's
`GET_INFO` (the same value the OTP tab shows). The PC/SC probe now reads that full
serial for Token2 readers and falls back to the OpenPGP-AID serial only if the
full read fails — so the header shows the longest available serial.
*File:* `crates/keyroost-transport/src/lib.rs` (+ a comment in `device.rs`).

 

### CLI

```bash
# interface command help + the brick-guard
./target/release/keyroostctl otp interface --help
./target/release/keyroostctl otp interface            # refuses (no interface enabled)

# enable keyboard-HID + CCID + FIDO (typical "all on"); prompts for the phrase
./target/release/keyroostctl otp interface --fido --keyboard --ccid

# enable HID so touch-HOTP works, keep FIDO + CCID; then set the touch slot
./target/release/keyroostctl otp interface --fido --keyboard --ccid
echo -n "<BASE32SEED>" | ./target/release/keyroostctl otp button-hotp --seed-stdin
```

### GUI

```bash
cargo run -p keyroost
```
Select a Token2 key → **On-device OTP** tab → **Touch HOTP** button → fill the
form → **Save**. "Clear slot" removes it.

## Hardware testing checklist (needs a real key — couldn't be done in CI)

- [ ] OTP tab appears for a Token2 key reached **over CCID only** (HID disabled).
- [ ] `otp interface` enabling/disabling each interface behaves as expected, and
      the change persists after re-plugging.
- [ ] **Carefully**: confirm the guards — `otp interface` with fewer than two
      interfaces enabled is refused, and the typed-phrase prompt works.
- [ ] GUI erase-all shows the touch warning and the "touch your key" status, and
      completes when the sensor is touched.
- [ ] Touch-HOTP set from the GUI types the expected code on touch (with/without
      Enter, short vs long touch, numpad).
- [ ] With keyboard-HID **disabled**, the Touch HOTP button is greyed out with a
      tooltip explaining why (no more 6A81 at submit); re-enabling the interface
      re-enables the button.
- [ ] The GUI "Enable/Disable keyboard" toggle: typed-phrase confirm works, the
      change applies and persists after re-plug, and a disable that would leave
      fewer than two interfaces is refused (button greyed with tooltip).
- [ ] `delete-button-hotp` / GUI "Clear slot" removes it.

 