### PR TITLE
fix(appimage): use the host's libpcsclite instead of bundling one

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,6 +329,14 @@ chmod +x keyroost-x86_64.AppImage
 ./keyroost-x86_64.AppImage --appimage-extract-and-run
 ```
 
+> **Needs the host's pcsc-lite.** Unlike the other bundles, this AppImage does
+> **not** ship the pcsc-lite client library — it uses the host's, so the smart-card
+> client always matches the host's `pcscd` daemon. Practically that means the
+> host must have `pcsc-lite` installed (it comes with `pcscd`; see
+> [Smart-card prerequisite](#smart-card-prerequisite)). Pure-FIDO use still needs
+> it present for now, since the GUI links libpcsclite at startup — a future
+> release will load it lazily so FIDO-only hosts can run without it.
+
 ### Smart-card prerequisite
 
 The smart-card features (OATH / OpenPGP / PIV, and Token2 Molto2 programming)

--- a/TODO-v0.7.5.md
+++ b/TODO-v0.7.5.md
@@ -1,0 +1,43 @@
+# v0.7.5 TODO
+
+Deferred items that are too large or too risky to fold into a same-day patch.
+Captured here so they don't get lost. Unchecked = not started.
+
+## PC/SC: load libpcsclite at runtime, degrade gracefully (the real #47 fix)
+
+- [ ] Stop hard-linking libpcsclite; **`dlopen` it at runtime** in
+      `keyroost-transport` (and wherever the `pcsc` crate is used), so:
+  - the **host's** libpcsclite is always used — the only client guaranteed to
+    match the host's `pcscd` daemon (fixes the version-mismatch root cause of
+    [#47](https://github.com/framefilter/keyroost/issues/47) for **every**
+    distribution channel, not just the AppImage); and
+  - when libpcsclite is **absent**, keyroost still launches and FIDO/USB-HID
+    keeps working — the PC/SC panes show a clear "PC/SC unavailable" state
+    instead of the binary failing to start.
+- [ ] This **removes the AppImage limitation** noted in
+      `packaging/appimage/build-appimage.sh` (the 0.7.x AppImage drops the
+      bundled libpcsclite and so needs the host's to even launch).
+- [ ] The `pcsc` crate links at build time; check whether it exposes a
+      dlopen/dynamic-load path or whether we wrap libpcsclite via a thin FFI
+      loader ourselves. Design before implementing; verify on a host WITH and a
+      host WITHOUT libpcsclite.
+
+## egui / eframe version bump
+
+- [ ] Bump **egui / eframe / egui-winit 0.29.1 → 0.34.3** (current latest).
+      Five minor versions of breaking API changes across the ~11k-line GUI —
+      treat as its own project with a full pass + regression check (zoom/slider,
+      modals, layout, light/dark themes).
+- [ ] **winit stays 0.30.13** either way (0.31 is beta only; egui 0.34 still
+      rides the 0.30.x line), so this is **not** guaranteed to fix the Wayland
+      text-input regression in
+      [#48](https://github.com/framefilter/keyroost/issues/48) — but check
+      whether egui-winit's glue changes incidentally resolve it on Fedora-44 KWin
+      while we're here.
+
+## GUI — Text-size control polish ([#42](https://github.com/framefilter/keyroost/issues/42), @token2)
+
+- [ ] Add discrete **"−" / "+" buttons** on the ends of the zoom slider; mouse
+      dragging is unpredictable near the boundaries.
+- [ ] **Light theme:** the slider track/handle is almost invisible — restyle it
+      so it reads on the light palette (it's currently tuned for dark only).

--- a/packaging/appimage/build-appimage.sh
+++ b/packaging/appimage/build-appimage.sh
@@ -13,8 +13,10 @@
 # RUNTIME (user side):
 #   * FIDO HID needs the host udev rules (udev/70-keyroost-fido.rules) for
 #     non-root /dev/hidraw access — the AppImage cannot install them itself.
-#   * Smart-card applets need a running HOST pcscd. The AppImage bundles the
-#     pcsc-lite *client* lib but always talks to the host daemon.
+#   * Smart-card applets need a running HOST pcscd AND the host's libpcsclite:
+#     the AppImage deliberately does NOT bundle the pcsc-lite client (see step 3
+#     for why), so the host must provide libpcsclite.so.1 — which it does
+#     wherever pcscd is installed.
 #   * AppImages mount via FUSE. On FUSE3-only distros users may need libfuse2,
 #     or can run with:  ./keyroost-x86_64.AppImage --appimage-extract-and-run
 #     (TODO(maintainer): pin the appimagetool/runtime version and state the
@@ -64,13 +66,28 @@ fetch "${LDP_BASE}/linuxdeploy-plugin-appimage-x86_64.AppImage"   linuxdeploy-pl
 export APPIMAGE_EXTRACT_AND_RUN=1
 
 # ---------------------------------------------------------------------------
-# 3. Stage the AppDir. linuxdeploy copies the executable, reads the desktop file
-#    + icon, and recursively bundles dependent libraries (incl. libpcsclite —
-#    it is pulled in as a dependency of the keyroost binary so the AppImage is
-#    self-contained on hosts whose pcsc-lite *client* lib isn't installed even
-#    though pcscd is reachable. The DAEMON is always the host's).
-#    TODO(maintainer): decide bundle-vs-host for libpcsclite (recommend bundle);
-#    if NOT bundling, add it to the linuxdeploy exclude list.
+# 3. Stage the AppDir, then DROP the bundled libpcsclite so the host's is used.
+#
+#    Why not bundle it: libpcsclite is the PC/SC *client*, and it speaks a
+#    version-sensitive private protocol to the host's pcscd *daemon*. A client
+#    built on one machine can mismatch a user's daemon, which silently breaks
+#    every PC/SC feature (serial, OATH/OpenPGP/PIV, the serial-keyed friendly
+#    name) while FIDO over USB-HID keeps working — issue #47. The only client
+#    guaranteed to match a host's pcscd is that host's OWN libpcsclite (same
+#    package), so we delete the auto-bundled copy and let the dynamic linker
+#    resolve it from the system at runtime — same as the cargo/Homebrew builds,
+#    which work on hosts where the bundling AppImage did not.
+#
+#    KNOWN LIMITATION: keyroost hard-links libpcsclite, so this AppImage needs
+#    libpcsclite.so.1 present on the host to LAUNCH at all. Any host set up for
+#    PC/SC has it (it ships with pcscd); a pure-FIDO host without it cannot start
+#    this AppImage. The real fix — dlopen pcsc at runtime and degrade gracefully
+#    when it is absent — is tracked in TODO-v0.7.5.md; it removes this limitation
+#    and fixes the mismatch for every channel, not just the AppImage.
+#
+#    Mechanics: deploy WITHOUT --output, delete the auto-bundled libpcsclite,
+#    then package with the appimage plugin directly. (Re-running linuxdeploy with
+#    --output would just re-bundle it, so packaging is a separate step.)
 # ---------------------------------------------------------------------------
 rm -rf "${APPDIR}"
 mkdir -p "${APPDIR}"
@@ -79,12 +96,20 @@ mkdir -p "${APPDIR}"
 [ -f "${ICON_FILE}" ] || {
   echo "ERROR: no icon at ${ICON_FILE} — supply one (see ../icons/README.md)"; exit 1; }
 
+# 3a. Deploy: populate the AppDir + its libraries. No --output yet.
 ./linuxdeploy.AppImage \
     --appdir "${APPDIR}" \
     --executable "${BIN}" \
     --desktop-file "${DESKTOP_FILE}" \
-    --icon-file "${ICON_FILE}" \
-    --output appimage
+    --icon-file "${ICON_FILE}"
+
+# 3b. Drop the auto-bundled libpcsclite so the host's copy (which matches its
+#     own pcscd) is used at runtime (issue #47 — see the rationale above).
+echo ">> dropping bundled libpcsclite (use the host's, which matches its pcscd)"
+find "${APPDIR}" -name 'libpcsclite.so*' -delete
+
+# 3c. Package the prepared AppDir into the AppImage (no re-deploy).
+./linuxdeploy-plugin-appimage.AppImage --appdir "${APPDIR}"
 
 # ---------------------------------------------------------------------------
 # 4. Result: keyroost-x86_64.AppImage in ${BUILD_DIR}. Attach it to a GitHub


### PR DESCRIPTION
## What

The AppImage bundled its own `libpcsclite` (the PC/SC *client* library). That client speaks a version-sensitive private protocol to the host's `pcscd` *daemon*, so a bundled client mismatches a user's daemon and silently breaks every PC/SC feature — serial readout, OATH/OpenPGP/PIV, and the serial-keyed friendly name — while FIDO over USB-HID keeps working. That's the behavior reported in #47.

## Fix

Stop shipping the mismatched client and let the host's resolve at runtime:
- run `linuxdeploy` to populate the AppDir (no `--output`),
- delete the auto-bundled `libpcsclite.so*`,
- package the AppDir with the appimage plugin directly (re-running `linuxdeploy --output` would just re-bundle it).

This is the same arrangement under which the cargo and Homebrew builds already work on hosts where the bundling AppImage failed. Confirmed working on a test build by @errant253 in #47.

## Known limitation

keyroost hard-links `libpcsclite`, so this AppImage now needs `libpcsclite.so.1` present on the host to launch at all. Every PC/SC host has it (ships with `pcscd`); a pure-FIDO host without it can't start the AppImage. The real fix — `dlopen` PC/SC at runtime and degrade gracefully when absent, which also fixes the mismatch for *every* channel — is tracked in `TODO-v0.7.5.md`.

## Notes

- Addresses #47 (left open until the fix ships in a release so testers can confirm).
- Also updates the README AppImage section and adds the v0.7.5 TODO.
- No release here — merging just lands this on `main` to batch with other in-flight work.