### PR TITLE
feat(windows): non-admin FIDO2 tab (PR for v0.7.2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1746,6 +1746,7 @@ dependencies = [
  "keyroost-token2otp",
  "keyroost-token2prog",
  "keyroost-transport",
+ "keyroost-winwebauthn",
  "png 0.18.1",
  "pollster",
  "rfd",
@@ -1893,6 +1894,13 @@ dependencies = [
  "keyroost-token2prog",
  "pcsc",
  "zeroize",
+]
+
+[[package]]
+name = "keyroost-winwebauthn"
+version = "0.7.2"
+dependencies = [
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ members = [
     "crates/keyroost-rsakey",
     "crates/keyroost-qr",
     "crates/keyroost-import",
+    "crates/keyroost-winwebauthn",
     "crates/keyroostctl",
     "crates/keyroost",
 ]

--- a/crates/keyroost-winwebauthn/Cargo.toml
+++ b/crates/keyroost-winwebauthn/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "keyroost-winwebauthn"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Windows-only helper: detect a FIDO key and open Windows' security-key settings, without admin."
+
+# This crate is the one deliberate exception to the workspace-wide
+# forbid(unsafe_code): it is a thin FFI shim over Windows' HID enumeration and
+# the shell. The unsafe is confined to src/sys.rs and to this crate.
+[lints.rust]
+unsafe_code = "allow"
+
+# Windows-only. On other platforms the crate still builds but every entry point
+# is inert (returns empty / Unsupported), so callers can depend on it
+# unconditionally and gate behaviour at runtime.
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.59", features = [
+    "Win32_Foundation",
+    "Win32_Security",                            # SECURITY_ATTRIBUTES (CreateFileW param)
+    "Win32_UI_WindowsAndMessaging",              # SW_SHOWNORMAL
+    "Win32_UI_Shell",                            # ShellExecuteW (ms-settings: launch)
+    "Win32_Devices_DeviceAndDriverInstallation", # SetupDi* (HID enumeration)
+    "Win32_Devices_HumanInterfaceDevice",        # HidD_* / HidP_GetCaps (usage page)
+    "Win32_Storage_FileSystem",                  # CreateFileW (open HID for caps)
+] }

--- a/crates/keyroost-winwebauthn/README.md
+++ b/crates/keyroost-winwebauthn/README.md
@@ -1,0 +1,46 @@
+# keyroost-winwebauthn
+
+Windows-only helper for keyroost's **non-admin FIDO2 tab**. Reviewed skeleton —
+the Windows code can't be compiled or run off-Windows; build and verify it there.
+
+## Scope (deliberately small)
+
+keyroost needs admin to manage a FIDO key directly on Windows (the FIDO-HID
+interface is gated since Win10 1903). When keyroost is not elevated, this crate
+provides just enough for an informational tab:
+
+- `detect_fido_keys()` / `fido_key_present()` — detect a FIDO key WITHOUT admin,
+  via the HID usage page `0xF1D0` (no FIDO interface is opened).
+- `open_windows_security_key_settings()` — open Windows' built-in Settings >
+  Accounts > Sign-in options > Security Key page, which does PIN / reset /
+  biometrics WITHOUT admin (Settings is itself the privileged component).
+
+That's all. No passkey enumeration, no PIN/reset via API. The `webauthn.dll` API
+was investigated and proved a dead end for **external** keys: its credential
+list/delete only cover Windows Hello / TPM credentials, and it has no PIN or
+reset function at all. So the design is: detect + inform + link out to Windows.
+
+## Intended tab (non-admin Windows, FIDO key detected)
+
+> Managing this security key's FIDO2 settings (PIN, passkeys, reset,
+> fingerprints) requires administrator rights, or you can use Windows' built-in
+> security-key management.
+
+with a single button: **Open Windows security-key settings** →
+`open_windows_security_key_settings()`.
+
+## Verify on Windows
+
+```
+cargo run -p keyroost-winwebauthn --example probe
+cargo run -p keyroost-winwebauthn --example probe -- --open-settings
+```
+
+Expect the probe to list your Token2 key, and `--open-settings` to open the
+Windows security-key page. Risky FFI spots are marked `VERIFY:` in `src/sys.rs`
+(the SetupAPI detail `cbSize`, the HID open flags, the usage-page read).
+
+## Status
+
+- Non-Windows (inert) path: compiles clean.
+- Windows path: NOT compiled in CI (no Windows toolchain). Reviewed against docs.

--- a/crates/keyroost-winwebauthn/examples/probe.rs
+++ b/crates/keyroost-winwebauthn/examples/probe.rs
@@ -1,0 +1,58 @@
+//! Manual probe for the slimmed `keyroost-winwebauthn`. Run WITHOUT admin, with
+//! a FIDO key inserted:
+//!
+//!   cargo run -p keyroost-winwebauthn --example probe
+//!   cargo run -p keyroost-winwebauthn --example probe -- --open-settings
+//!
+//! What to look for:
+//!   * "FIDO key(s) detected" lists your Token2 key (usage page 0xF1D0)
+//!   * with --open-settings, the Windows security-key page opens
+//!
+//! Read-only except for --open-settings (which just launches a Settings page).
+
+use keyroost_winwebauthn as w;
+
+fn main() {
+    println!("keyroost-winwebauthn probe\n");
+
+    let debug = std::env::args().any(|a| a == "--debug");
+    let keys = if debug {
+        let (keys, log) = w::detect_fido_keys_verbose();
+        println!("--- HID enumeration ---");
+        for line in &log {
+            println!("{line}");
+        }
+        println!("-----------------------\n");
+        keys
+    } else {
+        w::detect_fido_keys()
+    };
+
+    if keys.is_empty() {
+        println!("no FIDO key detected (no HID device with usage page 0xF1D0)");
+        if !debug {
+            println!("re-run with `--debug` to list every HID device the scan saw.");
+        }
+    } else {
+        println!("{} FIDO key(s) detected (usage page 0xF1D0):", keys.len());
+        for (i, k) in keys.iter().enumerate() {
+            let vid = k.vendor_id.map(|v| format!("{v:04X}")).unwrap_or_default();
+            let pid = k.product_id.map(|v| format!("{v:04X}")).unwrap_or_default();
+            println!(
+                "  [{i}] {}  VID:{vid} PID:{pid}",
+                k.product.as_deref().unwrap_or("(no product string)")
+            );
+        }
+    }
+    println!();
+
+    if std::env::args().any(|a| a == "--open-settings") {
+        println!("opening Windows security-key settings...");
+        match w::open_windows_security_key_settings() {
+            Ok(()) => println!("  launched (a Settings window should appear)."),
+            Err(e) => println!("  failed: {e}"),
+        }
+    } else {
+        println!("re-run with `--open-settings` to open the Windows security-key page.");
+    }
+}

--- a/crates/keyroost-winwebauthn/src/lib.rs
+++ b/crates/keyroost-winwebauthn/src/lib.rs
@@ -1,0 +1,144 @@
+//! Windows-only helper for keyroost's **non-admin FIDO2 tab**.
+//!
+//! keyroost talks raw CTAP-HID to a security key, which on Windows requires the
+//! process to be elevated (admin) since Win10 1903. When keyroost is not
+//! elevated it can't manage the key directly — but it can still:
+//!
+//!   1. **Detect** that a FIDO key is present, without admin and without opening
+//!      the protected FIDO interface, via the HID usage page `0xF1D0`
+//!      ([`detect_fido_keys`] / [`fido_key_present`]); and
+//!   2. **Hand off to Windows** — open the built-in Settings > Accounts >
+//!      Sign-in options > Security Key page, which performs PIN / reset /
+//!      biometrics **without admin** because Settings itself is the privileged
+//!      component ([`open_windows_security_key_settings`]).
+//!
+//! That is the entire scope: an informational tab plus a link to the Windows
+//! security-key page. No passkey enumeration, no PIN/reset over the API (the
+//! `webauthn.dll` API was investigated and proved to not support external-key
+//! management — see the crate README).
+//!
+//! On non-Windows targets every function is inert, so the rest of keyroost can
+//! depend on this crate unconditionally and branch at runtime.
+//!
+//! # Verification status
+//!
+//! The Windows code can't be compiled or run off-Windows. It is written against
+//! Microsoft's documented APIs; spots needing on-Windows checking are marked
+//! `VERIFY:` in `src/sys.rs`. The non-Windows (inert) path compiles cleanly.
+
+use std::fmt;
+
+/// A FIDO authenticator detected on the system, recognised WITHOUT opening the
+/// (admin-gated) FIDO interface. Detection uses only readable HID metadata.
+#[derive(Clone, Debug, Default)]
+pub struct FidoKeyInfo {
+    /// Product / device string, if the OS exposed one (e.g. "TOKEN2 FIDO2 ...").
+    pub product: Option<String>,
+    /// USB vendor id, if known.
+    pub vendor_id: Option<u16>,
+    /// USB product id, if known.
+    pub product_id: Option<u16>,
+}
+
+#[derive(Debug, Clone)]
+pub enum WinWebAuthnError {
+    /// Not running on Windows.
+    Unsupported,
+    /// Could not launch the Windows settings page.
+    LaunchFailed,
+    /// Elevated relaunch failed or the UAC prompt was declined.
+    RelaunchFailed,
+}
+
+impl fmt::Display for WinWebAuthnError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            WinWebAuthnError::Unsupported => {
+                write!(f, "only available on Windows")
+            }
+            WinWebAuthnError::LaunchFailed => {
+                write!(f, "could not open Windows security-key settings")
+            }
+            WinWebAuthnError::RelaunchFailed => {
+                write!(f, "could not relaunch as administrator")
+            }
+        }
+    }
+}
+
+impl std::error::Error for WinWebAuthnError {}
+
+pub type Result<T> = std::result::Result<T, WinWebAuthnError>;
+
+/// Detect FIDO security keys present on the system, WITHOUT administrator rights
+/// and without opening the protected FIDO interface.
+///
+/// Enumerates HID devices and keeps those advertising the FIDO usage page
+/// (`0xF1D0`). Returns an empty vec if none are found, or on non-Windows.
+pub fn detect_fido_keys() -> Vec<FidoKeyInfo> {
+    #[cfg(windows)]
+    {
+        sys::detect_fido_keys()
+    }
+    #[cfg(not(windows))]
+    {
+        Vec::new()
+    }
+}
+
+/// Convenience: is at least one FIDO key present? Always false on non-Windows.
+pub fn fido_key_present() -> bool {
+    !detect_fido_keys().is_empty()
+}
+
+/// Diagnostic detection: returns (found_keys, human-readable log lines) so a
+/// probe can show every HID device seen and why it did or didn't match. Empty
+/// log on non-Windows.
+pub fn detect_fido_keys_verbose() -> (Vec<FidoKeyInfo>, Vec<String>) {
+    #[cfg(windows)]
+    {
+        sys::detect_fido_keys_verbose()
+    }
+    #[cfg(not(windows))]
+    {
+        (Vec::new(), Vec::new())
+    }
+}
+
+/// Open the Windows built-in security-key management page (Settings > Accounts >
+/// Sign-in options > Security Key), which can set/change the PIN, manage
+/// biometrics, and reset the key — all WITHOUT administrator rights, because
+/// Settings itself is the privileged component.
+///
+/// Launches `ms-settings:signinoptions-launchsecuritykeyenrollment`, falling
+/// back to the general `ms-settings:signinoptions` page if that specific URI is
+/// unavailable on this Windows build.
+pub fn open_windows_security_key_settings() -> Result<()> {
+    #[cfg(windows)]
+    {
+        sys::open_windows_security_key_settings()
+    }
+    #[cfg(not(windows))]
+    {
+        Err(WinWebAuthnError::Unsupported)
+    }
+}
+
+/// Relaunch the current executable elevated, via a UAC prompt (ShellExecuteW
+/// with the "runas" verb). On success the elevated process has been requested
+/// and the caller should exit the current, non-elevated one so only one
+/// instance runs. Returns `Err` if the user declines the UAC prompt or the
+/// launch fails. Always `Unsupported` off-Windows.
+pub fn relaunch_as_admin() -> Result<()> {
+    #[cfg(windows)]
+    {
+        sys::relaunch_as_admin()
+    }
+    #[cfg(not(windows))]
+    {
+        Err(WinWebAuthnError::Unsupported)
+    }
+}
+
+#[cfg(windows)]
+mod sys;

--- a/crates/keyroost-winwebauthn/src/sys.rs
+++ b/crates/keyroost-winwebauthn/src/sys.rs
@@ -1,0 +1,335 @@
+//! Windows implementation: HID enumeration to detect a FIDO key (usage page
+//! 0xF1D0) and a shell launch of the Windows security-key settings page.
+//!
+//! All FFI is confined here. VERIFY markers call out spots to check against your
+//! exact Windows SDK / hardware.
+
+#![allow(non_snake_case)]
+
+use windows_sys::Win32::Devices::DeviceAndDriverInstallation::{
+    SetupDiDestroyDeviceInfoList, SetupDiEnumDeviceInterfaces, SetupDiGetClassDevsW,
+    SetupDiGetDeviceInterfaceDetailW, DIGCF_DEVICEINTERFACE, DIGCF_PRESENT, HDEVINFO,
+    SP_DEVICE_INTERFACE_DATA,
+};
+use windows_sys::Win32::Devices::HumanInterfaceDevice::{
+    HidD_FreePreparsedData, HidD_GetAttributes, HidD_GetHidGuid, HidD_GetPreparsedData,
+    HidD_GetProductString, HidP_GetCaps, HIDD_ATTRIBUTES, HIDP_CAPS, PHIDP_PREPARSED_DATA,
+};
+use windows_sys::Win32::Foundation::{
+    CloseHandle, GetLastError, GENERIC_READ, GENERIC_WRITE, INVALID_HANDLE_VALUE,
+};
+use windows_sys::Win32::Storage::FileSystem::{
+    CreateFileW, FILE_FLAG_OVERLAPPED, FILE_SHARE_READ, FILE_SHARE_WRITE, OPEN_EXISTING,
+};
+
+use crate::{FidoKeyInfo, Result, WinWebAuthnError};
+
+/// The FIDO HID usage page (FIDO Alliance). Authoritative marker of a FIDO key.
+const FIDO_USAGE_PAGE: u16 = 0xF1D0;
+/// HIDP_STATUS_SUCCESS.
+const HIDP_STATUS_SUCCESS: i32 = 0x0011_0000u32 as i32;
+
+/// Encode a Rust &str as a NUL-terminated UTF-16 buffer.
+fn to_wide(s: &str) -> Vec<u16> {
+    s.encode_utf16().chain(std::iter::once(0)).collect()
+}
+
+/// Parse `vid_XXXX` / `pid_XXXX` (hex) out of a lowercased HID device path.
+fn parse_vid_pid(path_lc: &str) -> (Option<u16>, Option<u16>) {
+    fn grab(s: &str, key: &str) -> Option<u16> {
+        let i = s.find(key)? + key.len();
+        let hex: String = s[i..].chars().take(4).collect();
+        u16::from_str_radix(&hex, 16).ok()
+    }
+    (grab(path_lc, "vid_"), grab(path_lc, "pid_"))
+}
+
+/// Push a key, merging duplicates by (vid, pid) so the same physical key seen on
+/// multiple HID collections appears once. Prefers an entry that has a product
+/// string.
+fn push_unique(out: &mut Vec<FidoKeyInfo>, k: FidoKeyInfo) {
+    if let Some(existing) = out
+        .iter_mut()
+        .find(|e| e.vendor_id == k.vendor_id && e.product_id == k.product_id)
+    {
+        if existing.product.is_none() && k.product.is_some() {
+            existing.product = k.product;
+        }
+        return;
+    }
+    out.push(k);
+}
+
+pub(crate) fn detect_fido_keys() -> Vec<FidoKeyInfo> {
+    detect_fido_keys_impl(false).0
+}
+
+/// Verbose detection: returns (found_keys, diagnostic_lines).
+pub(crate) fn detect_fido_keys_verbose() -> (Vec<FidoKeyInfo>, Vec<String>) {
+    detect_fido_keys_impl(true)
+}
+
+fn detect_fido_keys_impl(verbose: bool) -> (Vec<FidoKeyInfo>, Vec<String>) {
+    let mut out = Vec::new();
+    let mut log: Vec<String> = Vec::new();
+    macro_rules! dbg {
+        ($($a:tt)*) => { if verbose { log.push(format!($($a)*)); } };
+    }
+    unsafe {
+        let mut hid_guid = std::mem::zeroed();
+        HidD_GetHidGuid(&mut hid_guid);
+
+        let dev_info: HDEVINFO = SetupDiGetClassDevsW(
+            &hid_guid,
+            std::ptr::null(),
+            std::ptr::null_mut(),
+            DIGCF_PRESENT | DIGCF_DEVICEINTERFACE,
+        );
+        if dev_info == INVALID_HANDLE_VALUE as isize {
+            dbg!("SetupDiGetClassDevsW returned INVALID_HANDLE_VALUE");
+            return (out, log);
+        }
+
+        let mut index = 0u32;
+        let mut enumerated = 0u32;
+        let mut opened = 0u32;
+        loop {
+            let mut iface: SP_DEVICE_INTERFACE_DATA = std::mem::zeroed();
+            iface.cbSize = std::mem::size_of::<SP_DEVICE_INTERFACE_DATA>() as u32;
+            if SetupDiEnumDeviceInterfaces(
+                dev_info,
+                std::ptr::null_mut(),
+                &hid_guid,
+                index,
+                &mut iface,
+            ) == 0
+            {
+                break; // no more interfaces
+            }
+            index += 1;
+            enumerated += 1;
+
+            // First call: required size for the detail (device-path) struct.
+            let mut needed = 0u32;
+            SetupDiGetDeviceInterfaceDetailW(
+                dev_info,
+                &iface,
+                std::ptr::null_mut(),
+                0,
+                &mut needed,
+                std::ptr::null_mut(),
+            );
+            if needed == 0 {
+                dbg!("dev {}: detail size query returned 0", index);
+                continue;
+            }
+            // SP_DEVICE_INTERFACE_DETAIL_DATA_W: DWORD cbSize; WCHAR DevicePath[].
+            // cbSize is 8 on 64-bit, 6 on 32-bit. Path starts at offset 4.
+            let mut buf = vec![0u8; needed as usize];
+            let cb_size: u32 = if cfg!(target_pointer_width = "64") { 8 } else { 6 };
+            *(buf.as_mut_ptr() as *mut u32) = cb_size;
+            if SetupDiGetDeviceInterfaceDetailW(
+                dev_info,
+                &iface,
+                buf.as_mut_ptr() as *mut _,
+                needed,
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+            ) == 0
+            {
+                dbg!("dev {}: SetupDiGetDeviceInterfaceDetailW failed", index);
+                continue;
+            }
+            let path_ptr = buf.as_ptr().add(4) as *const u16;
+            // Read the path into a Rust string (no device open needed). The HID
+            // path looks like: \\?\hid#vid_349e&pid_0026&mi_01&col01#...{guid}
+            let path = {
+                let mut len = 0usize;
+                while *path_ptr.add(len) != 0 {
+                    len += 1;
+                }
+                let slice = std::slice::from_raw_parts(path_ptr, len);
+                String::from_utf16_lossy(slice)
+            };
+            let path_lc = path.to_ascii_lowercase();
+            let (path_vid, path_pid) = parse_vid_pid(&path_lc);
+
+            // Open device for HID metadata. Zero-access first (works on most
+            // collections), then R/W.
+            let mut handle = CreateFileW(
+                path_ptr,
+                0,
+                FILE_SHARE_READ | FILE_SHARE_WRITE,
+                std::ptr::null(),
+                OPEN_EXISTING,
+                0,
+                std::ptr::null_mut(),
+            );
+            if handle.is_null() || handle as isize == INVALID_HANDLE_VALUE as isize {
+                handle = CreateFileW(
+                    path_ptr,
+                    GENERIC_READ | GENERIC_WRITE,
+                    FILE_SHARE_READ | FILE_SHARE_WRITE,
+                    std::ptr::null(),
+                    OPEN_EXISTING,
+                    FILE_FLAG_OVERLAPPED,
+                    std::ptr::null_mut(),
+                );
+            }
+            if handle.is_null() || handle as isize == INVALID_HANDLE_VALUE as isize {
+                let err = GetLastError();
+                // ERROR_ACCESS_DENIED (5) on a HID interface is the signature of
+                // a Windows-protected FIDO collection: we cannot open it
+                // non-elevated, which is exactly the FIDO-HID gating. Treat it as
+                // a detected FIDO key, using VID/PID parsed from the path.
+                dbg!(
+                    "dev {}: CreateFileW failed (err {}) path-VID:{:04X} PID:{:04X}{}",
+                    index,
+                    err,
+                    path_vid.unwrap_or(0),
+                    path_pid.unwrap_or(0),
+                    if err == 5 { "  <-- protected (FIDO?)" } else { "" }
+                );
+                if err == 5 {
+                    push_unique(
+                        &mut out,
+                        FidoKeyInfo {
+                            product: None,
+                            vendor_id: path_vid,
+                            product_id: path_pid,
+                        },
+                    );
+                }
+                continue;
+            }
+            opened += 1;
+
+            // VID/PID via HidD_GetAttributes (works on zero-access handle).
+            let mut attrs: HIDD_ATTRIBUTES = std::mem::zeroed();
+            attrs.Size = std::mem::size_of::<HIDD_ATTRIBUTES>() as u32;
+            let (vid, pid) = if HidD_GetAttributes(handle, &mut attrs) != 0 {
+                (Some(attrs.VendorID), Some(attrs.ProductID))
+            } else {
+                (path_vid, path_pid)
+            };
+
+            // Usage page via preparsed data + caps.
+            let mut preparsed: PHIDP_PREPARSED_DATA = 0;
+            let mut usage_page = 0u16;
+            if HidD_GetPreparsedData(handle, &mut preparsed) != 0 && preparsed != 0 {
+                let mut caps: HIDP_CAPS = std::mem::zeroed();
+                if HidP_GetCaps(preparsed, &mut caps) == HIDP_STATUS_SUCCESS {
+                    usage_page = caps.UsagePage;
+                }
+                HidD_FreePreparsedData(preparsed);
+            }
+
+            dbg!(
+                "dev {}: VID:{:04X} PID:{:04X} usage_page:0x{:04X}{}",
+                index,
+                vid.unwrap_or(0),
+                pid.unwrap_or(0),
+                usage_page,
+                if usage_page == FIDO_USAGE_PAGE { "  <-- FIDO" } else { "" }
+            );
+
+            if usage_page == FIDO_USAGE_PAGE {
+                let mut product = None;
+                let mut prod_buf = [0u16; 128];
+                if HidD_GetProductString(
+                    handle,
+                    prod_buf.as_mut_ptr() as *mut _,
+                    (prod_buf.len() * 2) as u32,
+                ) != 0
+                {
+                    if let Some(end) = prod_buf.iter().position(|&c| c == 0) {
+                        let s = String::from_utf16_lossy(&prod_buf[..end]);
+                        if !s.is_empty() {
+                            product = Some(s);
+                        }
+                    }
+                }
+                push_unique(
+                    &mut out,
+                    FidoKeyInfo {
+                        product,
+                        vendor_id: vid,
+                        product_id: pid,
+                    },
+                );
+            }
+
+            CloseHandle(handle);
+        }
+
+        dbg!(
+            "enumerated {} HID interface(s), opened {}, found {} FIDO",
+            enumerated,
+            opened,
+            out.len()
+        );
+        SetupDiDestroyDeviceInfoList(dev_info);
+    }
+    (out, log)
+}
+
+#[allow(dead_code)]
+fn _unused() {}
+
+pub(crate) fn open_windows_security_key_settings() -> Result<()> {
+    use windows_sys::Win32::UI::Shell::ShellExecuteW;
+    use windows_sys::Win32::UI::WindowsAndMessaging::SW_SHOWNORMAL;
+
+    // Preferred deep link to the security-key page, then a general fallback if
+    // that URI isn't recognised on this Windows build.
+    const PRIMARY: &str = "ms-settings:signinoptions-launchsecuritykeyenrollment";
+    const FALLBACK: &str = "ms-settings:signinoptions";
+
+    let open = to_wide("open");
+    for uri in [PRIMARY, FALLBACK] {
+        let uri_w = to_wide(uri);
+        let h = unsafe {
+            ShellExecuteW(
+                std::ptr::null_mut(),
+                open.as_ptr(),
+                uri_w.as_ptr(),
+                std::ptr::null(),
+                std::ptr::null(),
+                SW_SHOWNORMAL,
+            )
+        };
+        // ShellExecuteW returns a value > 32 on success.
+        if (h as isize) > 32 {
+            return Ok(());
+        }
+    }
+    Err(WinWebAuthnError::LaunchFailed)
+}
+
+pub(crate) fn relaunch_as_admin() -> Result<()> {
+    use windows_sys::Win32::UI::Shell::ShellExecuteW;
+    use windows_sys::Win32::UI::WindowsAndMessaging::SW_SHOWNORMAL;
+
+    // Resolve the current executable path; ShellExecuteW with the "runas" verb
+    // triggers the UAC elevation prompt on it.
+    let exe = std::env::current_exe().map_err(|_| WinWebAuthnError::RelaunchFailed)?;
+    let exe_w = to_wide(&exe.to_string_lossy());
+    let verb = to_wide("runas");
+
+    let h = unsafe {
+        ShellExecuteW(
+            std::ptr::null_mut(),
+            verb.as_ptr(),
+            exe_w.as_ptr(),
+            std::ptr::null(),
+            std::ptr::null(),
+            SW_SHOWNORMAL,
+        )
+    };
+    // > 32 == success. <= 32 includes SE_ERR_ACCESSDENIED / a declined UAC prompt.
+    if (h as isize) > 32 {
+        Ok(())
+    } else {
+        Err(WinWebAuthnError::RelaunchFailed)
+    }
+}

--- a/crates/keyroost/Cargo.toml
+++ b/crates/keyroost/Cargo.toml
@@ -30,6 +30,9 @@ keyroost-import = { path = "../keyroost-import", version = "0.7.2", features = [
 # Host-side RSA keygen / key-file loading for OpenPGP on-card import (shared with
 # keyroostctl). Owns the scoped `rsa` dependency exception.
 keyroost-rsakey = { path = "../keyroost-rsakey", version = "0.7.2" }
+# Windows-only helper for the non-admin FIDO2 path: detect a FIDO key, open
+# Windows' security-key settings, and relaunch elevated. Inert on other platforms.
+keyroost-winwebauthn = { path = "../keyroost-winwebauthn", version = "0.7.2" }
 eframe = { version = "0.29", default-features = false, features = ["default_fonts", "glow", "wayland", "x11"] }
 egui = "0.29"
 # Already in the tree via eframe/egui-winit's clipboard integration; direct

--- a/crates/keyroost/src/main.rs
+++ b/crates/keyroost/src/main.rs
@@ -4034,6 +4034,59 @@ impl App {
             Box::new(move |app: &mut App| match result {
                 Ok(devices) => {
                     app.devices_error = None;
+                    let mut devices = devices;
+                    // Windows non-admin: the FIDO2 capability is read from the HID
+                    // usage page 0xF1D0, which a non-elevated process can't open
+                    // (ERROR_ACCESS_DENIED). So FIDO access is detected separately
+                    // via keyroost-winwebauthn (access-denied signal). This pass is
+                    // strictly ADDITIVE — it never removes a resolved device — and
+                    // is panic-isolated so an FFI fault can't empty the list.
+                    //  * Multiprotocol keys already resolve (via PC/SC) — add the
+                    //    FIDO2 cap so the tab appears.
+                    //  * FIDO-only keys don't resolve at all — synthesize a minimal
+                    //    device from the detected VID/PID.
+                    // cap_fido2 then shows the "needs admin / use Windows settings"
+                    // card for these.
+                    #[cfg(windows)]
+                    {
+                        let fido_keys = std::panic::catch_unwind(|| {
+                            keyroost_winwebauthn::detect_fido_keys()
+                        })
+                        .unwrap_or_default();
+                        if !fido_keys.is_empty() {
+                            if devices.iter().any(|d| d.kind == DeviceKind::Key) {
+                                for d in devices.iter_mut() {
+                                    if d.kind == DeviceKind::Key && !d.caps.has(Caps::FIDO2) {
+                                        d.caps.insert(Caps::FIDO2);
+                                    }
+                                }
+                            } else {
+                                for (i, k) in fido_keys.iter().enumerate() {
+                                    let mut caps = Caps::default();
+                                    caps.insert(Caps::FIDO2);
+                                    let vid = k.vendor_id.unwrap_or(0);
+                                    let pid = k.product_id.unwrap_or(0);
+                                    let model = k
+                                        .product
+                                        .clone()
+                                        .unwrap_or_else(|| "Security key".to_string());
+                                    devices.push(Device {
+                                        id: format!("winfido:{vid:04x}:{pid:04x}:{i}"),
+                                        name: None,
+                                        vendor: format!("{vid:04X}"),
+                                        model,
+                                        serial: String::new(),
+                                        transport: "USB · FIDO HID (admin required)".into(),
+                                        firmware: String::new(),
+                                        caps,
+                                        kind: DeviceKind::Key,
+                                        hid_path: None,
+                                        reader: None,
+                                    });
+                                }
+                            }
+                        }
+                    }
                     // Keep the current selection if that device is still present;
                     // otherwise fall back to the first device.
                     let keep = app
@@ -6702,6 +6755,26 @@ impl App {
                         self.cap_tab = CapTab::Fido2;
                     }
                     ui.add_space(8.0);
+                    // Windows non-admin: FIDO access is gated, so `info` never
+                    // loads; show an admin-needed hint instead of a perpetual
+                    // "Reading key…". The Manage → jump opens the full card.
+                    #[cfg(windows)]
+                    let non_admin = self.security_keys.info.is_none()
+                        && keyroost_winwebauthn::fido_key_present();
+                    #[cfg(not(windows))]
+                    let non_admin = false;
+                    if non_admin {
+                        theme::pill(ui, "Administrator rights needed", p.warn, p.warn_soft());
+                        ui.add_space(6.0);
+                        ui.label(
+                            egui::RichText::new(
+                                "Open the FIDO2 tab to manage this key via Windows \
+                                 settings or restart as administrator.",
+                            )
+                            .font(theme::f_reg(13.0))
+                            .color(p.txt2),
+                        );
+                    } else {
                     match self
                         .security_keys
                         .info
@@ -6731,6 +6804,7 @@ impl App {
                                     .color(p.txt3),
                             );
                         }
+                    }
                     }
                 });
                 ui.add_space(14.0);
@@ -6895,7 +6969,79 @@ impl App {
     }
 
     /// FIDO2 / Passkeys tab — reuses the existing PIN + credentials section.
+    /// Windows non-admin FIDO2 card: explain the admin requirement and offer to
+    /// open Windows' security-key settings (PIN / reset / biometrics work there
+    /// without elevation) or restart keyroost as administrator for full
+    /// management here. Only built on Windows; the helper is inert elsewhere.
+    #[cfg(windows)]
+    fn fido2_non_admin_card(&mut self, ui: &mut egui::Ui, p: &Palette) {
+        theme::card_frame(p).show(ui, |ui| {
+            ui.label(
+                egui::RichText::new("Administrator rights needed")
+                    .font(theme::f_sb(14.5))
+                    .color(p.txt),
+            );
+            ui.add_space(8.0);
+            ui.label(
+                egui::RichText::new(
+                    "A security key is connected, but managing its FIDO2 settings \
+                     (PIN, passkeys, reset, fingerprints) in this app requires \
+                     administrator rights on Windows.",
+                )
+                .font(theme::f_reg(13.0))
+                .color(p.txt2),
+            );
+            ui.add_space(4.0);
+            ui.label(
+                egui::RichText::new(
+                    "Change the PIN, manage biometrics or reset the key without \
+                     admin rights using Windows' built-in security-key settings, \
+                     or restart this app as administrator for full management here.",
+                )
+                .font(theme::f_reg(13.0))
+                .color(p.txt2),
+            );
+            ui.add_space(12.0);
+            ui.horizontal(|ui| {
+                if theme::button(ui, p, BtnKind::Primary, "Open Windows security-key settings")
+                    .clicked()
+                {
+                    if let Err(e) = keyroost_winwebauthn::open_windows_security_key_settings() {
+                        self.security_keys.error =
+                            Some(format!("Couldn't open Windows security-key settings: {e}"));
+                    }
+                }
+                if theme::button(ui, p, BtnKind::Default, "Restart as administrator")
+                    .clicked()
+                {
+                    match keyroost_winwebauthn::relaunch_as_admin() {
+                        // Elevated instance requested: exit this non-elevated one
+                        // so only the admin process remains.
+                        Ok(()) => std::process::exit(0),
+                        Err(e) => {
+                            self.security_keys.error =
+                                Some(format!("Couldn't restart as administrator: {e}"));
+                        }
+                    }
+                }
+            });
+        });
+    }
+
     fn cap_fido2(&mut self, ui: &mut egui::Ui, p: &Palette) {
+        // Non-admin Windows: if a FIDO key is present but we have no working FIDO
+        // access (the HID interface is gated), show the admin-needed card with a
+        // link to Windows' settings and an elevate button, instead of the normal
+        // — and here non-functional — management UI.
+        #[cfg(windows)]
+        {
+            let no_access = self.security_keys.info.is_none();
+            if no_access && keyroost_winwebauthn::fido_key_present() {
+                self.fido2_non_admin_card(ui, p);
+                return;
+            }
+        }
+
         let pin_set = self
             .security_keys
             .info


### PR DESCRIPTION
 non-admin FIDO2 tab — detect via access-denied, link to Windows settings, restart-as-admin

Adds a Windows-only keyroost-winwebauthn helper that detects a FIDO key without elevation (HID access-denied signal) and opens Windows' security-key settings or relaunches elevated. The FIDO2 tab shows an admin-needed card when running non-admin. Refs #58.

Final look 

Main tab:
<img width="1155" height="257" alt="image" src="https://github.com/user-attachments/assets/ac61bb59-3852-4c9b-a223-496916cec221" />
 

FIDO2 tab:
<img width="1148" height="327" alt="image" src="https://github.com/user-attachments/assets/07fbaa10-7e17-4c1f-b28f-4ad4e4404caa" />
 

