### PR TITLE
NFC Reader support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1799,6 +1799,7 @@ dependencies = [
  "des",
  "getrandom 0.2.17",
  "hidapi",
+ "keyroost-ctap",
  "keyroost-hid",
  "keyroost-oath",
  "keyroost-openpgp",

--- a/crates/keyroost-ctap/src/bio_enroll.rs
+++ b/crates/keyroost-ctap/src/bio_enroll.rs
@@ -13,7 +13,8 @@
 use crate::cbor::{self, Value};
 use crate::client_pin::PinUvAuthToken;
 use crate::cmd::CtapError;
-use crate::hid::{CtapHidDevice, CTAPHID_CBOR};
+use crate::hid::CTAPHID_CBOR;
+use crate::transport::CtapTransport;
 
 /// authenticatorBioEnrollment command byte (standard).
 pub const CTAP2_BIO_ENROLLMENT: u8 = 0x09;
@@ -104,17 +105,17 @@ pub fn sample_status_message(status: u64) -> &'static str {
 
 /// Bio-enrollment session: holds the authenticated channel + the chosen command
 /// byte (standard vs preview), like [`crate::cred_mgmt::CredentialManager`].
-pub struct BioEnrollment<'a> {
-    dev: &'a mut CtapHidDevice,
+pub struct BioEnrollment<'a, T: CtapTransport> {
+    dev: &'a mut T,
     token: PinUvAuthToken,
     cmd_code: u8,
 }
 
-impl<'a> BioEnrollment<'a> {
+impl<'a, T: CtapTransport> BioEnrollment<'a, T> {
     /// Create a session. `cmd_code` is [`CTAP2_BIO_ENROLLMENT`] or
     /// [`CTAP2_BIO_ENROLLMENT_PREVIEW`] depending on what the authenticator
     /// advertises in its `AuthenticatorInfo`.
-    pub fn new(dev: &'a mut CtapHidDevice, token: PinUvAuthToken, cmd_code: u8) -> Self {
+    pub fn new(dev: &'a mut T, token: PinUvAuthToken, cmd_code: u8) -> Self {
         BioEnrollment {
             dev,
             token,

--- a/crates/keyroost-ctap/src/client_pin.rs
+++ b/crates/keyroost-ctap/src/client_pin.rs
@@ -23,7 +23,8 @@
 
 use crate::cbor::{self, Value};
 use crate::cmd::{get_info, AuthenticatorInfo, CtapError};
-use crate::hid::{CtapHidDevice, CTAPHID_CBOR};
+use crate::hid::CTAPHID_CBOR;
+use crate::transport::CtapTransport;
 use crate::pin::{
     left16_sha256, pad_pin_to_64, EphemeralKey, PinProtocol, ProtocolV1, ProtocolV2,
     PIN_PROTOCOL_V1, PIN_PROTOCOL_V2,
@@ -157,7 +158,7 @@ impl PinUvAuthToken {
 }
 
 /// Read the current PIN retry counter. No auth required.
-pub fn get_pin_retries(dev: &mut CtapHidDevice) -> Result<u32, CtapError> {
+pub fn get_pin_retries(dev: &mut impl CtapTransport) -> Result<u32, CtapError> {
     let req = build_request_extra(PIN_PROTOCOL_V1, SUB_GET_PIN_RETRIES, &[]);
     let resp = dispatch(dev, &req)?;
     resp.retries
@@ -173,7 +174,7 @@ pub fn get_pin_retries(dev: &mut CtapHidDevice) -> Result<u32, CtapError> {
 /// mismatch, which is why this only surfaced on the YubiKey. Confirmed from an
 /// on-wire trace: getKeyAgreement declared 1 while setPIN ran 2.
 pub fn get_key_agreement(
-    dev: &mut CtapHidDevice,
+    dev: &mut impl CtapTransport,
     protocol: u32,
 ) -> Result<([u8; 32], [u8; 32]), CtapError> {
     let req = build_request_extra(protocol, SUB_GET_KEY_AGREEMENT, &[]);
@@ -183,7 +184,7 @@ pub fn get_key_agreement(
 }
 
 /// Set the initial PIN on an authenticator that doesn't have one yet.
-pub fn set_pin(dev: &mut CtapHidDevice, new_pin: &str) -> Result<(), CtapError> {
+pub fn set_pin(dev: &mut impl CtapTransport, new_pin: &str) -> Result<(), CtapError> {
     use zeroize::Zeroize;
     validate_pin(new_pin)?;
     let chosen = negotiate_protocol(dev)?;
@@ -205,7 +206,7 @@ pub fn set_pin(dev: &mut CtapHidDevice, new_pin: &str) -> Result<(), CtapError> 
 }
 
 /// Change an existing PIN.
-pub fn change_pin(dev: &mut CtapHidDevice, old_pin: &str, new_pin: &str) -> Result<(), CtapError> {
+pub fn change_pin(dev: &mut impl CtapTransport, old_pin: &str, new_pin: &str) -> Result<(), CtapError> {
     use zeroize::Zeroize;
     validate_pin(new_pin)?;
     let chosen = negotiate_protocol(dev)?;
@@ -236,14 +237,14 @@ pub fn change_pin(dev: &mut CtapHidDevice, old_pin: &str, new_pin: &str) -> Resu
 /// Obtain a pinUvAuthToken bound to the current PIN. The returned token is
 /// usable as an HMAC key for credential management and similar commands
 /// until the authenticator power-cycles.
-pub fn get_pin_token(dev: &mut CtapHidDevice, pin: &str) -> Result<PinUvAuthToken, CtapError> {
+pub fn get_pin_token(dev: &mut impl CtapTransport, pin: &str) -> Result<PinUvAuthToken, CtapError> {
     let chosen = negotiate_protocol(dev)?;
     token_legacy(dev, pin, chosen)
 }
 
 /// `getPinToken` (0x05) with the protocol already negotiated.
 fn token_legacy(
-    dev: &mut CtapHidDevice,
+    dev: &mut impl CtapTransport,
     pin: &str,
     chosen: SelectedPinProtocol,
 ) -> Result<PinUvAuthToken, CtapError> {
@@ -310,7 +311,7 @@ pub mod permissions {
 /// `CTAP2_ERR_PIN_AUTH_INVALID` (0x33). Requesting `cm` via 0x09 fixes it.
 /// Legacy keys ignore the permission argument.
 pub fn get_pin_uv_auth_token(
-    dev: &mut CtapHidDevice,
+    dev: &mut impl CtapTransport,
     pin: &str,
     info: &AuthenticatorInfo,
     permissions: u32,
@@ -329,7 +330,7 @@ pub fn get_pin_uv_auth_token(
 /// Like [`get_pin_token`] but binds the returned token to `permissions` (and,
 /// when the permission set requires it, an `rp_id`).
 pub fn get_pin_uv_auth_token_with_permissions(
-    dev: &mut CtapHidDevice,
+    dev: &mut impl CtapTransport,
     pin: &str,
     permissions: u32,
     rp_id: Option<&str>,
@@ -341,7 +342,7 @@ pub fn get_pin_uv_auth_token_with_permissions(
 /// `getPinUvAuthTokenUsingPinWithPermissions` (0x09) with the protocol already
 /// negotiated.
 fn token_with_permissions(
-    dev: &mut CtapHidDevice,
+    dev: &mut impl CtapTransport,
     pin: &str,
     permissions: u32,
     rp_id: Option<&str>,
@@ -416,7 +417,7 @@ impl PeerKey {
 /// returned [`PinProtocol`] is boxed so the v1/v2 split key derivation and
 /// AES/HMAC framing stay behind one interface; callers don't branch on version.
 fn key_agreement(
-    dev: &mut CtapHidDevice,
+    dev: &mut impl CtapTransport,
     chosen: SelectedPinProtocol,
 ) -> Result<(Box<dyn PinProtocol>, PeerKey), CtapError> {
     let (peer_x, peer_y) = get_key_agreement(dev, chosen.version())?;
@@ -444,7 +445,7 @@ fn key_agreement(
 /// caller (`set_pin`, `change_pin`, `get_pin_token`). One extra read-only
 /// `getInfo` round-trip keeps these public signatures unchanged while still
 /// honouring the device's preferred protocol.
-fn negotiate_protocol(dev: &mut CtapHidDevice) -> Result<SelectedPinProtocol, CtapError> {
+fn negotiate_protocol(dev: &mut impl CtapTransport) -> Result<SelectedPinProtocol, CtapError> {
     let info = get_info(dev)?;
     Ok(select_pin_protocol(&info.pin_uv_auth_protocols))
 }
@@ -458,7 +459,7 @@ fn validate_pin(pin: &str) -> Result<(), CtapError> {
 }
 
 /// CBOR-encode the `clientPin` request and dispatch it.
-fn dispatch(dev: &mut CtapHidDevice, req: &[u8]) -> Result<PinResponse, CtapError> {
+fn dispatch(dev: &mut impl CtapTransport, req: &[u8]) -> Result<PinResponse, CtapError> {
     let mut payload = Vec::with_capacity(req.len() + 1);
     payload.push(CTAP2_CLIENT_PIN);
     payload.extend_from_slice(req);

--- a/crates/keyroost-ctap/src/cmd.rs
+++ b/crates/keyroost-ctap/src/cmd.rs
@@ -7,7 +7,8 @@
 use std::time::Duration;
 
 use crate::cbor::{self, Value};
-use crate::hid::{CtapHidDevice, HidTransportError, CTAPHID_CBOR};
+use crate::hid::{HidTransportError, CTAPHID_CBOR};
+use crate::transport::CtapTransport;
 
 pub const CTAP2_GET_INFO: u8 = 0x04;
 pub const CTAP2_RESET: u8 = 0x07;
@@ -31,6 +32,10 @@ pub enum CtapError {
     /// A caller-supplied argument was rejected before anything was sent to
     /// the device (e.g. a PIN outside the 4–63 byte range).
     InvalidArgument(&'static str),
+    /// A non-HID transport (e.g. PC/SC over NFC or a contact reader) failed at
+    /// the link level — reader I/O error, card removed, or an ISO 7816 status
+    /// word that does not map to a CTAP2 status.
+    Transport(String),
 }
 
 impl CtapError {
@@ -70,6 +75,7 @@ impl std::fmt::Display for CtapError {
                 write!(f, "authenticator response had wrong shape: {}", s)
             }
             CtapError::InvalidArgument(s) => write!(f, "invalid argument: {}", s),
+            CtapError::Transport(s) => write!(f, "reader transport error: {}", s),
         }
     }
 }
@@ -189,7 +195,7 @@ impl AuthenticatorInfo {
 }
 
 /// Issue `authenticatorGetInfo` and decode the response.
-pub fn get_info(dev: &mut CtapHidDevice) -> Result<AuthenticatorInfo, CtapError> {
+pub fn get_info(dev: &mut impl CtapTransport) -> Result<AuthenticatorInfo, CtapError> {
     let resp = dev.transact(CTAPHID_CBOR, &[CTAP2_GET_INFO])?;
     let (status, body) = split_status(&resp)?;
     if status != 0 {
@@ -202,7 +208,7 @@ pub fn get_info(dev: &mut CtapHidDevice) -> Result<AuthenticatorInfo, CtapError>
 /// Issue `authenticatorReset`. Most authenticators require this within ~10
 /// seconds of plug-in *and* a physical touch — failures with status 0x2D
 /// usually mean the touch window has closed.
-pub fn reset(dev: &mut CtapHidDevice) -> Result<(), CtapError> {
+pub fn reset(dev: &mut impl CtapTransport) -> Result<(), CtapError> {
     dev.set_timeout(RESET_TIMEOUT);
     let resp = dev.transact(CTAPHID_CBOR, &[CTAP2_RESET])?;
     let (status, _) = split_status(&resp)?;

--- a/crates/keyroost-ctap/src/config.rs
+++ b/crates/keyroost-ctap/src/config.rs
@@ -28,7 +28,8 @@
 use crate::cbor::{self, Value};
 use crate::client_pin::PinUvAuthToken;
 use crate::cmd::{AuthenticatorInfo, CtapError};
-use crate::hid::{CtapHidDevice, CTAPHID_CBOR};
+use crate::hid::CTAPHID_CBOR;
+use crate::transport::CtapTransport;
 
 pub const CTAP2_CONFIG: u8 = 0x0D;
 
@@ -50,16 +51,16 @@ const PARAM_FORCE_CHANGE_PIN: u64 = 0x03;
 
 /// Issues `authenticatorConfig` sub-commands against an open device, using a
 /// pinUvAuthToken that carries the AuthenticatorConfiguration permission.
-pub struct Configurator<'a> {
-    dev: &'a mut CtapHidDevice,
+pub struct Configurator<'a, T: CtapTransport> {
+    dev: &'a mut T,
     token: PinUvAuthToken,
 }
 
-impl<'a> Configurator<'a> {
+impl<'a, T: CtapTransport> Configurator<'a, T> {
     /// Construct after obtaining a token with the `acfg` permission. Verifies
     /// the authenticator actually advertises `authenticatorConfig` support.
     pub fn new(
-        dev: &'a mut CtapHidDevice,
+        dev: &'a mut T,
         token: PinUvAuthToken,
         info: &AuthenticatorInfo,
     ) -> Result<Self, CtapError> {

--- a/crates/keyroost-ctap/src/cred_mgmt.rs
+++ b/crates/keyroost-ctap/src/cred_mgmt.rs
@@ -13,7 +13,8 @@
 use crate::cbor::{self, Value};
 use crate::client_pin::PinUvAuthToken;
 use crate::cmd::{AuthenticatorInfo, CtapError};
-use crate::hid::{CtapHidDevice, CTAPHID_CBOR};
+use crate::hid::CTAPHID_CBOR;
+use crate::transport::CtapTransport;
 
 pub const CTAP2_CREDENTIAL_MANAGEMENT: u8 = 0x0A;
 pub const CTAP2_CREDENTIAL_MANAGEMENT_PREVIEW: u8 = 0x41;
@@ -90,18 +91,18 @@ pub struct Credential {
 /// sub-commands. The wrapper exists because every sub-command needs the
 /// same authentication and the device's choice between 0x0A and 0x41 has to
 /// be discovered once from `getInfo`.
-pub struct CredentialManager<'a> {
-    dev: &'a mut CtapHidDevice,
+pub struct CredentialManager<'a, T: CtapTransport> {
+    dev: &'a mut T,
     token: PinUvAuthToken,
     cmd_code: u8,
 }
 
-impl<'a> CredentialManager<'a> {
+impl<'a, T: CtapTransport> CredentialManager<'a, T> {
     /// Construct after `clientPin::get_pin_token`. Returns
     /// [`CtapError::InvalidResponseShape`] if the authenticator advertises
     /// neither `credMgmt` nor `credentialMgmtPreview`.
     pub fn new(
-        dev: &'a mut CtapHidDevice,
+        dev: &'a mut T,
         token: PinUvAuthToken,
         info: &AuthenticatorInfo,
     ) -> Result<Self, CtapError> {

--- a/crates/keyroost-ctap/src/hid.rs
+++ b/crates/keyroost-ctap/src/hid.rs
@@ -443,6 +443,23 @@ fn generate_nonce() -> [u8; 8] {
     nonce
 }
 
+impl crate::transport::CtapTransport for CtapHidDevice {
+    /// Delegate to the inherent HID `transact`, mapping its transport error into
+    /// the shared [`CtapError`]. This is what lets HID and PC/SC backends be used
+    /// interchangeably by the command layer.
+    fn transact(&mut self, cmd: u8, payload: &[u8]) -> Result<Vec<u8>, crate::cmd::CtapError> {
+        CtapHidDevice::transact(self, cmd, payload).map_err(crate::cmd::CtapError::from)
+    }
+
+    fn set_timeout(&mut self, timeout: std::time::Duration) {
+        CtapHidDevice::set_timeout(self, timeout);
+    }
+
+    fn set_cancel_flag(&mut self, flag: std::sync::Arc<std::sync::atomic::AtomicBool>) {
+        CtapHidDevice::set_cancel_flag(self, flag);
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/keyroost-ctap/src/large_blobs.rs
+++ b/crates/keyroost-ctap/src/large_blobs.rs
@@ -48,7 +48,8 @@
 use crate::cbor::{self, Value};
 use crate::client_pin::PinUvAuthToken;
 use crate::cmd::{AuthenticatorInfo, CtapError};
-use crate::hid::{CtapHidDevice, CTAPHID_CBOR};
+use crate::hid::CTAPHID_CBOR;
+use crate::transport::CtapTransport;
 use crate::pin::left16_sha256;
 
 /// CTAP command byte for `authenticatorLargeBlobs`.
@@ -210,7 +211,7 @@ pub fn max_fragment_length(info: &AuthenticatorInfo) -> usize {
     max.saturating_sub(MSG_SIZE_OVERHEAD).max(1) as usize
 }
 
-fn dispatch(dev: &mut CtapHidDevice, params: Value) -> Result<Value, CtapError> {
+fn dispatch(dev: &mut impl CtapTransport, params: Value) -> Result<Value, CtapError> {
     let mut payload = Vec::new();
     payload.push(CTAP2_LARGE_BLOBS);
     payload.extend_from_slice(&cbor::encode(&params));
@@ -228,7 +229,7 @@ fn dispatch(dev: &mut CtapHidDevice, params: Value) -> Result<Value, CtapError> 
 }
 
 /// Read one fragment beginning at `offset`, asking for at most `count` bytes.
-fn read_fragment(dev: &mut CtapHidDevice, offset: u64, count: u64) -> Result<Vec<u8>, CtapError> {
+fn read_fragment(dev: &mut impl CtapTransport, offset: u64, count: u64) -> Result<Vec<u8>, CtapError> {
     let params = Value::Map(vec![
         (Value::UInt(KEY_GET), Value::UInt(count)),
         (Value::UInt(KEY_OFFSET), Value::UInt(offset)),
@@ -255,7 +256,7 @@ fn read_fragment(dev: &mut CtapHidDevice, offset: u64, count: u64) -> Result<Vec
 /// Read the entire serialized large-blob array, verify its checksum, and parse
 /// the entries. Requires no PIN/UV.
 pub fn read(
-    dev: &mut CtapHidDevice,
+    dev: &mut impl CtapTransport,
     info: &AuthenticatorInfo,
 ) -> Result<LargeBlobArray, CtapError> {
     let frag = max_fragment_length(info) as u64;
@@ -374,7 +375,7 @@ fn write_auth_param(token: &PinUvAuthToken, offset: u32, fragment: &[u8]) -> Vec
 /// in `maxFragmentLength`-sized fragments, honoring the authenticator's stateful
 /// write protocol (length declared once at offset 0).
 pub fn write(
-    dev: &mut CtapHidDevice,
+    dev: &mut impl CtapTransport,
     info: &AuthenticatorInfo,
     token: &PinUvAuthToken,
     serialized: &[u8],

--- a/crates/keyroost-ctap/src/lib.rs
+++ b/crates/keyroost-ctap/src/lib.rs
@@ -21,6 +21,7 @@ pub mod cred_mgmt;
 pub mod hid;
 pub mod large_blobs;
 pub mod pin;
+pub mod transport;
 
 pub use bio_enroll::{BioEnrollment, CaptureStatus, Enrollment, SensorInfo};
 pub use cmd::{get_info, reset, AuthenticatorInfo, CtapError};

--- a/crates/keyroost-ctap/src/transport.rs
+++ b/crates/keyroost-ctap/src/transport.rs
@@ -1,0 +1,72 @@
+//! Transport abstraction for CTAP2 commands.
+//!
+//! Every CTAP command in this crate is expressed as a single logical exchange:
+//! send a command byte plus a CBOR payload, get back a response byte string
+//! (the first byte is the CTAP2 status, the rest is CBOR). Historically that
+//! exchange went only over CTAP-HID (USB). [`CtapTransport`] lifts it into a
+//! trait so the same command code can run over any link that can carry a CTAP
+//! message — in particular PC/SC, which is how both **NFC** and **contact**
+//! smart-card readers present a key (see [`crate::pcsc`]).
+//!
+//! The trait is deliberately tiny: one method, mirroring
+//! `CtapHidDevice::transact`. Backends own all the link-specific framing —
+//! CTAP-HID channels and continuation packets on one side, ISO 7816 `NFCCTAP_MSG`
+//! APDUs with command chaining and `GET RESPONSE` reassembly on the other — and
+//! present the command layer with the same clean `Vec<u8>` it always had.
+
+use crate::cmd::CtapError;
+
+/// Forwarding impl so a `&mut T` (and, by extension, the `&mut dyn` produced
+/// from a boxed transport) can be passed where `impl CtapTransport` is expected.
+impl<T: CtapTransport + ?Sized> CtapTransport for &mut T {
+    fn transact(&mut self, cmd: u8, payload: &[u8]) -> Result<Vec<u8>, CtapError> {
+        (**self).transact(cmd, payload)
+    }
+    fn set_timeout(&mut self, timeout: std::time::Duration) {
+        (**self).set_timeout(timeout);
+    }
+    fn set_cancel_flag(&mut self, flag: std::sync::Arc<std::sync::atomic::AtomicBool>) {
+        (**self).set_cancel_flag(flag);
+    }
+}
+
+/// Forwarding impl so a `Box<dyn CtapTransport>` is itself a `CtapTransport`,
+/// letting a runtime-selected backend (HID vs PC/SC) be used with the generic
+/// command functions that take `&mut impl CtapTransport`.
+impl CtapTransport for Box<dyn CtapTransport> {
+    fn transact(&mut self, cmd: u8, payload: &[u8]) -> Result<Vec<u8>, CtapError> {
+        (**self).transact(cmd, payload)
+    }
+    fn set_timeout(&mut self, timeout: std::time::Duration) {
+        (**self).set_timeout(timeout);
+    }
+    fn set_cancel_flag(&mut self, flag: std::sync::Arc<std::sync::atomic::AtomicBool>) {
+        (**self).set_cancel_flag(flag);
+    }
+}
+///
+/// `cmd` is the CTAP-HID command byte the command layer would historically pass
+/// (e.g. `CTAPHID_CBOR`). Non-HID transports interpret it as needed — the PC/SC
+/// backend, for instance, treats `CTAPHID_CBOR` as "wrap this payload in an
+/// `NFCCTAP_MSG` APDU" and ignores HID-only commands like `CTAPHID_INIT`.
+pub trait CtapTransport {
+    /// Perform one command/response exchange and return the raw response bytes
+    /// (CTAP2 status byte followed by the CBOR body).
+    fn transact(&mut self, cmd: u8, payload: &[u8]) -> Result<Vec<u8>, CtapError>;
+
+    /// Extend the read timeout for a long, user-present operation (a reset or a
+    /// fingerprint-enrollment capture that waits for a touch).
+    ///
+    /// HID overrides this to widen its report-read deadline. Transports that
+    /// manage their own timeouts (PC/SC drivers apply their own card timeouts)
+    /// can leave the default no-op.
+    fn set_timeout(&mut self, _timeout: std::time::Duration) {}
+
+    /// Wire in a cooperative cancel flag so a capture blocked waiting for a touch
+    /// can abort promptly when the user cancels.
+    ///
+    /// HID checks this between KEEPALIVE frames. PC/SC has no equivalent hook in
+    /// its blocking transmit, so the default is a no-op (a reader-attached
+    /// enrollment simply runs to its own timeout if not completed).
+    fn set_cancel_flag(&mut self, _flag: std::sync::Arc<std::sync::atomic::AtomicBool>) {}
+}

--- a/crates/keyroost-resolve/src/device.rs
+++ b/crates/keyroost-resolve/src/device.rs
@@ -227,7 +227,10 @@ pub fn correlate(hids: &[HidDevice], probes: &[ReaderProbe], keyring: &Keyring) 
         if p.has_piv {
             caps.insert(Caps::PIV);
         }
-        if p.reader_name.to_ascii_lowercase().contains("token2") {
+        if p.has_fido {
+            caps.insert(Caps::FIDO2);
+        }
+        if p.has_otp {
             caps.insert(Caps::OTP);
         }
         if caps.is_empty() {
@@ -421,6 +424,8 @@ mod tests {
             has_oath: oath,
             has_openpgp: pgp,
             has_piv: piv,
+            has_fido: false,
+            has_otp: false,
             yubikey_serial: yk_serial.map(str::to_owned),
             usb_bus: bus,
             usb_address: addr,

--- a/crates/keyroost-transport/Cargo.toml
+++ b/crates/keyroost-transport/Cargo.toml
@@ -17,6 +17,9 @@ keyroost-openpgp = { path = "../keyroost-openpgp", version = "0.6.0" }
 keyroost-piv = { path = "../keyroost-piv", version = "0.6.0" }
 keyroost-token2otp = { path = "../keyroost-token2otp", version = "0.6.0" }
 keyroost-hid = { path = "../keyroost-hid", version = "0.6.0" }
+# For the CtapTransport trait — the PC/SC CTAP backend (NFC + contact readers)
+# implements it so FIDO2 commands can run over a smart-card reader, not just USB-HID.
+keyroost-ctap = { path = "../keyroost-ctap", version = "0.6.0" }
 pcsc = "2"
 # hidapi backs the Token2 OTP USB-HID transport on macOS / Windows; Linux uses
 # the dependency-free hidraw `File` path (same split as keyroost-ctap). Optional

--- a/crates/keyroost-transport/src/ctap_pcsc.rs
+++ b/crates/keyroost-transport/src/ctap_pcsc.rs
@@ -1,0 +1,203 @@
+//! CTAP2 over PC/SC — FIDO2 across NFC and contact smart-card readers.
+//!
+//! USB security keys speak CTAP-HID; keys presented over an **NFC** or
+//! **contact (IC chip)** reader instead speak **CTAP over ISO 7816-4 APDUs**
+//! (FIDO CTAP §11.2, "Message Encoding"). This module bridges the two: it
+//! implements [`keyroost_ctap::transport::CtapTransport`] on top of a PC/SC card
+//! connection, so every existing CTAP2 command (`get_info`, PIN, passkeys,
+//! config, large blobs) runs unchanged over a reader.
+//!
+//! ## How a CTAP message is carried
+//!
+//! 1. **Applet selection.** On connect we `SELECT` the FIDO applet by AID
+//!    (`A0000006472F0001`). A compliant authenticator answers `U2F_V2` or
+//!    `FIDO_2_0`.
+//! 2. **Request.** A CTAP2 message (command byte + CBOR) is sent in the data
+//!    field of an `NFCCTAP_MSG` APDU: `CLA=0x80 INS=0x10 P1=0x00 P2=0x00`. If
+//!    the message exceeds the short-APDU limit (255 bytes) it is split across
+//!    several APDUs using ISO 7816 **command chaining** (CLA bit 0x10 set on all
+//!    but the last).
+//! 3. **Response.** The authenticator may return the body directly, or signal
+//!    more data with status `61 XX`, in which case we issue `GET RESPONSE`
+//!    (`00 C0 00 00 XX`) repeatedly and concatenate until `90 00`.
+//!
+//! Keep-alive: NFC authenticators that need time (user presence) answer with
+//! `91 00` (NFCCTAP_GETRESPONSE pending) — we re-poll with the GET-RESPONSE
+//! instruction until a final answer arrives.
+//!
+//! ## Scope note
+//!
+//! Read/identity/management operations work over a reader. Fingerprint
+//! *enrollment* may be refused by some keys over NFC/contact (they gate the
+//! sensor to USB); that is a per-key firmware behaviour, not a limit of this
+//! transport.
+
+use keyroost_ctap::cmd::CtapError;
+use keyroost_ctap::transport::CtapTransport;
+use pcsc::{Card, Context, Protocols, Scope, ShareMode};
+
+/// FIDO applet AID — `A0 00 00 06 47 2F 00 01`.
+const FIDO_AID: [u8; 8] = [0xA0, 0x00, 0x00, 0x06, 0x47, 0x2F, 0x00, 0x01];
+
+/// `NFCCTAP_MSG` instruction class/byte (CTAP §11.2.3).
+const NFCCTAP_CLA: u8 = 0x80;
+const NFCCTAP_INS: u8 = 0x10;
+/// Continuation-class bit for ISO 7816 command chaining.
+const CLA_CHAIN: u8 = 0x10;
+
+/// ISO 7816 `GET RESPONSE`.
+const GET_RESPONSE_CLA: u8 = 0x00;
+const GET_RESPONSE_INS: u8 = 0xC0;
+
+/// Largest data field in a short-form command APDU.
+const MAX_SHORT_DATA: usize = 255;
+
+/// PC/SC receive buffer (large-blob reads can return a few KB per APDU).
+const RECV_BUF: usize = 4096;
+
+/// A FIDO2 authenticator reached over a PC/SC reader (NFC or contact).
+pub struct CtapPcscDevice {
+    card: Card,
+    /// Applet-select answer (`U2F_V2` / `FIDO_2_0`), retained for diagnostics.
+    selected_version: Vec<u8>,
+}
+
+impl CtapPcscDevice {
+    /// Connect to the named reader, select the FIDO applet, and return a ready
+    /// transport. Fails if the reader has no card, or the card has no FIDO
+    /// applet (e.g. an OATH-only or PIV-only card).
+    pub fn open(reader_name: &str) -> Result<Self, CtapError> {
+        let ctx = Context::establish(Scope::User)
+            .map_err(|e| CtapError::Transport(format!("PC/SC unavailable: {e}")))?;
+        let cname = std::ffi::CString::new(reader_name)
+            .map_err(|_| CtapError::Transport("reader name contains NUL".into()))?;
+        let card = ctx
+            .connect(&cname, ShareMode::Shared, Protocols::ANY)
+            .map_err(|e| CtapError::Transport(format!("connect to reader failed: {e}")))?;
+        let mut dev = CtapPcscDevice {
+            card,
+            selected_version: Vec::new(),
+        };
+        dev.select_fido_applet()?;
+        Ok(dev)
+    }
+
+    /// The applet-select answer string (`U2F_V2` or `FIDO_2_0`).
+    pub fn selected_version(&self) -> &[u8] {
+        &self.selected_version
+    }
+
+    fn select_fido_applet(&mut self) -> Result<(), CtapError> {
+        // SELECT by DF name: 00 A4 04 00 Lc <AID> 00
+        let mut apdu = vec![0x00, 0xA4, 0x04, 0x00, FIDO_AID.len() as u8];
+        apdu.extend_from_slice(&FIDO_AID);
+        apdu.push(0x00); // Le
+        let (data, sw1, sw2) = self.exchange(&apdu)?;
+        if (sw1, sw2) != (0x90, 0x00) {
+            return Err(CtapError::Transport(format!(
+                "FIDO applet not present on this card (SELECT -> {sw1:02X}{sw2:02X})"
+            )));
+        }
+        self.selected_version = data;
+        Ok(())
+    }
+
+    /// One raw APDU exchange. Returns `(response_data, sw1, sw2)`.
+    fn exchange(&mut self, apdu: &[u8]) -> Result<(Vec<u8>, u8, u8), CtapError> {
+        let mut buf = [0u8; RECV_BUF];
+        let resp = self
+            .card
+            .transmit(apdu, &mut buf)
+            .map_err(|e| CtapError::Transport(format!("APDU transmit failed: {e}")))?;
+        if resp.len() < 2 {
+            return Err(CtapError::Transport(format!(
+                "APDU response too short ({} bytes)",
+                resp.len()
+            )));
+        }
+        let (data, sw) = resp.split_at(resp.len() - 2);
+        Ok((data.to_vec(), sw[0], sw[1]))
+    }
+
+    /// Send a full CTAP message body (command byte + CBOR) wrapped in
+    /// `NFCCTAP_MSG`, using command chaining for long payloads, and collect the
+    /// full response across any `61 XX` / `91 00` continuations.
+    fn send_ctap_message(&mut self, message: &[u8]) -> Result<Vec<u8>, CtapError> {
+        // Chain the request if it exceeds one short APDU.
+        let chunks: Vec<&[u8]> = if message.is_empty() {
+            vec![&[][..]]
+        } else {
+            message.chunks(MAX_SHORT_DATA).collect()
+        };
+
+        let mut last = (Vec::new(), 0u8, 0u8);
+        for (i, chunk) in chunks.iter().enumerate() {
+            let is_last = i + 1 == chunks.len();
+            let cla = if is_last { NFCCTAP_CLA } else { NFCCTAP_CLA | CLA_CHAIN };
+            let mut apdu = vec![cla, NFCCTAP_INS, 0x00, 0x00, chunk.len() as u8];
+            apdu.extend_from_slice(chunk);
+            apdu.push(0x00); // Le — expect a response
+            last = self.exchange(&apdu)?;
+            // Non-final chaining APDUs should answer 90 00 with no data.
+            if !is_last && (last.1, last.2) != (0x90, 0x00) {
+                return Err(CtapError::Transport(format!(
+                    "command chaining rejected (SW {:02X}{:02X})",
+                    last.1, last.2
+                )));
+            }
+        }
+
+        let (mut data, mut sw1, mut sw2) = last;
+
+        // Pull any continued response.
+        loop {
+            match (sw1, sw2) {
+                (0x90, 0x00) => break,
+                // More data available: GET RESPONSE for sw2 bytes (0 => 256).
+                (0x61, n) => {
+                    let le = n;
+                    let apdu = [GET_RESPONSE_CLA, GET_RESPONSE_INS, 0x00, 0x00, le];
+                    let (more, s1, s2) = self.exchange(&apdu)?;
+                    data.extend_from_slice(&more);
+                    sw1 = s1;
+                    sw2 = s2;
+                }
+                // NFC keep-alive / processing: re-poll with GET RESPONSE.
+                (0x91, _) => {
+                    let apdu = [GET_RESPONSE_CLA, GET_RESPONSE_INS, 0x00, 0x00, 0x00];
+                    let (more, s1, s2) = self.exchange(&apdu)?;
+                    data.extend_from_slice(&more);
+                    sw1 = s1;
+                    sw2 = s2;
+                }
+                (s1, s2) => {
+                    return Err(CtapError::Transport(format!(
+                        "authenticator returned ISO status {s1:02X}{s2:02X}"
+                    )));
+                }
+            }
+        }
+
+        Ok(data)
+    }
+}
+
+impl CtapTransport for CtapPcscDevice {
+    /// Carry one CTAP exchange. The HID `cmd` byte is interpreted for the APDU
+    /// world: `CTAPHID_CBOR` (and the U2F/MSG-style codes) map onto
+    /// `NFCCTAP_MSG`. `CTAPHID_INIT` has no APDU analogue (channel setup is
+    /// implicit once the applet is selected), so it is a no-op success.
+    fn transact(&mut self, cmd: u8, payload: &[u8]) -> Result<Vec<u8>, CtapError> {
+        use keyroost_ctap::hid::{CTAPHID_CBOR, CTAPHID_INIT};
+        if cmd == CTAPHID_INIT {
+            // No channel negotiation over APDU; report a benign empty response.
+            return Ok(Vec::new());
+        }
+        if cmd != CTAPHID_CBOR {
+            return Err(CtapError::Transport(format!(
+                "CTAP command 0x{cmd:02X} is not supported over a smart-card reader"
+            )));
+        }
+        self.send_ctap_message(payload)
+    }
+}

--- a/crates/keyroost-transport/src/lib.rs
+++ b/crates/keyroost-transport/src/lib.rs
@@ -29,6 +29,9 @@ use pcsc::{
 mod oath;
 pub use oath::OathSession;
 
+mod ctap_pcsc;
+pub use ctap_pcsc::CtapPcscDevice;
+
 mod openpgp;
 pub use openpgp::{OpenPgpSession, OpenPgpStatus};
 
@@ -574,6 +577,16 @@ pub struct ReaderProbe {
     pub has_oath: bool,
     pub has_openpgp: bool,
     pub has_piv: bool,
+    /// True when the card answers a SELECT of the FIDO applet
+    /// (`A0000006472F0001`) — i.e. a FIDO2/U2F security key reached over this
+    /// reader (NFC or contact). Lets the GUI offer the FIDO2 tab for reader-
+    /// attached keys, served by [`CtapPcscDevice`].
+    pub has_fido: bool,
+    /// True when the card answers a SELECT of the Token2 on-device OTP applet
+    /// (`F00000014F747001`). Detected by actually selecting the applet rather
+    /// than guessing from the reader name, so the OTP tab is offered only for
+    /// keys that really have it.
+    pub has_otp: bool,
     /// YubiKey management serial, read on the same connection when the reader is
     /// a YubiKey.
     pub yubikey_serial: Option<String>,
@@ -628,6 +641,8 @@ pub fn probe_readers() -> Result<Vec<ReaderProbe>, TransportError> {
                 has_oath: false,
                 has_openpgp: false,
                 has_piv: false,
+                has_fido: false,
+                has_otp: false,
                 yubikey_serial: None,
                 usb_bus: None,
                 usb_address: None,
@@ -642,6 +657,8 @@ pub fn probe_readers() -> Result<Vec<ReaderProbe>, TransportError> {
             has_oath: false,
             has_openpgp: false,
             has_piv: false,
+            has_fido: false,
+            has_otp: false,
             yubikey_serial: None,
             usb_bus: None,
             usb_address: None,
@@ -673,6 +690,20 @@ pub fn probe_readers() -> Result<Vec<ReaderProbe>, TransportError> {
             probe.has_oath = answers("oath", keyroost_oath::select());
             probe.has_openpgp = answers("openpgp", keyroost_openpgp::select());
             probe.has_piv = answers("piv", keyroost_piv::select());
+            // FIDO2/U2F: a SELECT of the FIDO applet that the card accepts means
+            // a security key is reachable over this reader (NFC or contact), to
+            // be driven by CtapPcscDevice.
+            probe.has_fido = answers(
+                "fido",
+                keyroost_token2otp::build_select(&keyroost_token2otp::FIDO_APPLET_AID),
+            );
+            // Token2 on-device OTP applet — select it to confirm presence,
+            // rather than inferring from the reader name (which mislabels any
+            // key on a "Token2" reader as having OTP).
+            probe.has_otp = answers(
+                "otp",
+                keyroost_token2otp::build_select(&keyroost_token2otp::OTP_APPLET_AID),
+            );
             // When OpenPGP is present, recover the card serial from its AID (the
             // standard OpenPGP AID encodes a 4-byte serial at offset 10). This
             // lets keys with no HID serial (e.g. Token2 PIN+) still show one.

--- a/crates/keyroost-transport/src/token2otp.rs
+++ b/crates/keyroost-transport/src/token2otp.rs
@@ -869,7 +869,17 @@ impl Token2OtpSession {
                 .transport
                 .transmit(&t2::build_select(&t2::FIDO_APPLET_AID), false);
         }
-        let (data, sw) = self.transport.transmit(&t2::read_serial_request(), false)?;
+        let serial = self.transport.transmit(&t2::read_serial_request(), false);
+        // Over PC/SC the FIDO SELECT above left the card on the FIDO applet.
+        // Restore the OTP applet so a following command (enumerate, config) does
+        // not fail with 6A86 ("no current applet / wrong parameters"). Without
+        // this, listing entries after a serial read returns empty.
+        if self.is_pcsc {
+            let _ = self
+                .transport
+                .transmit(&t2::build_select(&t2::OTP_APPLET_AID), false);
+        }
+        let (data, sw) = serial?;
         if OtpError::check(sw).is_err() {
             return Err(OtpTransportError::SerialUnavailable);
         }

--- a/crates/keyroost/src/main.rs
+++ b/crates/keyroost/src/main.rs
@@ -25,6 +25,47 @@ use keyroost_transport::{DeviceInfo, Session, TransportError};
 use keyroost_ctap::client_pin::PinUvAuthToken;
 use keyroost_ctap::cred_mgmt::{Credential, CredsMetadata, RelyingParty};
 use keyroost_ctap::{AuthenticatorInfo, CtapHidDevice, InitResponse};
+
+/// How the selected FIDO key is reached: over USB-HID (a `hidraw` path) or over
+/// a PC/SC reader (NFC or contact, by reader name).
+#[derive(Debug, Clone)]
+enum FidoTarget {
+    Hid(std::path::PathBuf),
+    Pcsc(String),
+}
+
+/// Open a CTAP transport for `target`, returning the boxed transport, whether
+/// it speaks CTAP2 (CBOR), and the HID `InitResponse` when available (HID only;
+/// `None` over PC/SC, which has no INIT phase). The InitResponse carries the
+/// firmware version shown on the hero for USB keys.
+fn open_fido(
+    target: &FidoTarget,
+) -> Result<
+    (
+        Box<dyn keyroost_ctap::transport::CtapTransport>,
+        bool,
+        Option<InitResponse>,
+    ),
+    String,
+> {
+    match target {
+        FidoTarget::Hid(path) => {
+            let (dev, init) = CtapHidDevice::open(path).map_err(|e| e.to_string())?;
+            let cbor = init.supports_cbor();
+            Ok((Box::new(dev), cbor, Some(init)))
+        }
+        FidoTarget::Pcsc(reader) => {
+            let dev = keyroost_transport::CtapPcscDevice::open(reader)
+                .map_err(|e| e.to_string())?;
+            // After a successful FIDO applet SELECT we attempt CTAP2 regardless of
+            // the exact version string (keys answer U2F_V2, FIDO_2_0, FIDO_2_1,
+            // sometimes with trailing bytes). A genuinely U2F-only card will make
+            // get_info return a clean CTAP error, which the caller surfaces —
+            // rather than silently reporting "no CBOR" and leaving the UI idle.
+            Ok((Box::new(dev), true, None))
+        }
+    }
+}
 use keyroost_hid::HidDevice;
 
 const PROFILES: u8 = 100;
@@ -2029,7 +2070,7 @@ impl App {
         self.security_keys.info = None;
         self.security_keys.init = None;
         self.security_keys.error = None;
-        let Some(path) = self.selected_fido_path() else {
+        let Some(target) = self.selected_fido_target() else {
             return;
         };
         // Tag the job with the device it reads — if the user switches devices
@@ -2037,21 +2078,19 @@ impl App {
         // device's pane (or its row in the sidebar).
         let for_device = self.selected_device.clone();
         self.spawn_job("Reading key info\u{2026}", move || {
-            // Off-thread: open the hidraw, run INIT + GetInfo.
-            let outcome = match CtapHidDevice::open(&path) {
-                Ok((mut hid, init)) => {
-                    let info = if init.supports_cbor() {
-                        Some(keyroost_ctap::get_info(&mut hid).map_err(|e| e.to_string()))
+            // Off-thread: open the transport, run GetInfo. HID also yields an
+            // InitResponse (firmware + CBOR capability); PC/SC (NFC/contact) has
+            // no INIT phase, so we synthesize a minimal one and rely on GetInfo.
+            let outcome = match open_fido(&target) {
+                Ok((mut dev, cbor, init)) => {
+                    let info = if cbor {
+                        Some(keyroost_ctap::get_info(&mut dev).map_err(|e| e.to_string()))
                     } else {
                         None
                     };
                     Ok((init, info))
                 }
-                Err(e) => Err(format!(
-                    "could not open {}: {} (have you installed udev/70-keyroost-fido.rules?)",
-                    path.display(),
-                    e
-                )),
+                Err(e) => Err(format!("could not open key: {e}")),
             };
             // Back on the UI thread: store the results.
             Box::new(move |app: &mut App| {
@@ -2060,16 +2099,19 @@ impl App {
                 }
                 match outcome {
                     Ok((init, info)) => {
-                        // Surface the key's firmware on the hero (e.g. "fw 5.7.4").
-                        let fw = format!(
-                            "{}.{}.{}",
-                            init.device_major, init.device_minor, init.device_build
-                        );
-                        app.security_keys.init = Some(init);
-                        if let Some(id) = for_device.clone() {
-                            if let Some(dev) = app.devices.iter_mut().find(|d| d.id == id) {
-                                dev.firmware = fw;
+                        // Surface the key's firmware on the hero (e.g. "fw 5.7.4")
+                        // when we have an InitResponse (USB-HID); PC/SC has none.
+                        if let Some(init) = init {
+                            let fw = format!(
+                                "{}.{}.{}",
+                                init.device_major, init.device_minor, init.device_build
+                            );
+                            if let Some(id) = for_device.clone() {
+                                if let Some(dev) = app.devices.iter_mut().find(|d| d.id == id) {
+                                    dev.firmware = fw;
+                                }
                             }
+                            app.security_keys.init = Some(init);
                         }
                         match info {
                             Some(Ok(info)) => {
@@ -2089,7 +2131,17 @@ impl App {
                             Some(Err(e)) => {
                                 app.security_keys.error = Some(format!("GetInfo failed: {}", e))
                             }
-                            None => {}
+                            None => {
+                                // CBOR was reported unavailable and we never even
+                                // attempted GetInfo. Record it as an error rather
+                                // than leaving the pane spinning on "Reading key…"
+                                // forever (the spinner re-fires while info is None).
+                                app.security_keys.error = Some(
+                                    "this key did not present a CTAP2 (FIDO2) interface over \
+                                     the reader; only U2F was detected"
+                                        .to_string(),
+                                );
+                            }
                         }
                     }
                     Err(e) => app.security_keys.error = Some(e),
@@ -2107,7 +2159,7 @@ impl App {
         if self.busy() {
             return;
         }
-        let Some(path) = self.selected_fido_path() else {
+        let Some(target) = self.selected_fido_target() else {
             return;
         };
         let pin = std::mem::take(&mut self.security_keys.pin_input);
@@ -2116,7 +2168,7 @@ impl App {
             return;
         }
         self.spawn_job("Unlocking\u{2026} (enter PIN / touch)", move || {
-            let result = Self::open_and_unlock(&path, &pin).map_err(|e| e.to_string());
+            let result = Self::open_and_unlock(&target, &pin).map_err(|e| e.to_string());
             Box::new(move |app: &mut App| match result {
                 Ok(sess) => {
                     // Surface fingerprints read during unlock so the list shows
@@ -2131,11 +2183,11 @@ impl App {
     }
 
     fn open_and_unlock(
-        path: &std::path::Path,
+        target: &FidoTarget,
         pin: &str,
     ) -> Result<UnlockedSession, Box<dyn std::error::Error>> {
-        let (mut dev, init) = CtapHidDevice::open(path)?;
-        if !init.supports_cbor() {
+        let (mut dev, cbor, _init) = open_fido(target)?;
+        if !cbor {
             return Err("device is U2F-only".into());
         }
         let info = keyroost_ctap::get_info(&mut dev)?;
@@ -2221,7 +2273,7 @@ impl App {
         if self.busy() {
             return;
         }
-        let Some(path) = self.selected_fido_path() else {
+        let Some(target) = self.selected_fido_target() else {
             return;
         };
         let Some(session) = self.security_keys.session.take() else {
@@ -2231,7 +2283,7 @@ impl App {
         let pin = session.pin;
         self.spawn_job("Refreshing credentials\u{2026}", move || {
             let result =
-                Self::refresh_with_token(&path, token, pin).map_err(SessionOpError::from_boxed);
+                Self::refresh_with_token(&target, token, pin).map_err(SessionOpError::from_boxed);
             Box::new(move |app: &mut App| match result {
                 Ok(fresh) => app.security_keys.session = Some(fresh),
                 Err(e) => app.fail_session_op(&e, "refresh failed"),
@@ -2240,11 +2292,11 @@ impl App {
     }
 
     fn refresh_with_token(
-        path: &std::path::Path,
+        target: &FidoTarget,
         token: PinUvAuthToken,
         pin: zeroize::Zeroizing<String>,
     ) -> Result<UnlockedSession, Box<dyn std::error::Error>> {
-        let (mut dev, _) = CtapHidDevice::open(path)?;
+        let (mut dev, _cbor, _init) = open_fido(target)?;
         let info = keyroost_ctap::get_info(&mut dev)?;
         let mut mgr =
             keyroost_ctap::cred_mgmt::CredentialManager::new(&mut dev, token.clone(), &info)?;
@@ -2283,13 +2335,15 @@ impl App {
     /// the authenticator can invalidate a token after a UV-gated bio write, so
     /// reusing the unlock token across operations fails with 0x33.
     fn with_fresh_bio<T>(
-        path: &std::path::Path,
+        target: &FidoTarget,
         pin: &str,
-        f: impl FnOnce(&mut keyroost_ctap::bio_enroll::BioEnrollment) -> Result<T, SessionOpError>,
+        f: impl FnOnce(
+            &mut keyroost_ctap::bio_enroll::BioEnrollment<Box<dyn keyroost_ctap::transport::CtapTransport>>,
+        ) -> Result<T, SessionOpError>,
     ) -> Result<T, SessionOpError> {
-        let (mut dev, init) =
-            CtapHidDevice::open(path).map_err(|e| SessionOpError::msg(e.to_string()))?;
-        if !init.supports_cbor() {
+        let (mut dev, cbor, _init) =
+            open_fido(target).map_err(SessionOpError::msg)?;
+        if !cbor {
             return Err(SessionOpError::msg("device is U2F-only"));
         }
         let info = keyroost_ctap::get_info(&mut dev).map_err(SessionOpError::from_ctap)?;
@@ -2318,7 +2372,7 @@ impl App {
         if self.busy() {
             return;
         }
-        let Some(path) = self.selected_fido_path() else {
+        let Some(target) = self.selected_fido_target() else {
             return;
         };
         let Some(session) = self.security_keys.session.as_ref() else {
@@ -2327,7 +2381,7 @@ impl App {
         };
         let pin = session.pin.clone();
         self.spawn_job("Reading fingerprints\u{2026}", move || {
-            let result = Self::with_fresh_bio(&path, &pin, |bio| {
+            let result = Self::with_fresh_bio(&target, &pin, |bio| {
                 bio.enumerate().map_err(SessionOpError::from_ctap)
             });
             Box::new(move |app: &mut App| match result {
@@ -2347,7 +2401,7 @@ impl App {
         if self.busy() {
             return;
         }
-        let Some(path) = self.selected_fido_path() else {
+        let Some(target) = self.selected_fido_target() else {
             return;
         };
         let Some(session) = self.security_keys.session.as_ref() else {
@@ -2371,9 +2425,9 @@ impl App {
         self.spawn_job("Enrolling fingerprint\u{2026}", move || {
             use keyroost_ctap::bio_enroll::sample_status_message;
             let result = (|| -> Result<Vec<keyroost_ctap::Enrollment>, SessionOpError> {
-                let (mut dev, init) =
-                    CtapHidDevice::open(&path).map_err(|e| SessionOpError::msg(e.to_string()))?;
-                if !init.supports_cbor() {
+                let (mut dev, cbor, _init) =
+                    open_fido(&target).map_err(SessionOpError::msg)?;
+                if !cbor {
                     return Err(SessionOpError::msg("device is U2F-only"));
                 }
                 // Wire the cooperative-cancel flag into the transport so a
@@ -2492,7 +2546,7 @@ impl App {
         if self.busy() {
             return;
         }
-        let Some(path) = self.selected_fido_path() else {
+        let Some(target) = self.selected_fido_target() else {
             return;
         };
         let Some(session) = self.security_keys.session.as_ref() else {
@@ -2500,7 +2554,7 @@ impl App {
         };
         let pin = session.pin.clone();
         self.spawn_job("Deleting fingerprint\u{2026}", move || {
-            let result = Self::with_fresh_bio(&path, &pin, |bio| {
+            let result = Self::with_fresh_bio(&target, &pin, |bio| {
                 bio.remove_enrollment(&template_id)
                     .map_err(SessionOpError::from_ctap)?;
                 bio.enumerate().map_err(SessionOpError::from_ctap)
@@ -2517,7 +2571,7 @@ impl App {
         if self.busy() {
             return;
         }
-        let Some(path) = self.selected_fido_path() else {
+        let Some(target) = self.selected_fido_target() else {
             return;
         };
         let Some(session) = self.security_keys.session.as_ref() else {
@@ -2525,7 +2579,7 @@ impl App {
         };
         let pin = session.pin.clone();
         self.spawn_job("Renaming fingerprint\u{2026}", move || {
-            let result = Self::with_fresh_bio(&path, &pin, |bio| {
+            let result = Self::with_fresh_bio(&target, &pin, |bio| {
                 bio.set_friendly_name(&template_id, &new_name)
                     .map_err(SessionOpError::from_ctap)?;
                 bio.enumerate().map_err(SessionOpError::from_ctap)
@@ -2542,13 +2596,15 @@ impl App {
     /// Mirrors `with_fresh_bio`; config commands need their own permissioned
     /// token, so they always take a PIN at action time.
     fn with_config<T>(
-        path: &std::path::Path,
+        target: &FidoTarget,
         pin: &str,
-        f: impl FnOnce(&mut keyroost_ctap::config::Configurator) -> Result<T, SessionOpError>,
+        f: impl FnOnce(
+            &mut keyroost_ctap::config::Configurator<Box<dyn keyroost_ctap::transport::CtapTransport>>,
+        ) -> Result<T, SessionOpError>,
     ) -> Result<T, SessionOpError> {
-        let (mut dev, init) =
-            CtapHidDevice::open(path).map_err(|e| SessionOpError::msg(e.to_string()))?;
-        if !init.supports_cbor() {
+        let (mut dev, cbor, _init) =
+            open_fido(target).map_err(SessionOpError::msg)?;
+        if !cbor {
             return Err(SessionOpError::msg("device is U2F-only"));
         }
         let info = keyroost_ctap::get_info(&mut dev).map_err(SessionOpError::from_ctap)?;
@@ -2578,7 +2634,7 @@ impl App {
         let Some(dlg) = self.security_keys.advanced.as_ref() else {
             return;
         };
-        let Some(path) = self.selected_fido_path() else {
+        let Some(target) = self.selected_fido_target() else {
             return;
         };
         let action = dlg.action;
@@ -2604,7 +2660,7 @@ impl App {
             AdvancedAction::None => return,
         };
         self.spawn_job(label, move || {
-            let result = Self::with_config(&path, &pin, |cfg| match action {
+            let result = Self::with_config(&target, &pin, |cfg| match action {
                 AdvancedAction::ToggleAlwaysUv => {
                     cfg.toggle_always_uv().map_err(SessionOpError::from_ctap)
                 }
@@ -2632,7 +2688,7 @@ impl App {
     }
 
     fn delete_credential(&mut self, cred_id: Vec<u8>) {
-        let Some(path) = self.selected_fido_path() else {
+        let Some(target) = self.selected_fido_target() else {
             return;
         };
         let Some(session) = self.security_keys.session.as_ref() else {
@@ -2644,8 +2700,8 @@ impl App {
         let pin_refresh = session.pin.clone();
         self.spawn_job("Deleting credential\u{2026}", move || {
             // Delete, then re-list in the same job so the UI updates atomically.
-            let result = Self::try_delete(&path, token, &cred_id)
-                .and_then(|()| Self::refresh_with_token(&path, token_refresh, pin_refresh))
+            let result = Self::try_delete(&target, token, &cred_id)
+                .and_then(|()| Self::refresh_with_token(&target, token_refresh, pin_refresh))
                 .map_err(SessionOpError::from_boxed);
             Box::new(move |app: &mut App| match result {
                 Ok(fresh) => {
@@ -2658,11 +2714,11 @@ impl App {
     }
 
     fn try_delete(
-        path: &std::path::Path,
+        target: &FidoTarget,
         token: PinUvAuthToken,
         cred_id: &[u8],
     ) -> Result<(), Box<dyn std::error::Error>> {
-        let (mut dev, _) = CtapHidDevice::open(path)?;
+        let (mut dev, _cbor, _init) = open_fido(target)?;
         let info = keyroost_ctap::get_info(&mut dev)?;
         let mut mgr = keyroost_ctap::cred_mgmt::CredentialManager::new(&mut dev, token, &info)?;
         mgr.delete(cred_id)?;
@@ -2674,7 +2730,7 @@ impl App {
         if self.busy() {
             return;
         }
-        let Some(path) = self.selected_fido_path() else {
+        let Some(target) = self.selected_fido_target() else {
             return;
         };
         let old = std::mem::take(&mut self.security_keys.change_pin.old);
@@ -2684,7 +2740,7 @@ impl App {
             return;
         }
         self.spawn_job("Changing PIN\u{2026}", move || {
-            let result = Self::try_change_pin(&path, &old, &new).map_err(|e| e.to_string());
+            let result = Self::try_change_pin(&target, &old, &new).map_err(|e| e.to_string());
             Box::new(move |app: &mut App| match result {
                 Ok(()) => {
                     app.security_keys.change_pin.open = false;
@@ -2698,11 +2754,11 @@ impl App {
     }
 
     fn try_change_pin(
-        path: &std::path::Path,
+        target: &FidoTarget,
         old: &str,
         new: &str,
     ) -> Result<(), Box<dyn std::error::Error>> {
-        let (mut dev, _) = CtapHidDevice::open(path)?;
+        let (mut dev, _cbor, _init) = open_fido(target)?;
         keyroost_ctap::client_pin::change_pin(&mut dev, old, new)?;
         Ok(())
     }
@@ -2715,7 +2771,7 @@ impl App {
         if self.busy() {
             return;
         }
-        let Some(path) = self.selected_fido_path() else {
+        let Some(target) = self.selected_fido_target() else {
             return;
         };
         let new = std::mem::take(&mut self.security_keys.change_pin.new);
@@ -2730,7 +2786,7 @@ impl App {
         }
         self.spawn_job("Setting PIN\u{2026}", move || {
             let result = (|| -> Result<(), String> {
-                let (mut dev, _) = CtapHidDevice::open(&path).map_err(|e| e.to_string())?;
+                let (mut dev, _cbor, _init) = open_fido(&target)?;
                 keyroost_ctap::client_pin::set_pin(&mut dev, &new).map_err(|e| e.to_string())
             })();
             Box::new(move |app: &mut App| match result {
@@ -2744,7 +2800,27 @@ impl App {
         });
     }
 
-    fn selected_fido_path(&self) -> Option<std::path::PathBuf> {
+    /// The transport descriptor for the selected FIDO key: a USB-HID path, or a
+    /// PC/SC reader name (NFC or contact). Prefers HID when both are present (a
+    /// USB key that also exposes a CCID interface).
+    fn selected_fido_target(&self) -> Option<FidoTarget> {
+        let d = self.selected_device()?;
+        if let Some(p) = d.hid_path.clone() {
+            return Some(FidoTarget::Hid(p));
+        }
+        if d.caps.has(Caps::FIDO2) {
+            if let Some(r) = d.reader.clone() {
+                return Some(FidoTarget::Pcsc(r));
+            }
+        }
+        None
+    }
+
+    /// The selected key's USB-HID path, if any. Used only by the armed-reset
+    /// hotplug tracker, which watches for a USB key being unplugged and
+    /// replugged within the reset window — a USB-only concept (an NFC tap has no
+    /// replug), so this intentionally returns `None` for reader-attached keys.
+    fn selected_fido_hid_path(&self) -> Option<std::path::PathBuf> {
         self.selected_device().and_then(|d| d.hid_path.clone())
     }
 
@@ -3234,7 +3310,7 @@ impl App {
             // Snapshot the current FIDO keys so the poll can tell when ours
             // leaves and a fresh one arrives. Prefer the armed key's HID serial
             // (port-independent) and fall back to its path + USB ids.
-            let target_path = self.selected_fido_path();
+            let target_path = self.selected_fido_hid_path();
             let devices = Self::fido_devices();
             let target = target_path
                 .as_ref()
@@ -6820,7 +6896,7 @@ impl App {
                         // The initial read can be dropped if the worker was
                         // busy at selection time; retry rather than showing
                         // "Reading key…" forever.
-                        if self.security_keys.init.is_none() && !self.busy() {
+                        if self.security_keys.info.is_none() && !self.busy() {
                             self.fetch_selected_info();
                         }
                         "Reading key\u{2026}"
@@ -7407,7 +7483,7 @@ impl App {
     /// Append a keyroost text note to the array and write it back. Needs the
     /// unlocked session's PIN (the write path requires a Large-Blob-Write token).
     fn add_large_blob_note(&mut self, text: String) {
-        let Some(path) = self.selected_fido_path() else {
+        let Some(target) = self.selected_fido_target() else {
             self.security_keys.lb_status = Some("No FIDO key selected.".into());
             return;
         };
@@ -7424,8 +7500,8 @@ impl App {
 
         self.spawn_job("Saving to large blobs\u{2026}", move || {
             let result = (|| -> Result<keyroost_ctap::large_blobs::LargeBlobArray, String> {
-                let (mut dev, init) = CtapHidDevice::open(&path).map_err(|e| e.to_string())?;
-                if !init.supports_cbor() {
+                let (mut dev, cbor, _init) = open_fido(&target)?;
+                if !cbor {
                     return Err("device is U2F-only".into());
                 }
                 let info = keyroost_ctap::get_info(&mut dev).map_err(|e| e.to_string())?;
@@ -7475,7 +7551,7 @@ impl App {
     /// Replace the keyroost note at `idx` with `text` and write the array back.
     /// Refuses if the entry is not a keyroost note. Needs the session PIN.
     fn edit_large_blob_note(&mut self, idx: usize, text: String) {
-        let Some(path) = self.selected_fido_path() else {
+        let Some(target) = self.selected_fido_target() else {
             self.security_keys.lb_status = Some("No FIDO key selected.".into());
             return;
         };
@@ -7488,8 +7564,8 @@ impl App {
 
         self.spawn_job("Saving edit to large blobs\u{2026}", move || {
             let result = (|| -> Result<keyroost_ctap::large_blobs::LargeBlobArray, String> {
-                let (mut dev, init) = CtapHidDevice::open(&path).map_err(|e| e.to_string())?;
-                if !init.supports_cbor() {
+                let (mut dev, cbor, _init) = open_fido(&target)?;
+                if !cbor {
                     return Err("device is U2F-only".into());
                 }
                 let info = keyroost_ctap::get_info(&mut dev).map_err(|e| e.to_string())?;
@@ -7536,13 +7612,13 @@ impl App {
     /// Read the large-blob array from the selected key (no PIN required) and
     /// cache it. Runs synchronously — a read is one or two small fragments.
     fn load_large_blobs(&mut self) {
-        let Some(path) = self.selected_fido_path() else {
+        let Some(target) = self.selected_fido_target() else {
             self.security_keys.lb_status = Some("No FIDO key selected.".into());
             return;
         };
         let result = (|| -> Result<keyroost_ctap::large_blobs::LargeBlobArray, String> {
-            let (mut dev, init) = CtapHidDevice::open(&path).map_err(|e| e.to_string())?;
-            if !init.supports_cbor() {
+            let (mut dev, cbor, _init) = open_fido(&target)?;
+            if !cbor {
                 return Err("device is U2F-only".into());
             }
             let info = keyroost_ctap::get_info(&mut dev).map_err(|e| e.to_string())?;
@@ -7568,7 +7644,7 @@ impl App {
     /// checksum, and write the array back. Needs a Large-Blob-Write token, which
     /// we derive from the unlocked session's PIN. Runs on the worker thread.
     fn delete_large_blob_entry(&mut self, idx: usize) {
-        let Some(path) = self.selected_fido_path() else {
+        let Some(target) = self.selected_fido_target() else {
             self.security_keys.lb_status = Some("No FIDO key selected.".into());
             return;
         };
@@ -7592,8 +7668,8 @@ impl App {
 
         self.spawn_job("Updating large blobs\u{2026}", move || {
             let result = (|| -> Result<keyroost_ctap::large_blobs::LargeBlobArray, String> {
-                let (mut dev, init) = CtapHidDevice::open(&path).map_err(|e| e.to_string())?;
-                if !init.supports_cbor() {
+                let (mut dev, cbor, _init) = open_fido(&target)?;
+                if !cbor {
                     return Err("device is U2F-only".into());
                 }
                 let info = keyroost_ctap::get_info(&mut dev).map_err(|e| e.to_string())?;
@@ -7638,7 +7714,7 @@ impl App {
     /// `delete_large_blob_entry` but clears every entry. Needs a Large-Blob-Write
     /// token derived from the unlocked session's PIN. Runs on the worker thread.
     fn clear_large_blob_storage(&mut self) {
-        let Some(path) = self.selected_fido_path() else {
+        let Some(target) = self.selected_fido_target() else {
             self.security_keys.lb_status = Some("No FIDO key selected.".into());
             return;
         };
@@ -7658,8 +7734,8 @@ impl App {
 
         self.spawn_job("Clearing large blobs\u{2026}", move || {
             let result = (|| -> Result<keyroost_ctap::large_blobs::LargeBlobArray, String> {
-                let (mut dev, init) = CtapHidDevice::open(&path).map_err(|e| e.to_string())?;
-                if !init.supports_cbor() {
+                let (mut dev, cbor, _init) = open_fido(&target)?;
+                if !cbor {
                     return Err("device is U2F-only".into());
                 }
                 let info = keyroost_ctap::get_info(&mut dev).map_err(|e| e.to_string())?;

--- a/crates/keyroost/src/otp_pane.rs
+++ b/crates/keyroost/src/otp_pane.rs
@@ -35,10 +35,14 @@ impl OtpTransportSel {
     }
 
     fn open(self) -> Result<Token2OtpSession, OtpTransportError> {
+        // Honor KEYROOST_OTP_DEBUG so a stuck/empty list over NFC can be traced
+        // from the GUI (the CLI has --debug; the GUI had no switch). Matches the
+        // KEYROOST_CTAP_DEBUG convention.
+        let debug = std::env::var_os("KEYROOST_OTP_DEBUG").is_some();
         match self {
-            OtpTransportSel::Auto => Token2OtpSession::detect_debug(false),
-            OtpTransportSel::Hid => Token2OtpSession::detect_hid_only(false),
-            OtpTransportSel::Ccid => Token2OtpSession::detect_pcsc_only(false),
+            OtpTransportSel::Auto => Token2OtpSession::detect_debug(debug),
+            OtpTransportSel::Hid => Token2OtpSession::detect_hid_only(debug),
+            OtpTransportSel::Ccid => Token2OtpSession::detect_pcsc_only(debug),
         }
     }
 }
@@ -252,7 +256,28 @@ impl App {
     /// List entries on the selected key over the chosen transport.
     pub(crate) fn load_otp_entries(&mut self) {
         self.otp.error = None;
-        let sel = self.otp.transport;
+        // On a reader-attached key (no USB-HID interface), force the CCID/NFC
+        // transport. The "Auto" path probes USB-HID first, which is pointless
+        // here and — on Windows, where the FIDO HID interface is access-
+        // restricted — can disrupt the read and yield an empty list, even though
+        // the OTP applet is reachable over the reader. If the user explicitly
+        // picked a transport, honour it.
+        let reader_only = self
+            .selected_device()
+            .map(|d| d.hid_path.is_none() && d.reader.is_some())
+            .unwrap_or(false);
+        let sel = if reader_only && self.otp.transport == OtpTransportSel::Auto {
+            OtpTransportSel::Ccid
+        } else {
+            self.otp.transport
+        };
+        if std::env::var_os("KEYROOST_OTP_DEBUG").is_some() {
+            eprintln!(
+                "[otp gui] reader_only={reader_only} chosen_transport={} (user_sel={})",
+                sel.label(),
+                self.otp.transport.label()
+            );
+        }
         let for_device = self.selected_device.clone();
         self.spawn_job("Reading OTP entries\u{2026}", move || {
             let result =

--- a/crates/keyroostctl/src/main.rs
+++ b/crates/keyroostctl/src/main.rs
@@ -5442,7 +5442,7 @@ fn with_credential_manager<F>(
 ) -> Result<(), Box<dyn std::error::Error>>
 where
     F: for<'a> FnOnce(
-        &mut keyroost_ctap::cred_mgmt::CredentialManager<'a>,
+        &mut keyroost_ctap::cred_mgmt::CredentialManager<'a, keyroost_ctap::CtapHidDevice>,
     ) -> Result<(), Box<dyn std::error::Error>>,
 {
     let path = resolve_fido_path(path)?;
@@ -5471,7 +5471,7 @@ fn with_bio_enrollment<F>(
 ) -> Result<(), Box<dyn std::error::Error>>
 where
     F: for<'a> FnOnce(
-        &mut keyroost_ctap::bio_enroll::BioEnrollment<'a>,
+        &mut keyroost_ctap::bio_enroll::BioEnrollment<'a, keyroost_ctap::CtapHidDevice>,
     ) -> Result<(), Box<dyn std::error::Error>>,
 {
     let path = resolve_fido_path(path)?;
@@ -5514,7 +5514,7 @@ fn with_configurator<F>(
 ) -> Result<(), Box<dyn std::error::Error>>
 where
     F: for<'a> FnOnce(
-        &mut keyroost_ctap::config::Configurator<'a>,
+        &mut keyroost_ctap::config::Configurator<'a, keyroost_ctap::CtapHidDevice>,
     ) -> Result<(), Box<dyn std::error::Error>>,
 {
     let path = resolve_fido_path(path)?;


### PR DESCRIPTION
Tested and working over NFC readers only. Contact (ISO 7816 / contact-chip)
readers are not yet supported — the contact path failed in testing and will be
addressed in follow-up work. The PC/SC transport layer is shared between both,
so contact support is expected to be an incremental fix rather than a redesign.

Verified on Token2 keys and a Yubikey over a Token2 NFC reader: FIDO2 get-info and passkey
management, plus on-device OTP enumeration, all working. Fingerprint enrollment
over a reader may still be refused by some key firmware.

Partially addressing this :  https://github.com/framefilter/keyroost/issues/43