### PR TITLE
feat: large-blob legibility — classify, decode, meter, and export FIDO2 large-blob entries (roadmap Tier A)

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -9,4 +9,14 @@ ignore = [
     # the vulnerable code path is unreachable. Revisit when a fixed `rsa`
     # version ships.
     "RUSTSEC-2023-0071",
+    # quick-xml 0.39 quadratic-time duplicate-attribute check (0194) and
+    # unbounded NsReader namespace allocation (0195). quick-xml enters the
+    # tree only through wayland-scanner, a build-time proc-macro that parses
+    # the Wayland protocol XML files vendored inside the windowing crates —
+    # it never sees attacker-supplied XML, and the affected code isn't in the
+    # shipped binaries at all. No parent release allows quick-xml >=0.41 yet
+    # (wayland-scanner 0.31.10 is the newest its dependents accept); drop
+    # both ignores when the winit/smithay stack moves to a fixed quick-xml.
+    "RUSTSEC-2026-0194",
+    "RUSTSEC-2026-0195",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1925,6 +1925,7 @@ dependencies = [
  "hidapi",
  "hmac",
  "keyroost-hid",
+ "keyroost-proto",
  "p256",
  "rand_core",
  "sha2",

--- a/crates/keyroost-ctap/Cargo.toml
+++ b/crates/keyroost-ctap/Cargo.toml
@@ -20,6 +20,7 @@ hidapi-backend = ["dep:hidapi", "keyroost-hid/hidapi-backend"]
 
 [dependencies]
 keyroost-hid = { path = "../keyroost-hid", version = "0.7.3" }
+keyroost-proto = { path = "../keyroost-proto", version = "0.7.3" }
 # Optional so a default Linux build pulls nothing (the hidraw File backend is
 # dependency-free); enabled by `hidapi-backend` for testing.
 hidapi = { version = "2.6", optional = true, default-features = false, features = [

--- a/crates/keyroost-ctap/src/cmd.rs
+++ b/crates/keyroost-ctap/src/cmd.rs
@@ -181,6 +181,11 @@ pub struct AuthenticatorInfo {
     pub force_pin_change: Option<bool>,
     pub min_pin_length: Option<u64>,
     pub firmware_version: Option<u64>,
+    /// `maxSerializedLargeBlobArray` (getInfo key 0x0B): the maximum size, in
+    /// bytes, of the serialized large-blob array this authenticator stores —
+    /// including the 16-byte checksum trailer. Spec minimum is 1024 when the
+    /// `largeBlobs` option is supported; absent on keys without large blobs.
+    pub max_serialized_large_blob_array: Option<u64>,
 }
 
 impl AuthenticatorInfo {
@@ -249,6 +254,7 @@ pub fn parse_authenticator_info(v: &Value) -> Result<AuthenticatorInfo, CtapErro
             0x07 => info.max_credential_count_in_list = val.as_uint(),
             0x08 => info.max_credential_id_length = val.as_uint(),
             0x09 => info.transports = collect_strings(val),
+            0x0b => info.max_serialized_large_blob_array = val.as_uint(),
             0x0C => info.force_pin_change = val.as_bool(),
             0x0D => info.min_pin_length = val.as_uint(),
             0x0E => info.firmware_version = val.as_uint(),
@@ -382,5 +388,20 @@ mod tests {
         let v = Value::Map(vec![(Value::UInt(3), Value::Bytes(vec![0x11; 8]))]);
         let info = parse_authenticator_info(&v).unwrap();
         assert_eq!(info.aaguid, [0u8; 16]);
+    }
+
+    #[test]
+    fn parses_max_serialized_large_blob_array() {
+        // CTAP2.1 authenticatorGetInfo key 0x0B.
+        let v = Value::Map(vec![(Value::UInt(0x0b), Value::UInt(2048))]);
+        let info = parse_authenticator_info(&v).unwrap();
+        assert_eq!(info.max_serialized_large_blob_array, Some(2048));
+    }
+
+    #[test]
+    fn max_serialized_large_blob_array_defaults_to_none() {
+        let v = Value::Map(vec![]);
+        let info = parse_authenticator_info(&v).unwrap();
+        assert_eq!(info.max_serialized_large_blob_array, None);
     }
 }

--- a/crates/keyroost-ctap/src/large_blobs.rs
+++ b/crates/keyroost-ctap/src/large_blobs.rs
@@ -80,6 +80,22 @@ const CHECKSUM_LEN: usize = 16;
 const DEFAULT_MAX_MSG_SIZE: u64 = 1024;
 const MSG_SIZE_OVERHEAD: u64 = 64;
 
+/// Spec floor for `maxSerializedLargeBlobArray` when the authenticator
+/// supports large blobs but does not advertise the key (CTAP 2.1 §6.10).
+const SPEC_MIN_SERIALIZED_ARRAY: u64 = 1024;
+
+/// Space accounting for a large-blob array against an authenticator's
+/// advertised (or spec-minimum) storage. Sizes count the full serialized
+/// form — CBOR array plus the 16-byte checksum trailer — because that is
+/// what `maxSerializedLargeBlobArray` bounds.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BlobCapacity {
+    pub max_bytes: u64,
+    pub used_bytes: u64,
+    pub free_bytes: u64,
+    pub entry_count: usize,
+}
+
 /// The empty large-blob array: an empty CBOR array (`0x80`) followed by the
 /// 16-byte checksum of that single byte. Writing this effectively clears the
 /// store. Computed lazily to avoid a const-fn hash.
@@ -185,6 +201,21 @@ impl LargeBlobArray {
             entries,
             raw_array: Vec::new(),
         })
+    }
+
+    /// Compute capacity from the entries as currently held (re-serialized,
+    /// so it stays correct after local adds/edits that haven't been written).
+    pub fn capacity(&self, info: &AuthenticatorInfo) -> BlobCapacity {
+        let used = self.serialize_with_checksum().len() as u64;
+        let max = info
+            .max_serialized_large_blob_array
+            .unwrap_or(SPEC_MIN_SERIALIZED_ARRAY);
+        BlobCapacity {
+            max_bytes: max,
+            used_bytes: used,
+            free_bytes: max.saturating_sub(used),
+            entry_count: self.entries.len(),
+        }
     }
 }
 
@@ -547,5 +578,41 @@ mod tests {
         assert!(arr.with_replaced_note(0, "hack").is_none());
         // Out-of-range index is refused.
         assert!(arr.with_replaced_note(9, "x").is_none());
+    }
+
+    #[test]
+    fn capacity_of_empty_array() {
+        let arr = LargeBlobArray { entries: Vec::new(), raw_array: Vec::new() };
+        let info = AuthenticatorInfo::default(); // no 0x0B advertised -> spec minimum
+        let cap = arr.capacity(&info);
+        // Empty CBOR array (0x80, 1 byte) + 16-byte checksum trailer.
+        assert_eq!(cap.used_bytes, 17);
+        assert_eq!(cap.max_bytes, 1024);
+        assert_eq!(cap.free_bytes, 1024 - 17);
+        assert_eq!(cap.entry_count, 0);
+    }
+
+    #[test]
+    fn capacity_uses_advertised_max_and_saturates() {
+        let arr = LargeBlobArray {
+            entries: vec![LargeBlobEntry::from_text("hello")],
+            raw_array: Vec::new(),
+        };
+        let info = AuthenticatorInfo {
+            max_serialized_large_blob_array: Some(4096),
+            ..Default::default()
+        };
+        let cap = arr.capacity(&info);
+        assert_eq!(cap.max_bytes, 4096);
+        assert_eq!(cap.used_bytes, arr.serialize_with_checksum().len() as u64);
+        assert_eq!(cap.free_bytes, cap.max_bytes - cap.used_bytes);
+        assert_eq!(cap.entry_count, 1);
+
+        // A max smaller than what's stored must not underflow.
+        let info_small = AuthenticatorInfo {
+            max_serialized_large_blob_array: Some(10),
+            ..Default::default()
+        };
+        assert_eq!(arr.capacity(&info_small).free_bytes, 0);
     }
 }

--- a/crates/keyroost-ctap/src/large_blobs.rs
+++ b/crates/keyroost-ctap/src/large_blobs.rs
@@ -621,7 +621,10 @@ mod tests {
 
     #[test]
     fn capacity_of_empty_array() {
-        let arr = LargeBlobArray { entries: Vec::new(), raw_array: Vec::new() };
+        let arr = LargeBlobArray {
+            entries: Vec::new(),
+            raw_array: Vec::new(),
+        };
         let info = AuthenticatorInfo::default(); // no 0x0B advertised -> spec minimum
         let cap = arr.capacity(&info);
         // Empty CBOR array (0x80, 1 byte) + 16-byte checksum trailer.
@@ -669,8 +672,13 @@ mod tests {
         assert!(matches!(cert_note.classify(), EntryKind::Note(t) if t == FIXTURE_CERT_PUB));
 
         // Wire-format certificate.
-        let wire = base64_decode(FIXTURE_CERT_PUB.split_ascii_whitespace().nth(1).unwrap()).unwrap();
-        let wire_entry = LargeBlobEntry { ciphertext: wire.clone(), nonce: vec![0; 12], orig_size: wire.len() as u64 };
+        let wire =
+            base64_decode(FIXTURE_CERT_PUB.split_ascii_whitespace().nth(1).unwrap()).unwrap();
+        let wire_entry = LargeBlobEntry {
+            ciphertext: wire.clone(),
+            nonce: vec![0; 12],
+            orig_size: wire.len() as u64,
+        };
         match wire_entry.classify() {
             EntryKind::SshCert { info, wire: w } => {
                 assert_eq!(info.key_id, "test-key-id");
@@ -694,7 +702,11 @@ mod tests {
         }
 
         // Random RP bytes stay opaque.
-        let rp = LargeBlobEntry { ciphertext: vec![0xde, 0xad, 0xbe, 0xef], nonce: vec![1; 12], orig_size: 4 };
+        let rp = LargeBlobEntry {
+            ciphertext: vec![0xde, 0xad, 0xbe, 0xef],
+            nonce: vec![1; 12],
+            orig_size: 4,
+        };
         assert!(matches!(rp.classify(), EntryKind::Opaque));
     }
 }

--- a/crates/keyroost-ctap/src/large_blobs.rs
+++ b/crates/keyroost-ctap/src/large_blobs.rs
@@ -50,6 +50,7 @@ use crate::client_pin::PinUvAuthToken;
 use crate::cmd::{AuthenticatorInfo, CtapError};
 use crate::hid::CTAPHID_CBOR;
 use crate::pin::left16_sha256;
+use crate::ssh_cert;
 use crate::transport::CtapTransport;
 
 /// CTAP command byte for `authenticatorLargeBlobs`.
@@ -155,6 +156,44 @@ impl LargeBlobEntry {
     pub fn is_kr_note(&self) -> bool {
         self.ciphertext.starts_with(KR_NOTE_MAGIC)
     }
+
+    /// Classify this entry. Conservative by construction: the keyroost note
+    /// magic wins outright, certificate recognition requires a complete,
+    /// well-formed parse, and everything else is opaque.
+    pub fn classify(&self) -> EntryKind {
+        if let Some(text) = self.as_text() {
+            return EntryKind::Note(text);
+        }
+        if let Some(info) = ssh_cert::parse_wire(&self.ciphertext) {
+            return EntryKind::SshCert {
+                info,
+                wire: self.ciphertext.clone(),
+            };
+        }
+        if let Ok(s) = std::str::from_utf8(&self.ciphertext) {
+            if let Some((info, wire)) = ssh_cert::parse_text(s.trim()) {
+                return EntryKind::SshCert { info, wire };
+            }
+        }
+        EntryKind::Opaque
+    }
+}
+
+/// What a large-blob entry *is*, as far as keyroost can honestly tell.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EntryKind {
+    /// keyroost plaintext note (magic-prefixed).
+    Note(String),
+    /// A recognized OpenSSH certificate. `wire` holds the canonical binary
+    /// certificate (decoded from base64 when the entry stored the text form),
+    /// ready for export as a `-cert.pub`.
+    SshCert {
+        info: ssh_cert::SshCertInfo,
+        wire: Vec<u8>,
+    },
+    /// Anything unrecognized — treated as RP-owned AEAD data: shown raw,
+    /// never reinterpreted, never rewritten.
+    Opaque,
 }
 
 /// A parsed large-blob array: the structured entries plus the exact raw bytes
@@ -614,5 +653,44 @@ mod tests {
             ..Default::default()
         };
         assert_eq!(arr.capacity(&info_small).free_bytes, 0);
+    }
+
+    #[test]
+    fn classify_note_ssh_cert_and_opaque() {
+        use crate::ssh_cert::tests_fixture::FIXTURE_CERT_PUB;
+        use keyroost_proto::codec::base64_decode;
+
+        // Note wins (even if a note happens to contain a cert line).
+        let note = LargeBlobEntry::from_text("hello");
+        assert!(matches!(note.classify(), EntryKind::Note(t) if t == "hello"));
+
+        // Wire-format certificate.
+        let wire = base64_decode(FIXTURE_CERT_PUB.split_ascii_whitespace().nth(1).unwrap()).unwrap();
+        let wire_entry = LargeBlobEntry { ciphertext: wire.clone(), nonce: vec![0; 12], orig_size: wire.len() as u64 };
+        match wire_entry.classify() {
+            EntryKind::SshCert { info, wire: w } => {
+                assert_eq!(info.key_id, "test-key-id");
+                assert_eq!(w, wire);
+            }
+            other => panic!("expected SshCert, got {other:?}"),
+        }
+
+        // Text-form certificate (a -cert.pub file dropped in verbatim).
+        let text_entry = LargeBlobEntry {
+            ciphertext: FIXTURE_CERT_PUB.as_bytes().to_vec(),
+            nonce: vec![0; 12],
+            orig_size: FIXTURE_CERT_PUB.len() as u64,
+        };
+        match text_entry.classify() {
+            EntryKind::SshCert { info, wire: w } => {
+                assert_eq!(info.serial, 42);
+                assert_eq!(w, wire); // canonical wire bytes, not the text
+            }
+            other => panic!("expected SshCert, got {other:?}"),
+        }
+
+        // Random RP bytes stay opaque.
+        let rp = LargeBlobEntry { ciphertext: vec![0xde, 0xad, 0xbe, 0xef], nonce: vec![1; 12], orig_size: 4 };
+        assert!(matches!(rp.classify(), EntryKind::Opaque));
     }
 }

--- a/crates/keyroost-ctap/src/large_blobs.rs
+++ b/crates/keyroost-ctap/src/large_blobs.rs
@@ -664,6 +664,10 @@ mod tests {
         let note = LargeBlobEntry::from_text("hello");
         assert!(matches!(note.classify(), EntryKind::Note(t) if t == "hello"));
 
+        // A note whose body IS a cert line still classifies as a note.
+        let cert_note = LargeBlobEntry::from_text(FIXTURE_CERT_PUB);
+        assert!(matches!(cert_note.classify(), EntryKind::Note(t) if t == FIXTURE_CERT_PUB));
+
         // Wire-format certificate.
         let wire = base64_decode(FIXTURE_CERT_PUB.split_ascii_whitespace().nth(1).unwrap()).unwrap();
         let wire_entry = LargeBlobEntry { ciphertext: wire.clone(), nonce: vec![0; 12], orig_size: wire.len() as u64 };

--- a/crates/keyroost-ctap/src/lib.rs
+++ b/crates/keyroost-ctap/src/lib.rs
@@ -21,6 +21,7 @@ pub mod cred_mgmt;
 pub mod hid;
 pub mod large_blobs;
 pub mod pin;
+pub mod ssh_cert;
 pub mod transport;
 
 pub use bio_enroll::{BioEnrollment, CaptureStatus, Enrollment, SensorInfo};

--- a/crates/keyroost-ctap/src/ssh_cert.rs
+++ b/crates/keyroost-ctap/src/ssh_cert.rs
@@ -1,0 +1,281 @@
+//! Read-only decoding of OpenSSH certificates (the `*-cert-v01@openssh.com`
+//! wire format described in OpenSSH's PROTOCOL.certkeys). This exists so the
+//! large-blob Storage views can *recognize and display* a certificate an SSH
+//! CA workflow parked on the key — type, key id, principals, validity,
+//! critical options. It deliberately does NOT verify the CA signature; that
+//! is the relying server's job, not a display surface's.
+
+/// Certificate type field values (PROTOCOL.certkeys).
+pub const CERT_TYPE_USER: u32 = 1;
+pub const CERT_TYPE_HOST: u32 = 2;
+
+/// The human-relevant fields of an OpenSSH certificate.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SshCertInfo {
+    /// e.g. `ssh-ed25519-cert-v01@openssh.com`.
+    pub key_type: String,
+    pub serial: u64,
+    /// [`CERT_TYPE_USER`] or [`CERT_TYPE_HOST`].
+    pub cert_type: u32,
+    pub key_id: String,
+    pub principals: Vec<String>,
+    /// Unix seconds; 0 = no lower bound.
+    pub valid_after: u64,
+    /// Unix seconds; `u64::MAX` = no upper bound ("forever").
+    pub valid_before: u64,
+    /// `(name, value)` pairs; value is empty for flag-style options.
+    pub critical_options: Vec<(String, String)>,
+    /// Extension names (values are conventionally empty).
+    pub extensions: Vec<String>,
+}
+
+/// Cursor over SSH wire data: big-endian integers and u32-length-prefixed
+/// byte strings.
+struct Reader<'a> {
+    buf: &'a [u8],
+    pos: usize,
+}
+
+impl<'a> Reader<'a> {
+    fn new(buf: &'a [u8]) -> Self {
+        Reader { buf, pos: 0 }
+    }
+
+    fn take(&mut self, n: usize) -> Option<&'a [u8]> {
+        let end = self.pos.checked_add(n)?;
+        let out = self.buf.get(self.pos..end)?;
+        self.pos = end;
+        Some(out)
+    }
+
+    fn u32(&mut self) -> Option<u32> {
+        self.take(4).map(|b| u32::from_be_bytes(b.try_into().unwrap()))
+    }
+
+    fn u64(&mut self) -> Option<u64> {
+        self.take(8).map(|b| u64::from_be_bytes(b.try_into().unwrap()))
+    }
+
+    fn bytes(&mut self) -> Option<&'a [u8]> {
+        let n = self.u32()? as usize;
+        self.take(n)
+    }
+
+    fn string(&mut self) -> Option<String> {
+        std::str::from_utf8(self.bytes()?).ok().map(str::to_owned)
+    }
+
+    fn done(&self) -> bool {
+        self.pos == self.buf.len()
+    }
+}
+
+/// How many wire fields the embedded public key occupies for each supported
+/// certificate type (they sit between the nonce and the serial). `mpint`s and
+/// `string`s share the same length-prefixed wire shape, so a count suffices.
+fn pubkey_field_count(key_type: &str) -> Option<usize> {
+    Some(match key_type {
+        "ssh-ed25519-cert-v01@openssh.com" => 1, // pk
+        "ssh-rsa-cert-v01@openssh.com" => 2,     // e, n
+        "ecdsa-sha2-nistp256-cert-v01@openssh.com"
+        | "ecdsa-sha2-nistp384-cert-v01@openssh.com"
+        | "ecdsa-sha2-nistp521-cert-v01@openssh.com" => 2, // curve, point
+        "sk-ssh-ed25519-cert-v01@openssh.com" => 2, // pk, application
+        "sk-ecdsa-sha2-nistp256-cert-v01@openssh.com" => 3, // curve, point, application
+        _ => return None,
+    })
+}
+
+/// Parse a wire-format OpenSSH certificate. Returns `None` on anything that
+/// is not a complete, well-formed certificate of a supported type — including
+/// trailing bytes — so this can double as a classifier over arbitrary
+/// large-blob entry bytes without false positives.
+pub fn parse_wire(blob: &[u8]) -> Option<SshCertInfo> {
+    let mut r = Reader::new(blob);
+    let key_type = r.string()?;
+    let pubkey_fields = pubkey_field_count(&key_type)?;
+    let _nonce = r.bytes()?;
+    for _ in 0..pubkey_fields {
+        r.bytes()?;
+    }
+    let serial = r.u64()?;
+    let cert_type = r.u32()?;
+    if cert_type != CERT_TYPE_USER && cert_type != CERT_TYPE_HOST {
+        return None;
+    }
+    let key_id = r.string()?;
+    let principals = packed_strings(r.bytes()?)?;
+    let valid_after = r.u64()?;
+    let valid_before = r.u64()?;
+    let critical_options = packed_pairs(r.bytes()?)?;
+    let extensions = packed_pairs(r.bytes()?)?
+        .into_iter()
+        .map(|(name, _)| name)
+        .collect();
+    let _reserved = r.bytes()?;
+    let _signature_key = r.bytes()?;
+    let _signature = r.bytes()?;
+    if !r.done() {
+        return None;
+    }
+    Some(SshCertInfo {
+        key_type,
+        serial,
+        cert_type,
+        key_id,
+        principals,
+        valid_after,
+        valid_before,
+        critical_options,
+        extensions,
+    })
+}
+
+/// A buffer holding zero or more concatenated wire strings (the principals
+/// section).
+fn packed_strings(buf: &[u8]) -> Option<Vec<String>> {
+    let mut r = Reader::new(buf);
+    let mut out = Vec::new();
+    while !r.done() {
+        out.push(r.string()?);
+    }
+    Some(out)
+}
+
+/// A buffer holding zero or more `(string name, string data)` tuples, where
+/// `data` is either empty or itself a single wire string (the critical
+/// options and extensions sections).
+fn packed_pairs(buf: &[u8]) -> Option<Vec<(String, String)>> {
+    let mut r = Reader::new(buf);
+    let mut out = Vec::new();
+    while !r.done() {
+        let name = r.string()?;
+        let data = r.bytes()?;
+        let value = if data.is_empty() {
+            String::new()
+        } else {
+            let mut inner = Reader::new(data);
+            let v = inner.string()?;
+            if !inner.done() {
+                return None;
+            }
+            v
+        };
+        out.push((name, value));
+    }
+    Some(out)
+}
+
+/// Render a Unix timestamp as `YYYY-MM-DD HH:MM:SS UTC` without pulling in a
+/// date crate. Civil-from-days per Howard Hinnant's algorithm.
+pub fn format_timestamp(secs: u64) -> String {
+    let days = (secs / 86_400) as i64;
+    let rem = secs % 86_400;
+    let (y, m, d) = civil_from_days(days);
+    format!(
+        "{:04}-{:02}-{:02} {:02}:{:02}:{:02} UTC",
+        y,
+        m,
+        d,
+        rem / 3600,
+        (rem % 3600) / 60,
+        rem % 60
+    )
+}
+
+/// Human validity window. OpenSSH treats `(0, u64::MAX)` as unbounded.
+pub fn format_validity(valid_after: u64, valid_before: u64) -> String {
+    if valid_after == 0 && valid_before == u64::MAX {
+        return "always valid".to_string();
+    }
+    let from = if valid_after == 0 {
+        "beginning of time".to_string()
+    } else {
+        format_timestamp(valid_after)
+    };
+    let to = if valid_before == u64::MAX {
+        "forever".to_string()
+    } else {
+        format_timestamp(valid_before)
+    };
+    format!("{from} to {to}")
+}
+
+fn civil_from_days(z: i64) -> (i64, u32, u32) {
+    let z = z + 719_468;
+    let era = if z >= 0 { z } else { z - 146_096 } / 146_097;
+    let doe = (z - era * 146_097) as u64;
+    let yoe = (doe - doe / 1_460 + doe / 36_524 - doe / 146_096) / 365;
+    let y = yoe as i64 + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = (doy - (153 * mp + 2) / 5 + 1) as u32;
+    let m = if mp < 10 { mp + 3 } else { mp - 9 } as u32;
+    (y + i64::from(m <= 2), m, d)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use keyroost_proto::codec::base64_decode;
+
+    /// Real ed25519 user certificate produced by ssh-keygen from throwaway
+    /// keys (see the Tier A plan for the exact invocation). The base64 body
+    /// is the wire-format certificate blob.
+    const FIXTURE_CERT_PUB: &str = "ssh-ed25519-cert-v01@openssh.com AAAAIHNzaC1lZDI1NTE5LWNlcnQtdjAxQG9wZW5zc2guY29tAAAAIFnHByOSs9oyjoM3FSMYa4CyEkl9qj7cPldTCWBGw3soAAAAIB8WYDicxYHAvQ5QE8w24ZO0pod+x5Y7Zcjdk8D3kOpZAAAAAAAAACoAAAABAAAAC3Rlc3Qta2V5LWlkAAAAEAAAAAVhbGljZQAAAANib2IAAAAAaVW5AAAAAABrNuyAAAAAJgAAAA5zb3VyY2UtYWRkcmVzcwAAABAAAAAMMTkyLjAuMi4wLzI0AAAAEgAAAApwZXJtaXQtcHR5AAAAAAAAAAAAAAAzAAAAC3NzaC1lZDI1NTE5AAAAIOkAWA6QeBu6LNDfyV4zAgonPK7XpSmq9aFdozDaQr76AAAAUwAAAAtzc2gtZWQyNTUxOQAAAEAEeDetmfpeDeQHbXOGfLlLg9XHjJQpaXg1foE9TuNXWP3Bx3oCk4Foa8S7VkuXtK0geecTqa4WZGF9dM6VSWgI user";
+
+    fn fixture_wire() -> Vec<u8> {
+        let b64 = FIXTURE_CERT_PUB.split_ascii_whitespace().nth(1).unwrap();
+        base64_decode(b64).unwrap()
+    }
+
+    #[test]
+    fn parses_real_ed25519_user_cert() {
+        let info = parse_wire(&fixture_wire()).unwrap();
+        assert_eq!(info.key_type, "ssh-ed25519-cert-v01@openssh.com");
+        assert_eq!(info.serial, 42);
+        assert_eq!(info.cert_type, CERT_TYPE_USER);
+        assert_eq!(info.key_id, "test-key-id");
+        assert_eq!(info.principals, vec!["alice".to_string(), "bob".to_string()]);
+        assert_eq!(info.valid_after, 1767225600);
+        assert_eq!(info.valid_before, 1798761600);
+        assert_eq!(
+            info.critical_options,
+            vec![("source-address".to_string(), "192.0.2.0/24".to_string())]
+        );
+        assert_eq!(info.extensions, vec!["permit-pty".to_string()]);
+    }
+
+    #[test]
+    fn rejects_non_certificates() {
+        // Not even a length-prefixed string.
+        assert!(parse_wire(&[0xde, 0xad, 0xbe, 0xef]).is_none());
+        // Empty input.
+        assert!(parse_wire(&[]).is_none());
+        // A valid-looking type string but nothing after it.
+        let mut b = Vec::new();
+        b.extend_from_slice(&32u32.to_be_bytes());
+        b.extend_from_slice(b"ssh-ed25519-cert-v01@openssh.com");
+        assert!(parse_wire(&b).is_none());
+        // Truncated real cert: cut the last 10 bytes off.
+        let wire = fixture_wire();
+        assert!(parse_wire(&wire[..wire.len() - 10]).is_none());
+        // Trailing junk after a real cert must also be rejected (strictness
+        // keeps classification from matching almost-certs).
+        let mut padded = fixture_wire();
+        padded.push(0x00);
+        assert!(parse_wire(&padded).is_none());
+    }
+
+    #[test]
+    fn formats_timestamps_and_validity() {
+        assert_eq!(format_timestamp(1767225600), "2026-01-01 00:00:00 UTC");
+        assert_eq!(format_timestamp(0), "1970-01-01 00:00:00 UTC");
+        // OpenSSH convention: the all-1s valid_before means "forever".
+        assert_eq!(format_validity(0, u64::MAX), "always valid");
+        assert_eq!(
+            format_validity(1767225600, 1798761600),
+            "2026-01-01 00:00:00 UTC to 2027-01-01 00:00:00 UTC"
+        );
+    }
+}

--- a/crates/keyroost-ctap/src/ssh_cert.rs
+++ b/crates/keyroost-ctap/src/ssh_cert.rs
@@ -51,11 +51,13 @@ impl<'a> Reader<'a> {
     }
 
     fn u32(&mut self) -> Option<u32> {
-        self.take(4).map(|b| u32::from_be_bytes(b.try_into().unwrap()))
+        self.take(4)
+            .map(|b| u32::from_be_bytes(b.try_into().unwrap()))
     }
 
     fn u64(&mut self) -> Option<u64> {
-        self.take(8).map(|b| u64::from_be_bytes(b.try_into().unwrap()))
+        self.take(8)
+            .map(|b| u64::from_be_bytes(b.try_into().unwrap()))
     }
 
     fn bytes(&mut self) -> Option<&'a [u8]> {
@@ -252,8 +254,8 @@ pub(crate) mod tests_fixture {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use super::tests_fixture::FIXTURE_CERT_PUB;
+    use super::*;
 
     fn fixture_wire() -> Vec<u8> {
         let b64 = FIXTURE_CERT_PUB.split_ascii_whitespace().nth(1).unwrap();
@@ -267,7 +269,10 @@ mod tests {
         assert_eq!(info.serial, 42);
         assert_eq!(info.cert_type, CERT_TYPE_USER);
         assert_eq!(info.key_id, "test-key-id");
-        assert_eq!(info.principals, vec!["alice".to_string(), "bob".to_string()]);
+        assert_eq!(
+            info.principals,
+            vec!["alice".to_string(), "bob".to_string()]
+        );
         assert_eq!(info.valid_after, 1767225600);
         assert_eq!(info.valid_before, 1798761600);
         assert_eq!(
@@ -338,7 +343,10 @@ mod tests {
         let lied = format!("ssh-rsa-cert-v01@openssh.com {b64}");
         assert!(parse_text(&lied).is_none());
         // Ordinary public keys (not certs) are not recognized.
-        assert!(parse_text("ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIB8WYDicxYHAvQ5QE8w24ZO0pod+x5Y7Zcjdk8D3kOpZ user").is_none());
+        assert!(parse_text(
+            "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIB8WYDicxYHAvQ5QE8w24ZO0pod+x5Y7Zcjdk8D3kOpZ user"
+        )
+        .is_none());
         // Not base64 / not a cert at all.
         assert!(parse_text("hello world").is_none());
         assert!(parse_text("").is_none());

--- a/crates/keyroost-ctap/src/ssh_cert.rs
+++ b/crates/keyroost-ctap/src/ssh_cert.rs
@@ -5,6 +5,8 @@
 //! critical options. It deliberately does NOT verify the CA signature; that
 //! is the relying server's job, not a display surface's.
 
+use keyroost_proto::codec::{base64_decode, base64_encode};
+
 /// Certificate type field values (PROTOCOL.certkeys).
 pub const CERT_TYPE_USER: u32 = 1;
 pub const CERT_TYPE_HOST: u32 = 2;
@@ -214,10 +216,34 @@ fn civil_from_days(z: i64) -> (i64, u32, u32) {
     (y + i64::from(m <= 2), m, d)
 }
 
+/// Parse the text form of a certificate — the single `-cert.pub` line
+/// (`<type> <base64> [comment]`). Returns the decoded fields plus the raw
+/// wire blob so callers can export or re-store the canonical bytes. The
+/// declared type must match the type embedded in the blob.
+pub fn parse_text(s: &str) -> Option<(SshCertInfo, Vec<u8>)> {
+    let mut parts = s.split_ascii_whitespace();
+    let declared = parts.next()?;
+    if !declared.ends_with("-cert-v01@openssh.com") {
+        return None;
+    }
+    let wire = base64_decode(parts.next()?).ok()?;
+    let info = parse_wire(&wire)?;
+    if info.key_type != declared {
+        return None;
+    }
+    Some((info, wire))
+}
+
+/// Re-encode a wire-format certificate as the body of a `-cert.pub` file:
+/// `<type> <base64>\n`. Returns `None` if the bytes are not a certificate.
+pub fn to_cert_pub(wire: &[u8]) -> Option<String> {
+    let info = parse_wire(wire)?;
+    Some(format!("{} {}\n", info.key_type, base64_encode(wire)))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use keyroost_proto::codec::base64_decode;
 
     /// Real ed25519 user certificate produced by ssh-keygen from throwaway
     /// keys (see the Tier A plan for the exact invocation). The base64 body
@@ -277,5 +303,39 @@ mod tests {
             format_validity(1767225600, 1798761600),
             "2026-01-01 00:00:00 UTC to 2027-01-01 00:00:00 UTC"
         );
+    }
+
+    #[test]
+    fn parses_text_form_and_roundtrips_to_cert_pub() {
+        let (info, wire) = parse_text(FIXTURE_CERT_PUB).unwrap();
+        assert_eq!(info.key_id, "test-key-id");
+        assert_eq!(wire, fixture_wire());
+
+        // Re-encoding the wire form yields a line OpenSSH accepts: same type,
+        // same base64 body (comment is not preserved — it isn't part of the
+        // certificate).
+        let line = to_cert_pub(&wire).unwrap();
+        let mut parts = line.split_ascii_whitespace();
+        assert_eq!(parts.next(), Some("ssh-ed25519-cert-v01@openssh.com"));
+        assert_eq!(
+            parts.next(),
+            FIXTURE_CERT_PUB.split_ascii_whitespace().nth(1)
+        );
+        assert!(line.ends_with('\n'));
+        // And the re-encoded line parses back.
+        assert!(parse_text(&line).is_some());
+    }
+
+    #[test]
+    fn text_form_rejects_mismatch_and_garbage() {
+        // Declared type must match the type inside the blob.
+        let b64 = FIXTURE_CERT_PUB.split_ascii_whitespace().nth(1).unwrap();
+        let lied = format!("ssh-rsa-cert-v01@openssh.com {b64}");
+        assert!(parse_text(&lied).is_none());
+        // Ordinary public keys (not certs) are not recognized.
+        assert!(parse_text("ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIB8WYDicxYHAvQ5QE8w24ZO0pod+x5Y7Zcjdk8D3kOpZ user").is_none());
+        // Not base64 / not a cert at all.
+        assert!(parse_text("hello world").is_none());
+        assert!(parse_text("").is_none());
     }
 }

--- a/crates/keyroost-ctap/src/ssh_cert.rs
+++ b/crates/keyroost-ctap/src/ssh_cert.rs
@@ -241,14 +241,19 @@ pub fn to_cert_pub(wire: &[u8]) -> Option<String> {
     Some(format!("{} {}\n", info.key_type, base64_encode(wire)))
 }
 
+/// Test fixture shared with large_blobs' classification tests.
 #[cfg(test)]
-mod tests {
-    use super::*;
-
+pub(crate) mod tests_fixture {
     /// Real ed25519 user certificate produced by ssh-keygen from throwaway
     /// keys (see the Tier A plan for the exact invocation). The base64 body
     /// is the wire-format certificate blob.
-    const FIXTURE_CERT_PUB: &str = "ssh-ed25519-cert-v01@openssh.com AAAAIHNzaC1lZDI1NTE5LWNlcnQtdjAxQG9wZW5zc2guY29tAAAAIFnHByOSs9oyjoM3FSMYa4CyEkl9qj7cPldTCWBGw3soAAAAIB8WYDicxYHAvQ5QE8w24ZO0pod+x5Y7Zcjdk8D3kOpZAAAAAAAAACoAAAABAAAAC3Rlc3Qta2V5LWlkAAAAEAAAAAVhbGljZQAAAANib2IAAAAAaVW5AAAAAABrNuyAAAAAJgAAAA5zb3VyY2UtYWRkcmVzcwAAABAAAAAMMTkyLjAuMi4wLzI0AAAAEgAAAApwZXJtaXQtcHR5AAAAAAAAAAAAAAAzAAAAC3NzaC1lZDI1NTE5AAAAIOkAWA6QeBu6LNDfyV4zAgonPK7XpSmq9aFdozDaQr76AAAAUwAAAAtzc2gtZWQyNTUxOQAAAEAEeDetmfpeDeQHbXOGfLlLg9XHjJQpaXg1foE9TuNXWP3Bx3oCk4Foa8S7VkuXtK0geecTqa4WZGF9dM6VSWgI user";
+    pub const FIXTURE_CERT_PUB: &str = "ssh-ed25519-cert-v01@openssh.com AAAAIHNzaC1lZDI1NTE5LWNlcnQtdjAxQG9wZW5zc2guY29tAAAAIFnHByOSs9oyjoM3FSMYa4CyEkl9qj7cPldTCWBGw3soAAAAIB8WYDicxYHAvQ5QE8w24ZO0pod+x5Y7Zcjdk8D3kOpZAAAAAAAAACoAAAABAAAAC3Rlc3Qta2V5LWlkAAAAEAAAAAVhbGljZQAAAANib2IAAAAAaVW5AAAAAABrNuyAAAAAJgAAAA5zb3VyY2UtYWRkcmVzcwAAABAAAAAMMTkyLjAuMi4wLzI0AAAAEgAAAApwZXJtaXQtcHR5AAAAAAAAAAAAAAAzAAAAC3NzaC1lZDI1NTE5AAAAIOkAWA6QeBu6LNDfyV4zAgonPK7XpSmq9aFdozDaQr76AAAAUwAAAAtzc2gtZWQyNTUxOQAAAEAEeDetmfpeDeQHbXOGfLlLg9XHjJQpaXg1foE9TuNXWP3Bx3oCk4Foa8S7VkuXtK0geecTqa4WZGF9dM6VSWgI user";
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use super::tests_fixture::FIXTURE_CERT_PUB;
 
     fn fixture_wire() -> Vec<u8> {
         let b64 = FIXTURE_CERT_PUB.split_ascii_whitespace().nth(1).unwrap();

--- a/crates/keyroost/src/main.rs
+++ b/crates/keyroost/src/main.rs
@@ -8359,7 +8359,11 @@ impl App {
                         cap.max_bytes,
                         cap.free_bytes,
                         cap.entry_count,
-                        if cap.entry_count == 1 { "entry" } else { "entries" },
+                        if cap.entry_count == 1 {
+                            "entry"
+                        } else {
+                            "entries"
+                        },
                     ))
                     .font(theme::f_reg(11.5))
                     .color(p.txt2),

--- a/crates/keyroost/src/main.rs
+++ b/crates/keyroost/src/main.rs
@@ -152,6 +152,11 @@ struct SecurityKeysState {
     subview: FidoSubview,
     /// Cached large-blob array, read on demand. `None` until first load.
     large_blobs: Option<keyroost_ctap::large_blobs::LargeBlobArray>,
+    /// Capacity snapshot computed at load/reload time (needs the device's
+    /// getInfo, which only the worker thread holds).
+    lb_capacity: Option<keyroost_ctap::large_blobs::BlobCapacity>,
+    /// Entry index awaiting an export-dialog result.
+    lb_export_idx: Option<usize>,
     /// Index of the entry currently expanded in the hex/ASCII viewer.
     lb_selected: Option<usize>,
     /// Pending "delete entry N" confirmation in the structured editor.
@@ -1304,6 +1309,9 @@ enum FileTarget {
     PivCert,
     /// PIV "Export certificate" destination (`piv.export_path`).
     PivExport,
+    /// Storage tab "Export…" destination for a large-blob entry
+    /// (`lb_export_idx` holds which entry).
+    LbExport,
 }
 
 impl App {
@@ -1377,6 +1385,32 @@ impl App {
                             FileTarget::PivCsr => self.piv.csr_path = text,
                             FileTarget::PivCert => self.piv.cert_path = text,
                             FileTarget::PivExport => self.piv.export_path = text,
+                            FileTarget::LbExport => {
+                                if let (Some(idx), Some(arr)) = (
+                                    self.security_keys.lb_export_idx.take(),
+                                    self.security_keys.large_blobs.as_ref(),
+                                ) {
+                                    if let Some(entry) = arr.entries.get(idx) {
+                                        use keyroost_ctap::large_blobs::EntryKind;
+                                        let bytes = match entry.classify() {
+                                            EntryKind::SshCert { wire, .. } => {
+                                                keyroost_ctap::ssh_cert::to_cert_pub(&wire)
+                                                    .expect("classified cert must re-encode")
+                                                    .into_bytes()
+                                            }
+                                            _ => entry.ciphertext.clone(),
+                                        };
+                                        self.security_keys.lb_status =
+                                            Some(match std::fs::write(&path, &bytes) {
+                                                Ok(()) => format!(
+                                                    "Exported entry {idx} ({} bytes) to {text}",
+                                                    bytes.len()
+                                                ),
+                                                Err(e) => format!("Export failed: {e}"),
+                                            });
+                                    }
+                                }
+                            }
                         }
                     }
                 }
@@ -4157,6 +4191,8 @@ impl App {
         self.security_keys.error = None;
         // Large-blob state is per-key; drop it so the next key auto-loads fresh.
         self.security_keys.large_blobs = None;
+        self.security_keys.lb_capacity = None;
+        self.security_keys.lb_export_idx = None;
         self.security_keys.lb_autoloaded = false;
         self.security_keys.lb_selected = None;
         self.security_keys.lb_editing = None;
@@ -7875,7 +7911,13 @@ impl App {
         let loaded = self.security_keys.large_blobs.clone();
 
         self.spawn_job("Saving to large blobs\u{2026}", move || {
-            let result = (|| -> Result<keyroost_ctap::large_blobs::LargeBlobArray, String> {
+            let result = (|| -> Result<
+                (
+                    keyroost_ctap::large_blobs::LargeBlobArray,
+                    keyroost_ctap::large_blobs::BlobCapacity,
+                ),
+                String,
+            > {
                 let (mut dev, cbor, _init) = open_fido(&target)?;
                 if !cbor {
                     return Err("device is U2F-only".into());
@@ -7902,13 +7944,17 @@ impl App {
                 keyroost_ctap::large_blobs::write(&mut dev, &info, &token, &serialized)
                     .map_err(|e| e.to_string())?;
 
-                keyroost_ctap::large_blobs::read(&mut dev, &info).map_err(|e| e.to_string())
+                let array =
+                    keyroost_ctap::large_blobs::read(&mut dev, &info).map_err(|e| e.to_string())?;
+                let cap = array.capacity(&info);
+                Ok((array, cap))
             })();
 
             Box::new(move |app: &mut App| match result {
-                Ok(array) => {
+                Ok((array, cap)) => {
                     let n = array.entries.len();
                     app.security_keys.large_blobs = Some(array);
+                    app.security_keys.lb_capacity = Some(cap);
                     app.security_keys.lb_new_text.clear();
                     app.security_keys.lb_show_add = false;
                     app.security_keys.lb_status = Some(format!(
@@ -7939,7 +7985,13 @@ impl App {
         let pin = session.pin.clone();
 
         self.spawn_job("Saving edit to large blobs\u{2026}", move || {
-            let result = (|| -> Result<keyroost_ctap::large_blobs::LargeBlobArray, String> {
+            let result = (|| -> Result<
+                (
+                    keyroost_ctap::large_blobs::LargeBlobArray,
+                    keyroost_ctap::large_blobs::BlobCapacity,
+                ),
+                String,
+            > {
                 let (mut dev, cbor, _init) = open_fido(&target)?;
                 if !cbor {
                     return Err("device is U2F-only".into());
@@ -7967,12 +8019,16 @@ impl App {
                 keyroost_ctap::large_blobs::write(&mut dev, &info, &token, &serialized)
                     .map_err(|e| e.to_string())?;
 
-                keyroost_ctap::large_blobs::read(&mut dev, &info).map_err(|e| e.to_string())
+                let array =
+                    keyroost_ctap::large_blobs::read(&mut dev, &info).map_err(|e| e.to_string())?;
+                let cap = array.capacity(&info);
+                Ok((array, cap))
             })();
 
             Box::new(move |app: &mut App| match result {
-                Ok(array) => {
+                Ok((array, cap)) => {
                     app.security_keys.large_blobs = Some(array);
+                    app.security_keys.lb_capacity = Some(cap);
                     app.security_keys.lb_editing = None;
                     app.security_keys.lb_edit_text.clear();
                     app.security_keys.lb_status = Some("Note updated.".into());
@@ -7992,18 +8048,28 @@ impl App {
             self.security_keys.lb_status = Some("No FIDO key selected.".into());
             return;
         };
-        let result = (|| -> Result<keyroost_ctap::large_blobs::LargeBlobArray, String> {
+        let result = (|| -> Result<
+            (
+                keyroost_ctap::large_blobs::LargeBlobArray,
+                keyroost_ctap::large_blobs::BlobCapacity,
+            ),
+            String,
+        > {
             let (mut dev, cbor, _init) = open_fido(&target)?;
             if !cbor {
                 return Err("device is U2F-only".into());
             }
             let info = keyroost_ctap::get_info(&mut dev).map_err(|e| e.to_string())?;
-            keyroost_ctap::large_blobs::read(&mut dev, &info).map_err(|e| e.to_string())
+            let array =
+                keyroost_ctap::large_blobs::read(&mut dev, &info).map_err(|e| e.to_string())?;
+            let cap = array.capacity(&info);
+            Ok((array, cap))
         })();
         match result {
-            Ok(array) => {
+            Ok((array, cap)) => {
                 let n = array.entries.len();
                 self.security_keys.large_blobs = Some(array);
+                self.security_keys.lb_capacity = Some(cap);
                 self.security_keys.lb_selected = None;
                 self.security_keys.lb_status = Some(format!(
                     "Loaded {n} entr{}.",
@@ -8045,7 +8111,13 @@ impl App {
         let target_entry = array.entries[idx].clone();
 
         self.spawn_job("Updating large blobs\u{2026}", move || {
-            let result = (|| -> Result<keyroost_ctap::large_blobs::LargeBlobArray, String> {
+            let result = (|| -> Result<
+                (
+                    keyroost_ctap::large_blobs::LargeBlobArray,
+                    keyroost_ctap::large_blobs::BlobCapacity,
+                ),
+                String,
+            > {
                 let (mut dev, cbor, _init) = open_fido(&target)?;
                 if !cbor {
                     return Err("device is U2F-only".into());
@@ -8081,13 +8153,17 @@ impl App {
                     .map_err(|e| e.to_string())?;
 
                 // Read back so the view reflects the authenticator's actual state.
-                keyroost_ctap::large_blobs::read(&mut dev, &info).map_err(|e| e.to_string())
+                let array =
+                    keyroost_ctap::large_blobs::read(&mut dev, &info).map_err(|e| e.to_string())?;
+                let cap = array.capacity(&info);
+                Ok((array, cap))
             })();
 
             Box::new(move |app: &mut App| match result {
-                Ok(array) => {
+                Ok((array, cap)) => {
                     let n = array.entries.len();
                     app.security_keys.large_blobs = Some(array);
+                    app.security_keys.lb_capacity = Some(cap);
                     app.security_keys.lb_selected = None;
                     app.security_keys.lb_status = Some(format!("Entry deleted. {n} remaining."));
                     app.security_keys.error = None;
@@ -8124,7 +8200,13 @@ impl App {
         let new_entries = Vec::new();
 
         self.spawn_job("Clearing large blobs\u{2026}", move || {
-            let result = (|| -> Result<keyroost_ctap::large_blobs::LargeBlobArray, String> {
+            let result = (|| -> Result<
+                (
+                    keyroost_ctap::large_blobs::LargeBlobArray,
+                    keyroost_ctap::large_blobs::BlobCapacity,
+                ),
+                String,
+            > {
                 let (mut dev, cbor, _init) = open_fido(&target)?;
                 if !cbor {
                     return Err("device is U2F-only".into());
@@ -8147,13 +8229,17 @@ impl App {
                     .map_err(|e| e.to_string())?;
 
                 // Read back so the view reflects the authenticator's actual state.
-                keyroost_ctap::large_blobs::read(&mut dev, &info).map_err(|e| e.to_string())
+                let array =
+                    keyroost_ctap::large_blobs::read(&mut dev, &info).map_err(|e| e.to_string())?;
+                let cap = array.capacity(&info);
+                Ok((array, cap))
             })();
 
             Box::new(move |app: &mut App| match result {
-                Ok(array) => {
+                Ok((array, cap)) => {
                     let n = array.entries.len();
                     app.security_keys.large_blobs = Some(array);
+                    app.security_keys.lb_capacity = Some(cap);
                     app.security_keys.lb_selected = None;
                     app.security_keys.lb_status =
                         Some(format!("Storage cleared. {n} entries remaining."));
@@ -8242,6 +8328,35 @@ impl App {
             .color(p.txt3),
         );
 
+        if let Some(cap) = self.security_keys.lb_capacity {
+            ui.add_space(8.0);
+            let frac = if cap.max_bytes == 0 {
+                0.0
+            } else {
+                (cap.used_bytes as f32 / cap.max_bytes as f32).clamp(0.0, 1.0)
+            };
+            ui.horizontal(|ui| {
+                ui.add(
+                    egui::ProgressBar::new(frac)
+                        .desired_width(160.0)
+                        .desired_height(8.0),
+                );
+                ui.add_space(8.0);
+                ui.label(
+                    egui::RichText::new(format!(
+                        "{} of {} bytes used \u{00b7} {} free \u{00b7} {} {}",
+                        cap.used_bytes,
+                        cap.max_bytes,
+                        cap.free_bytes,
+                        cap.entry_count,
+                        if cap.entry_count == 1 { "entry" } else { "entries" },
+                    ))
+                    .font(theme::f_reg(11.5))
+                    .color(p.txt2),
+                );
+            });
+        }
+
         if let Some(status) = &self.security_keys.lb_status {
             ui.add_space(6.0);
             ui.label(
@@ -8325,7 +8440,12 @@ impl App {
         let editing = self.security_keys.lb_editing;
         for (idx, entry) in array.entries.iter().enumerate() {
             theme::card_frame(p).show(ui, |ui| {
-                let note_text = entry.as_text();
+                use keyroost_ctap::large_blobs::EntryKind;
+                let classification = entry.classify();
+                let note_text = match &classification {
+                    EntryKind::Note(text) => Some(text.clone()),
+                    _ => None,
+                };
                 ui.horizontal(|ui| {
                     let title = if note_text.is_some() {
                         format!("Note {}", idx + 1)
@@ -8338,15 +8458,18 @@ impl App {
                             .color(p.txt),
                     );
                     ui.add_space(8.0);
-                    let meta = if note_text.is_some() {
-                        "keyroost text note".to_string()
-                    } else {
-                        format!(
+                    let meta = match &classification {
+                        EntryKind::Note(_) => "keyroost text note".to_string(),
+                        EntryKind::SshCert { .. } => format!(
+                            "ssh-cert \u{00b7} {} bytes \u{00b7} relying-party data",
+                            entry.ciphertext.len(),
+                        ),
+                        EntryKind::Opaque => format!(
                             "{} bytes ciphertext \u{00b7} {}-byte nonce \u{00b7} origSize {} \u{00b7} relying-party data",
                             entry.ciphertext.len(),
                             entry.nonce.len(),
                             entry.orig_size,
-                        )
+                        ),
                     };
                     ui.label(
                         egui::RichText::new(meta)
@@ -8370,10 +8493,31 @@ impl App {
                         {
                             start_edit = Some((idx, note_text.clone().unwrap_or_default()));
                         }
+                        // Export is read-only, so it's always available
+                        // regardless of session lock state.
+                        if theme::button(ui, p, BtnKind::Ghost, "Export\u{2026}").clicked() {
+                            self.security_keys.lb_export_idx = Some(idx);
+                            let is_cert =
+                                matches!(classification, EntryKind::SshCert { .. });
+                            let default_name = if is_cert {
+                                format!("entry-{idx}-cert.pub")
+                            } else {
+                                format!("large-blob-entry-{idx}.bin")
+                            };
+                            self.spawn_file_dialog(
+                                FileTarget::LbExport,
+                                true,
+                                &[("All files", &["*"])],
+                                Some(&default_name),
+                            );
+                        }
                     });
                 });
                 // keyroost notes: inline editor when editing this entry, else
-                // the decoded text read-only.
+                // the decoded text read-only. SSH certificates get a parsed
+                // field-by-field view; anything else (opaque RP data) shows
+                // nothing extra here — its bytes remain available via "View
+                // bytes" below.
                 if editing == Some(idx) {
                     ui.add_space(6.0);
                     ui.add(
@@ -8410,6 +8554,63 @@ impl App {
                             .font(theme::f_reg(12.5))
                             .color(p.txt),
                     );
+                } else if let EntryKind::SshCert { info, .. } = &classification {
+                    ui.add_space(6.0);
+                    egui::Grid::new(format!("lb_cert_{idx}"))
+                        .num_columns(2)
+                        .spacing([12.0, 2.0])
+                        .show(ui, |ui| {
+                            let row = |ui: &mut egui::Ui, k: &str, v: String| {
+                                ui.label(
+                                    egui::RichText::new(k).font(theme::f_reg(11.5)).color(p.txt3),
+                                );
+                                ui.label(
+                                    egui::RichText::new(v).font(theme::f_reg(11.5)).color(p.txt),
+                                );
+                                ui.end_row();
+                            };
+                            let kind = if info.cert_type
+                                == keyroost_ctap::ssh_cert::CERT_TYPE_USER
+                            {
+                                "user"
+                            } else {
+                                "host"
+                            };
+                            row(ui, "Type", format!("{} ({kind})", info.key_type));
+                            row(ui, "Key ID", info.key_id.clone());
+                            row(ui, "Serial", info.serial.to_string());
+                            row(
+                                ui,
+                                "Principals",
+                                if info.principals.is_empty() {
+                                    "(any)".to_string()
+                                } else {
+                                    info.principals.join(", ")
+                                },
+                            );
+                            row(
+                                ui,
+                                "Valid",
+                                keyroost_ctap::ssh_cert::format_validity(
+                                    info.valid_after,
+                                    info.valid_before,
+                                ),
+                            );
+                            for (n, v) in &info.critical_options {
+                                row(
+                                    ui,
+                                    "Critical",
+                                    if v.is_empty() {
+                                        n.clone()
+                                    } else {
+                                        format!("{n}={v}")
+                                    },
+                                );
+                            }
+                            for ext in &info.extensions {
+                                row(ui, "Extension", ext.clone());
+                            }
+                        });
                 }
                 if selected == Some(idx) {
                     ui.add_space(8.0);

--- a/crates/keyroost/src/main.rs
+++ b/crates/keyroost/src/main.rs
@@ -155,8 +155,6 @@ struct SecurityKeysState {
     /// Capacity snapshot computed at load/reload time (needs the device's
     /// getInfo, which only the worker thread holds).
     lb_capacity: Option<keyroost_ctap::large_blobs::BlobCapacity>,
-    /// Entry index awaiting an export-dialog result.
-    lb_export_idx: Option<usize>,
     /// Index of the entry currently expanded in the hex/ASCII viewer.
     lb_selected: Option<usize>,
     /// Pending "delete entry N" confirmation in the structured editor.
@@ -1309,9 +1307,10 @@ enum FileTarget {
     PivCert,
     /// PIV "Export certificate" destination (`piv.export_path`).
     PivExport,
-    /// Storage tab "Export…" destination for a large-blob entry
-    /// (`lb_export_idx` holds which entry).
-    LbExport,
+    /// Storage tab "Export…" destination for a large-blob entry. Carries the
+    /// entry index so a second Export click (or a cancelled dialog) can never
+    /// mismatch which entry a resolving dialog belongs to.
+    LbExport(usize),
 }
 
 impl App {
@@ -1385,31 +1384,43 @@ impl App {
                             FileTarget::PivCsr => self.piv.csr_path = text,
                             FileTarget::PivCert => self.piv.cert_path = text,
                             FileTarget::PivExport => self.piv.export_path = text,
-                            FileTarget::LbExport => {
-                                if let (Some(idx), Some(arr)) = (
-                                    self.security_keys.lb_export_idx.take(),
-                                    self.security_keys.large_blobs.as_ref(),
-                                ) {
-                                    if let Some(entry) = arr.entries.get(idx) {
-                                        use keyroost_ctap::large_blobs::EntryKind;
+                            FileTarget::LbExport(idx) => {
+                                use keyroost_ctap::large_blobs::EntryKind;
+                                // The array may have been reloaded, cleared, or
+                                // shrunk between the Export click and the dialog
+                                // resolving — fail loudly instead of writing the
+                                // wrong entry or silently doing nothing.
+                                let entry = self
+                                    .security_keys
+                                    .large_blobs
+                                    .as_ref()
+                                    .and_then(|arr| arr.entries.get(idx));
+                                self.security_keys.lb_status = Some(match entry {
+                                    None => {
+                                        format!("Export failed: entry {idx} no longer exists")
+                                    }
+                                    Some(entry) => {
                                         let bytes = match entry.classify() {
                                             EntryKind::SshCert { wire, .. } => {
                                                 keyroost_ctap::ssh_cert::to_cert_pub(&wire)
-                                                    .expect("classified cert must re-encode")
-                                                    .into_bytes()
+                                                    .map(String::into_bytes)
                                             }
-                                            _ => entry.ciphertext.clone(),
+                                            _ => Some(entry.ciphertext.clone()),
                                         };
-                                        self.security_keys.lb_status =
-                                            Some(match std::fs::write(&path, &bytes) {
+                                        match bytes {
+                                            None => "Export failed: could not re-encode \
+                                                     certificate"
+                                                .into(),
+                                            Some(bytes) => match std::fs::write(&path, &bytes) {
                                                 Ok(()) => format!(
                                                     "Exported entry {idx} ({} bytes) to {text}",
                                                     bytes.len()
                                                 ),
                                                 Err(e) => format!("Export failed: {e}"),
-                                            });
+                                            },
+                                        }
                                     }
-                                }
+                                });
                             }
                         }
                     }
@@ -4192,7 +4203,6 @@ impl App {
         // Large-blob state is per-key; drop it so the next key auto-loads fresh.
         self.security_keys.large_blobs = None;
         self.security_keys.lb_capacity = None;
-        self.security_keys.lb_export_idx = None;
         self.security_keys.lb_autoloaded = false;
         self.security_keys.lb_selected = None;
         self.security_keys.lb_editing = None;
@@ -8496,7 +8506,6 @@ impl App {
                         // Export is read-only, so it's always available
                         // regardless of session lock state.
                         if theme::button(ui, p, BtnKind::Ghost, "Export\u{2026}").clicked() {
-                            self.security_keys.lb_export_idx = Some(idx);
                             let is_cert =
                                 matches!(classification, EntryKind::SshCert { .. });
                             let default_name = if is_cert {
@@ -8505,7 +8514,7 @@ impl App {
                                 format!("large-blob-entry-{idx}.bin")
                             };
                             self.spawn_file_dialog(
-                                FileTarget::LbExport,
+                                FileTarget::LbExport(idx),
                                 true,
                                 &[("All files", &["*"])],
                                 Some(&default_name),

--- a/crates/keyroost/src/ui/help.rs
+++ b/crates/keyroost/src/ui/help.rs
@@ -149,7 +149,7 @@ pub fn help(topic: &str) -> Option<&'static Help> {
         },
         "large_blobs" => &Help {
             title: "Large blob storage",
-            body: "A key-global area where relying parties store opaque, RP-encrypted data (e.g. SSH certificates). Anyone holding the key can read it, so it is not a place for plaintext secrets. keyroost shows each stored entry as hex and ASCII; you can also keep your own plaintext notes here (add, edit, delete). Writing rewrites the whole array with a fresh checksum and needs your PIN.",
+            body: "A key-global area where relying parties store opaque, RP-encrypted data (e.g. SSH certificates). Anyone holding the key can read it, so it is not a place for plaintext secrets. keyroost shows each stored entry as hex and ASCII; you can also keep your own plaintext notes here (add, edit, delete). Writing rewrites the whole array with a fresh checksum and needs your PIN. keyroost recognizes its own notes and OpenSSH certificates and shows a capacity meter; anything else is relying-party data, displayed raw and never modified. Any entry can be exported to a file.",
             slug: "/storage",
         },
         _ => return None,

--- a/crates/keyroostctl/src/main.rs
+++ b/crates/keyroostctl/src/main.rs
@@ -5198,8 +5198,8 @@ fn run_fido_large_blob_list(
                 "[{}] {} bytes  ssh-cert  {} ({})",
                 i,
                 e.orig_size,
-                info.key_id,
-                info.principals.join(",")
+                sanitize_cert_field(&info.key_id),
+                sanitize_cert_field(&info.principals.join(","))
             ),
             EntryKind::Opaque => println!(
                 "[{}] {} bytes  opaque    {}",
@@ -5253,21 +5253,21 @@ fn run_fido_large_blob_get(
             );
             println!(
                 "  Type:        {} ({})",
-                info.key_type,
+                sanitize_cert_field(&info.key_type),
                 if info.cert_type == keyroost_ctap::ssh_cert::CERT_TYPE_USER {
                     "user"
                 } else {
                     "host"
                 }
             );
-            println!("  Key ID:      {}", info.key_id);
+            println!("  Key ID:      {}", sanitize_cert_field(&info.key_id));
             println!("  Serial:      {}", info.serial);
             println!(
                 "  Principals:  {}",
                 if info.principals.is_empty() {
                     "(any)".to_string()
                 } else {
-                    info.principals.join(", ")
+                    sanitize_cert_field(&info.principals.join(", "))
                 }
             );
             println!(
@@ -5275,14 +5275,16 @@ fn run_fido_large_blob_get(
                 keyroost_ctap::ssh_cert::format_validity(info.valid_after, info.valid_before)
             );
             for (n, v) in &info.critical_options {
+                let n = sanitize_cert_field(n);
                 if v.is_empty() {
                     println!("  Critical:    {n}");
                 } else {
+                    let v = sanitize_cert_field(v);
                     println!("  Critical:    {n}={v}");
                 }
             }
             for ext in &info.extensions {
-                println!("  Extension:   {ext}");
+                println!("  Extension:   {}", sanitize_cert_field(ext));
             }
             println!("\nExport with: keyroostctl fido large-blob export {index} <FILE> --as-cert");
         }
@@ -5313,7 +5315,7 @@ fn run_fido_large_blob_export(
     let bytes: Vec<u8> = if as_cert {
         match entry.classify() {
             EntryKind::SshCert { wire, .. } => keyroost_ctap::ssh_cert::to_cert_pub(&wire)
-                .expect("classified cert must re-encode")
+                .ok_or("could not re-encode certificate")?
                 .into_bytes(),
             _ => {
                 return Err(format!(
@@ -5471,6 +5473,13 @@ fn large_blob_bad_index(index: usize, len: usize) -> Box<dyn std::error::Error> 
     } else {
         format!("no entry {} — valid indices are 0..={}", index, len - 1).into()
     }
+}
+
+/// Flatten control characters out of an attacker-suppliable certificate
+/// string (key IDs, principals, options come from unverified cert bytes)
+/// so a hostile entry cannot inject terminal escape sequences.
+fn sanitize_cert_field(s: &str) -> String {
+    s.chars().map(|c| if c.is_control() { ' ' } else { c }).collect()
 }
 
 /// A short, single-line preview of a note's text for the `list` view.

--- a/crates/keyroostctl/src/main.rs
+++ b/crates/keyroostctl/src/main.rs
@@ -5081,6 +5081,9 @@ fn open_and_read_large_blobs(
         return Err("device is U2F-only; CTAP2 large blobs not supported".into());
     }
     let info = keyroost_ctap::get_info(&mut dev)?;
+    if info.option("largeBlobs") != Some(true) {
+        return Err("this key does not support the FIDO2 large-blob store".into());
+    }
     let array = keyroost_ctap::large_blobs::read(&mut dev, &info)?;
     Ok((dev, info, array))
 }

--- a/crates/keyroostctl/src/main.rs
+++ b/crates/keyroostctl/src/main.rs
@@ -247,6 +247,33 @@ mod json_out {
     #[derive(Serialize)]
     pub struct FidoLargeBlobListJson {
         pub entries: Vec<FidoLargeBlobEntryJson>,
+        pub capacity: FidoLargeBlobCapacityJson,
+    }
+
+    /// Space accounting for the whole array (serialized form incl. checksum).
+    #[derive(Serialize)]
+    pub struct FidoLargeBlobCapacityJson {
+        pub max_bytes: u64,
+        pub used_bytes: u64,
+        pub free_bytes: u64,
+    }
+
+    /// Decoded fields of a recognized OpenSSH certificate entry.
+    #[derive(Serialize)]
+    pub struct FidoLargeBlobSshCertJson {
+        pub key_type: String,
+        pub serial: u64,
+        /// "user" or "host".
+        pub cert_type: &'static str,
+        pub key_id: String,
+        pub principals: Vec<String>,
+        pub valid_after: u64,
+        pub valid_before: u64,
+        /// Human validity window, e.g. "2026-01-01 00:00:00 UTC to …".
+        pub validity: String,
+        /// "name=value" (or bare "name") per critical option.
+        pub critical_options: Vec<String>,
+        pub extensions: Vec<String>,
     }
 
     /// One large-blob array entry as the `list` view renders it.
@@ -261,6 +288,10 @@ mod json_out {
         /// The note text when `is_note`; `null` for opaque entries.
         #[serde(skip_serializing_if = "Option::is_none")]
         pub text: Option<String>,
+        /// Entry classification: "note", "ssh-cert", or "opaque".
+        pub kind: &'static str,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub ssh_cert: Option<FidoLargeBlobSshCertJson>,
     }
 
     /// `keyroostctl fido large-blob --json get <INDEX>` — a single entry in full.
@@ -271,6 +302,10 @@ mod json_out {
         pub is_note: bool,
         #[serde(skip_serializing_if = "Option::is_none")]
         pub text: Option<String>,
+        /// Entry classification: "note", "ssh-cert", or "opaque".
+        pub kind: &'static str,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub ssh_cert: Option<FidoLargeBlobSshCertJson>,
         /// Hex of the raw ciphertext bytes (the note magic + UTF-8 for a note, or
         /// the RP's AEAD ciphertext for an opaque entry).
         pub hex: String,
@@ -1677,6 +1712,22 @@ enum LargeBlobCmd {
         pin_env: Option<String>,
         #[arg(long)]
         pin_stdin: bool,
+        #[arg(long, value_name = "PATH")]
+        path: Option<std::path::PathBuf>,
+    },
+    /// Save one entry's bytes to a file (read-only; no PIN needed).
+    ///
+    /// By default writes the entry's raw stored bytes. With --as-cert, a
+    /// recognized OpenSSH certificate entry is written as a `-cert.pub` text
+    /// line instead (the format `ssh` and `ssh-keygen` consume).
+    Export {
+        /// Zero-based entry index as printed by `large-blob list`.
+        index: usize,
+        /// Destination file (overwritten if it exists).
+        output: std::path::PathBuf,
+        /// Write a recognized SSH certificate in `-cert.pub` text form.
+        #[arg(long)]
+        as_cert: bool,
         #[arg(long, value_name = "PATH")]
         path: Option<std::path::PathBuf>,
     },
@@ -4993,6 +5044,12 @@ fn run_fido_large_blob(cmd: &LargeBlobCmd) -> Result<(), Box<dyn std::error::Err
             let pin = read_secret("PIN", pin_env.as_deref(), *pin_stdin)?;
             run_fido_large_blob_delete(path.as_deref(), &pin, *index, *yes)
         }
+        LargeBlobCmd::Export {
+            index,
+            output,
+            as_cert,
+            path,
+        } => run_fido_large_blob_export(path.as_deref(), *index, output, *as_cert),
         LargeBlobCmd::Clear {
             yes,
             pin_env,
@@ -5028,53 +5085,136 @@ fn open_and_read_large_blobs(
     Ok((dev, info, array))
 }
 
+/// Classification results shaped for both the human and JSON views.
+fn large_blob_kind(
+    entry: &keyroost_ctap::large_blobs::LargeBlobEntry,
+) -> (
+    &'static str,
+    Option<json_out::FidoLargeBlobSshCertJson>,
+    keyroost_ctap::large_blobs::EntryKind,
+) {
+    use keyroost_ctap::large_blobs::EntryKind;
+    let kind = entry.classify();
+    match &kind {
+        EntryKind::Note(_) => ("note", None, kind),
+        EntryKind::Opaque => ("opaque", None, kind),
+        EntryKind::SshCert { info, .. } => {
+            let cert = json_out::FidoLargeBlobSshCertJson {
+                key_type: info.key_type.clone(),
+                serial: info.serial,
+                cert_type: if info.cert_type == keyroost_ctap::ssh_cert::CERT_TYPE_USER {
+                    "user"
+                } else {
+                    "host"
+                },
+                key_id: info.key_id.clone(),
+                principals: info.principals.clone(),
+                valid_after: info.valid_after,
+                valid_before: info.valid_before,
+                validity: keyroost_ctap::ssh_cert::format_validity(
+                    info.valid_after,
+                    info.valid_before,
+                ),
+                critical_options: info
+                    .critical_options
+                    .iter()
+                    .map(|(n, v)| {
+                        if v.is_empty() {
+                            n.clone()
+                        } else {
+                            format!("{n}={v}")
+                        }
+                    })
+                    .collect(),
+                extensions: info.extensions.clone(),
+            };
+            ("ssh-cert", Some(cert), kind)
+        }
+    }
+}
+
 /// Shape a parsed large-blob array into the JSON `list` view.
 fn large_blob_list_json(
     array: &keyroost_ctap::large_blobs::LargeBlobArray,
+    info: &keyroost_ctap::AuthenticatorInfo,
 ) -> json_out::FidoLargeBlobListJson {
     let entries = array
         .entries
         .iter()
         .enumerate()
-        .map(|(index, e)| json_out::FidoLargeBlobEntryJson {
-            index,
-            size: e.orig_size,
-            is_note: e.is_kr_note(),
-            text: e.as_text(),
+        .map(|(index, e)| {
+            let (kind, ssh_cert, _) = large_blob_kind(e);
+            json_out::FidoLargeBlobEntryJson {
+                index,
+                size: e.orig_size,
+                is_note: e.is_kr_note(),
+                text: e.as_text(),
+                kind,
+                ssh_cert,
+            }
         })
         .collect();
-    json_out::FidoLargeBlobListJson { entries }
+    let cap = array.capacity(info);
+    json_out::FidoLargeBlobListJson {
+        entries,
+        capacity: json_out::FidoLargeBlobCapacityJson {
+            max_bytes: cap.max_bytes,
+            used_bytes: cap.used_bytes,
+            free_bytes: cap.free_bytes,
+        },
+    }
 }
 
 fn run_fido_large_blob_list(
     path: Option<&std::path::Path>,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let (_dev, _info, array) = open_and_read_large_blobs(path)?;
+    let (_dev, info, array) = open_and_read_large_blobs(path)?;
     if json_output() {
-        emit_json(&large_blob_list_json(&array))?;
+        emit_json(&large_blob_list_json(&array, &info))?;
         return Ok(());
     }
     if array.entries.is_empty() {
         println!("(large-blob array is empty)");
+        let cap = array.capacity(&info);
+        println!();
+        println!(
+            "Capacity: {} of {} bytes used, {} free",
+            cap.used_bytes, cap.max_bytes, cap.free_bytes
+        );
         return Ok(());
     }
     for (i, e) in array.entries.iter().enumerate() {
-        if let Some(text) = e.as_text() {
-            println!(
-                "[{}] {} bytes  note      {}",
+        use keyroost_ctap::large_blobs::EntryKind;
+        match e.classify() {
+            EntryKind::Note(text) => {
+                println!(
+                    "[{}] {} bytes  note      {}",
+                    i,
+                    e.orig_size,
+                    preview_note(&text)
+                )
+            }
+            EntryKind::SshCert { info, .. } => println!(
+                "[{}] {} bytes  ssh-cert  {} ({})",
                 i,
                 e.orig_size,
-                preview_note(&text)
-            );
-        } else {
-            println!(
+                info.key_id,
+                info.principals.join(",")
+            ),
+            EntryKind::Opaque => println!(
                 "[{}] {} bytes  opaque    {}",
                 i,
                 e.orig_size,
                 preview_opaque(&e.ciphertext)
-            );
+            ),
         }
     }
+    let cap = array.capacity(&info);
+    println!();
+    println!(
+        "Capacity: {} of {} bytes used, {} free",
+        cap.used_bytes, cap.max_bytes, cap.free_bytes
+    );
     Ok(())
 }
 
@@ -5087,27 +5227,106 @@ fn run_fido_large_blob_get(
         .entries
         .get(index)
         .ok_or_else(|| large_blob_bad_index(index, array.entries.len()))?;
+    let (kind, ssh_cert, classified) = large_blob_kind(entry);
     if json_output() {
         emit_json(&json_out::FidoLargeBlobGetJson {
             index,
             size: entry.orig_size,
             is_note: entry.is_kr_note(),
             text: entry.as_text(),
+            kind,
+            ssh_cert,
             hex: hex_encode(&entry.ciphertext),
         })?;
         return Ok(());
     }
-    if let Some(text) = entry.as_text() {
-        println!("Entry {}: keyroost note, {} bytes", index, entry.orig_size);
-        println!("{}", text);
-    } else {
-        println!(
-            "Entry {}: opaque (RP-encrypted), {} bytes",
-            index, entry.orig_size
-        );
-        println!();
-        print!("{}", hex_ascii_dump(&entry.ciphertext));
+    use keyroost_ctap::large_blobs::EntryKind;
+    match classified {
+        EntryKind::Note(text) => {
+            println!("Entry {}: keyroost note, {} bytes", index, entry.orig_size);
+            println!("{}", text);
+        }
+        EntryKind::SshCert { info, .. } => {
+            println!(
+                "Entry {}: OpenSSH certificate, {} bytes",
+                index, entry.orig_size
+            );
+            println!(
+                "  Type:        {} ({})",
+                info.key_type,
+                if info.cert_type == keyroost_ctap::ssh_cert::CERT_TYPE_USER {
+                    "user"
+                } else {
+                    "host"
+                }
+            );
+            println!("  Key ID:      {}", info.key_id);
+            println!("  Serial:      {}", info.serial);
+            println!(
+                "  Principals:  {}",
+                if info.principals.is_empty() {
+                    "(any)".to_string()
+                } else {
+                    info.principals.join(", ")
+                }
+            );
+            println!(
+                "  Valid:       {}",
+                keyroost_ctap::ssh_cert::format_validity(info.valid_after, info.valid_before)
+            );
+            for (n, v) in &info.critical_options {
+                if v.is_empty() {
+                    println!("  Critical:    {n}");
+                } else {
+                    println!("  Critical:    {n}={v}");
+                }
+            }
+            for ext in &info.extensions {
+                println!("  Extension:   {ext}");
+            }
+            println!("\nExport with: keyroostctl fido large-blob export {index} <FILE> --as-cert");
+        }
+        EntryKind::Opaque => {
+            println!(
+                "Entry {}: opaque (RP-encrypted), {} bytes",
+                index, entry.orig_size
+            );
+            println!();
+            print!("{}", hex_ascii_dump(&entry.ciphertext));
+        }
     }
+    Ok(())
+}
+
+fn run_fido_large_blob_export(
+    path: Option<&std::path::Path>,
+    index: usize,
+    output: &std::path::Path,
+    as_cert: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    use keyroost_ctap::large_blobs::EntryKind;
+    let (_dev, _info, array) = open_and_read_large_blobs(path)?;
+    let entry = array
+        .entries
+        .get(index)
+        .ok_or_else(|| large_blob_bad_index(index, array.entries.len()))?;
+    let bytes: Vec<u8> = if as_cert {
+        match entry.classify() {
+            EntryKind::SshCert { wire, .. } => keyroost_ctap::ssh_cert::to_cert_pub(&wire)
+                .expect("classified cert must re-encode")
+                .into_bytes(),
+            _ => {
+                return Err(format!(
+                "entry {index} is not a recognized SSH certificate; drop --as-cert to export raw bytes"
+            )
+                .into())
+            }
+        }
+    } else {
+        entry.ciphertext.clone()
+    };
+    std::fs::write(output, &bytes)?;
+    println!("Wrote {} bytes to {}", bytes.len(), output.display());
     Ok(())
 }
 
@@ -6503,7 +6722,8 @@ mod cli_tests {
             entries: vec![LargeBlobEntry::from_text("hello"), opaque_entry()],
             raw_array: Vec::new(),
         };
-        let shaped = large_blob_list_json(&array);
+        let info = keyroost_ctap::AuthenticatorInfo::default();
+        let shaped = large_blob_list_json(&array, &info);
         assert_eq!(shaped.entries.len(), 2);
 
         // [0] is a keyroost note: is_note true, text present, size == byte len.
@@ -6511,11 +6731,25 @@ mod cli_tests {
         assert!(shaped.entries[0].is_note);
         assert_eq!(shaped.entries[0].text.as_deref(), Some("hello"));
         assert_eq!(shaped.entries[0].size, "hello".len() as u64);
+        assert_eq!(shaped.entries[0].kind, "note");
+        assert!(shaped.entries[0].ssh_cert.is_none());
 
         // [1] is opaque: is_note false, text omitted.
         assert_eq!(shaped.entries[1].index, 1);
         assert!(!shaped.entries[1].is_note);
         assert!(shaped.entries[1].text.is_none());
+        assert_eq!(shaped.entries[1].kind, "opaque");
+        assert!(shaped.entries[1].ssh_cert.is_none());
+
+        // The array's capacity is computed against the given AuthenticatorInfo
+        // (spec-minimum 1024 bytes here, since max_serialized_large_blob_array
+        // is unset).
+        assert_eq!(shaped.capacity.max_bytes, 1024);
+        assert!(shaped.capacity.used_bytes > 0);
+        assert_eq!(
+            shaped.capacity.free_bytes,
+            shaped.capacity.max_bytes - shaped.capacity.used_bytes
+        );
 
         // The opaque entry's text is omitted from the JSON (skip_serializing_if).
         let s = serde_json::to_string(&shaped).unwrap();
@@ -6523,22 +6757,27 @@ mod cli_tests {
         let arr = v.get("entries").unwrap().as_array().unwrap();
         assert!(arr[0].get("text").is_some());
         assert!(arr[1].get("text").is_none());
+        assert!(arr[0].get("ssh_cert").is_none());
     }
 
     #[test]
     fn large_blob_get_json_carries_hex_for_opaque() {
         let entry = opaque_entry();
+        let (kind, ssh_cert, _) = large_blob_kind(&entry);
         let g = json_out::FidoLargeBlobGetJson {
             index: 0,
             size: entry.orig_size,
             is_note: entry.is_kr_note(),
             text: entry.as_text(),
+            kind,
+            ssh_cert,
             hex: hex_encode(&entry.ciphertext),
         };
         assert!(!g.is_note);
         assert!(g.text.is_none());
+        assert_eq!(g.kind, "opaque");
         assert_eq!(g.hex, "deadbeef0099");
-        assert_json_has_keys(&g, &["index", "size", "is_note", "hex"]);
+        assert_json_has_keys(&g, &["index", "size", "is_note", "kind", "hex"]);
         // text omitted for an opaque entry.
         let s = serde_json::to_string(&g).unwrap();
         assert!(!s.contains("\"text\""), "text should be omitted: {s}");
@@ -6547,17 +6786,44 @@ mod cli_tests {
     #[test]
     fn large_blob_get_json_includes_note_text() {
         let entry = LargeBlobEntry::from_text("a note");
+        let (kind, ssh_cert, _) = large_blob_kind(&entry);
         let g = json_out::FidoLargeBlobGetJson {
             index: 3,
             size: entry.orig_size,
             is_note: entry.is_kr_note(),
             text: entry.as_text(),
+            kind,
+            ssh_cert,
             hex: hex_encode(&entry.ciphertext),
         };
         assert!(g.is_note);
+        assert_eq!(g.kind, "note");
         assert_eq!(g.text.as_deref(), Some("a note"));
         let s = serde_json::to_string(&g).unwrap();
         assert!(s.contains("\"text\":\"a note\""), "{s}");
+    }
+
+    #[test]
+    fn large_blob_kind_classifies_note_and_opaque() {
+        // Note entries classify as "note" with no ssh_cert payload.
+        let note = LargeBlobEntry::from_text("hello");
+        let (kind, ssh_cert, classified) = large_blob_kind(&note);
+        assert_eq!(kind, "note");
+        assert!(ssh_cert.is_none());
+        assert!(matches!(
+            classified,
+            keyroost_ctap::large_blobs::EntryKind::Note(t) if t == "hello"
+        ));
+
+        // Unrecognized bytes classify as "opaque" with no ssh_cert payload.
+        let opaque = opaque_entry();
+        let (kind, ssh_cert, classified) = large_blob_kind(&opaque);
+        assert_eq!(kind, "opaque");
+        assert!(ssh_cert.is_none());
+        assert!(matches!(
+            classified,
+            keyroost_ctap::large_blobs::EntryKind::Opaque
+        ));
     }
 
     #[test]
@@ -6604,5 +6870,24 @@ mod cli_tests {
         assert!(parse(&["keyroostctl", "fido", "large-blob", "edit", "1", "new"]).is_ok());
         assert!(parse(&["keyroostctl", "fido", "large-blob", "delete", "2", "--yes"]).is_ok());
         assert!(parse(&["keyroostctl", "fido", "large-blob", "clear", "--yes"]).is_ok());
+        assert!(parse(&[
+            "keyroostctl",
+            "fido",
+            "large-blob",
+            "export",
+            "0",
+            "/tmp/out.bin"
+        ])
+        .is_ok());
+        assert!(parse(&[
+            "keyroostctl",
+            "fido",
+            "large-blob",
+            "export",
+            "0",
+            "/tmp/out-cert.pub",
+            "--as-cert"
+        ])
+        .is_ok());
     }
 }

--- a/crates/keyroostctl/src/main.rs
+++ b/crates/keyroostctl/src/main.rs
@@ -5482,7 +5482,9 @@ fn large_blob_bad_index(index: usize, len: usize) -> Box<dyn std::error::Error> 
 /// string (key IDs, principals, options come from unverified cert bytes)
 /// so a hostile entry cannot inject terminal escape sequences.
 fn sanitize_cert_field(s: &str) -> String {
-    s.chars().map(|c| if c.is_control() { ' ' } else { c }).collect()
+    s.chars()
+        .map(|c| if c.is_control() { ' ' } else { c })
+        .collect()
 }
 
 /// A short, single-line preview of a note's text for the `list` view.

--- a/docs/superpowers/plans/2026-07-01-largeblob-legibility.md
+++ b/docs/superpowers/plans/2026-07-01-largeblob-legibility.md
@@ -1,0 +1,1278 @@
+# Large-Blob Legibility (Tier A) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make every entry in a FIDO2 large-blob array legible — classified (keyroost note / SSH certificate / opaque RP data), decoded where recognized, capacity-metered, and exportable to a file — across the ctap layer, `keyroostctl`, and the GUI Storage view.
+
+**Architecture:** All recognition/decoding logic lives in `keyroost-ctap` (a new `ssh_cert` module plus additions to `large_blobs`), so the CLI and GUI stay thin renderers over one classifier. Everything is read-only inspection + export; no writes change shape, no new crypto.
+
+**Tech Stack:** Pure Rust. One new in-tree path dependency: `keyroost-ctap` → `keyroost-proto` (for the existing vendored base64 codec). No external dependencies added anywhere.
+
+**Spec:** Tier A of `docs/superpowers/specs/2026-06-30-largeblob-storage-roadmap-design.md`.
+
+## Global Constraints
+
+- Work on a branch `feat/largeblob-legibility` cut from `main` (after the roadmap-doc branch has landed). Sync `origin/main` first (project rule).
+- Commit with `git -c commit.gpgsign=false commit …` — the user re-signs before push (project rule; the hardware signing key is not available to agents).
+- No new external dependencies. `keyroost-proto` as a path dep of `keyroost-ctap` is in-tree and allowed; nothing else changes in any Cargo.toml dependency set.
+- Workspace MSRV is **1.85** (`keyroost-ctap`, `keyroostctl`); the GUI crate `keyroost` is pinned **1.92**. Don't use APIs newer than these floors in the respective crates.
+- `cargo clippy --workspace --all-targets --locked -- -D warnings` must stay clean on stable **1.96** (note: `manual_is_multiple_of` etc. are enforced).
+- Existing known-answer/unit suites must stay green: run `cargo test --workspace --offline` after every task.
+- RP-owned (opaque) entries are never rewritten or reinterpreted as text — display raw only. Recognition must be conservative: when parsing fails at any point, fall back to Opaque.
+- The large-blob store is world-readable; keep the existing UI/CLI honesty copy intact.
+
+## File Structure
+
+- `crates/keyroost-ctap/src/cmd.rs` — add `maxSerializedLargeBlobArray` (getInfo key `0x0B`) to `AuthenticatorInfo`.
+- `crates/keyroost-ctap/src/ssh_cert.rs` — **new**: OpenSSH certificate wire + text parsing, validity formatting, `-cert.pub` re-encoding. No I/O, no crypto verification (display-grade decode only).
+- `crates/keyroost-ctap/src/large_blobs.rs` — `BlobCapacity` + `LargeBlobArray::capacity()`, `EntryKind` + `LargeBlobEntry::classify()`.
+- `crates/keyroost-ctap/src/lib.rs` — one `pub mod ssh_cert;` line.
+- `crates/keyroost-ctap/Cargo.toml` — add `keyroost-proto` path dep.
+- `crates/keyroostctl/src/main.rs` — richer `list`/`get`, new `export` subcommand, JSON additions.
+- `crates/keyroost/src/main.rs` — capacity meter, per-entry kind + parsed-cert view, per-entry Export via the existing `FileTarget` dialog plumbing.
+- `crates/keyroost/src/ui/help.rs` — extend the `large_blobs` help copy.
+
+---
+
+### Task 1: `maxSerializedLargeBlobArray` in `AuthenticatorInfo`
+
+**Files:**
+- Modify: `crates/keyroost-ctap/src/cmd.rs` (struct at ~line 171, parse match in `parse_authenticator_info`)
+- Test: same file's existing `#[cfg(test)] mod tests`
+
+**Interfaces:**
+- Produces: `AuthenticatorInfo.max_serialized_large_blob_array: Option<u64>` — read by Task 2's `capacity()`.
+
+- [ ] **Step 1: Write the failing tests** (in `cmd.rs`'s existing tests module)
+
+```rust
+#[test]
+fn parses_max_serialized_large_blob_array() {
+    // CTAP2.1 authenticatorGetInfo key 0x0B.
+    let v = Value::Map(vec![(Value::UInt(0x0b), Value::UInt(2048))]);
+    let info = parse_authenticator_info(&v).unwrap();
+    assert_eq!(info.max_serialized_large_blob_array, Some(2048));
+}
+
+#[test]
+fn max_serialized_large_blob_array_defaults_to_none() {
+    let v = Value::Map(vec![]);
+    let info = parse_authenticator_info(&v).unwrap();
+    assert_eq!(info.max_serialized_large_blob_array, None);
+}
+```
+
+If the tests module doesn't already import `Value`/`parse_authenticator_info`, add `use super::*;`-style imports matching the module's existing pattern.
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cargo test -p keyroost-ctap --offline parses_max_serialized`
+Expected: FAIL — `no field max_serialized_large_blob_array` (compile error counts as the failing state).
+
+- [ ] **Step 3: Implement**
+
+In `pub struct AuthenticatorInfo`, after `pub firmware_version: Option<u64>,` add:
+
+```rust
+    /// `maxSerializedLargeBlobArray` (getInfo key 0x0B): the maximum size, in
+    /// bytes, of the serialized large-blob array this authenticator stores —
+    /// including the 16-byte checksum trailer. Spec minimum is 1024 when the
+    /// `largeBlobs` option is supported; absent on keys without large blobs.
+    pub max_serialized_large_blob_array: Option<u64>,
+```
+
+In `parse_authenticator_info`'s `match key` block, add an arm (numeric order with its neighbors):
+
+```rust
+            0x0b => info.max_serialized_large_blob_array = val.as_uint(),
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `cargo test -p keyroost-ctap --offline`
+Expected: PASS (all crate tests, including the two new ones).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/keyroost-ctap/src/cmd.rs
+git -c commit.gpgsign=false commit -m "feat(ctap): parse maxSerializedLargeBlobArray from getInfo (key 0x0B)"
+```
+
+---
+
+### Task 2: Capacity accounting on `LargeBlobArray`
+
+**Files:**
+- Modify: `crates/keyroost-ctap/src/large_blobs.rs`
+- Test: same file's existing `#[cfg(test)] mod tests`
+
+**Interfaces:**
+- Consumes: `AuthenticatorInfo.max_serialized_large_blob_array` (Task 1).
+- Produces: `pub struct BlobCapacity { pub max_bytes: u64, pub used_bytes: u64, pub free_bytes: u64, pub entry_count: usize }` and `LargeBlobArray::capacity(&self, info: &AuthenticatorInfo) -> BlobCapacity` — used by Tasks 6 and 7.
+
+- [ ] **Step 1: Write the failing tests**
+
+```rust
+#[test]
+fn capacity_of_empty_array() {
+    let arr = LargeBlobArray { entries: Vec::new(), raw_array: Vec::new() };
+    let info = AuthenticatorInfo::default(); // no 0x0B advertised -> spec minimum
+    let cap = arr.capacity(&info);
+    // Empty CBOR array (0x80, 1 byte) + 16-byte checksum trailer.
+    assert_eq!(cap.used_bytes, 17);
+    assert_eq!(cap.max_bytes, 1024);
+    assert_eq!(cap.free_bytes, 1024 - 17);
+    assert_eq!(cap.entry_count, 0);
+}
+
+#[test]
+fn capacity_uses_advertised_max_and_saturates() {
+    let arr = LargeBlobArray {
+        entries: vec![LargeBlobEntry::from_text("hello")],
+        raw_array: Vec::new(),
+    };
+    let mut info = AuthenticatorInfo::default();
+    info.max_serialized_large_blob_array = Some(4096);
+    let cap = arr.capacity(&info);
+    assert_eq!(cap.max_bytes, 4096);
+    assert_eq!(cap.used_bytes, arr.serialize_with_checksum().len() as u64);
+    assert_eq!(cap.free_bytes, cap.max_bytes - cap.used_bytes);
+    assert_eq!(cap.entry_count, 1);
+
+    // A max smaller than what's stored must not underflow.
+    info.max_serialized_large_blob_array = Some(10);
+    assert_eq!(arr.capacity(&info).free_bytes, 0);
+}
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cargo test -p keyroost-ctap --offline capacity_`
+Expected: FAIL — `no method named capacity` (compile error).
+
+- [ ] **Step 3: Implement** (in `large_blobs.rs`, near the `LargeBlobArray` impl)
+
+```rust
+/// Spec floor for `maxSerializedLargeBlobArray` when the authenticator
+/// supports large blobs but does not advertise the key (CTAP 2.1 §6.10).
+const SPEC_MIN_SERIALIZED_ARRAY: u64 = 1024;
+
+/// Space accounting for a large-blob array against an authenticator's
+/// advertised (or spec-minimum) storage. Sizes count the full serialized
+/// form — CBOR array plus the 16-byte checksum trailer — because that is
+/// what `maxSerializedLargeBlobArray` bounds.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BlobCapacity {
+    pub max_bytes: u64,
+    pub used_bytes: u64,
+    pub free_bytes: u64,
+    pub entry_count: usize,
+}
+
+impl LargeBlobArray {
+    /// Compute capacity from the entries as currently held (re-serialized,
+    /// so it stays correct after local adds/edits that haven't been written).
+    pub fn capacity(&self, info: &AuthenticatorInfo) -> BlobCapacity {
+        let used = self.serialize_with_checksum().len() as u64;
+        let max = info
+            .max_serialized_large_blob_array
+            .unwrap_or(SPEC_MIN_SERIALIZED_ARRAY);
+        BlobCapacity {
+            max_bytes: max,
+            used_bytes: used,
+            free_bytes: max.saturating_sub(used),
+            entry_count: self.entries.len(),
+        }
+    }
+}
+```
+
+(`AuthenticatorInfo` is already imported in this file — it's used by `max_fragment_length`.)
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `cargo test -p keyroost-ctap --offline`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/keyroost-ctap/src/large_blobs.rs
+git -c commit.gpgsign=false commit -m "feat(ctap): large-blob capacity accounting (used/free vs maxSerializedLargeBlobArray)"
+```
+
+---
+
+### Task 3: OpenSSH certificate wire parser (`ssh_cert.rs`)
+
+**Files:**
+- Create: `crates/keyroost-ctap/src/ssh_cert.rs`
+- Modify: `crates/keyroost-ctap/src/lib.rs` (add `pub mod ssh_cert;` alongside the other modules)
+- Modify: `crates/keyroost-ctap/Cargo.toml` (add the in-tree base64 source, used by tests here and by Task 4's text form):
+
+```toml
+keyroost-proto = { path = "../keyroost-proto", version = "0.7.3" }
+```
+
+- Test: `#[cfg(test)] mod tests` at the bottom of `ssh_cert.rs`
+
+**Interfaces:**
+- Produces (used by Tasks 4–7):
+  - `pub struct SshCertInfo { pub key_type: String, pub serial: u64, pub cert_type: u32, pub key_id: String, pub principals: Vec<String>, pub valid_after: u64, pub valid_before: u64, pub critical_options: Vec<(String, String)>, pub extensions: Vec<String> }`
+  - `pub fn parse_wire(blob: &[u8]) -> Option<SshCertInfo>`
+  - `pub fn format_timestamp(secs: u64) -> String` and `pub fn format_validity(valid_after: u64, valid_before: u64) -> String`
+  - `pub const CERT_TYPE_USER: u32 = 1;` / `pub const CERT_TYPE_HOST: u32 = 2;`
+
+**Test fixture** (generated with `ssh-keygen -s <ca> -I test-key-id -n alice,bob -z 42 -V <UTC 2026-01-01..2027-01-01> -O clear -O permit-pty -O source-address=192.0.2.0/24`; throwaway keys, safe to embed):
+
+```text
+ssh-ed25519-cert-v01@openssh.com AAAAIHNzaC1lZDI1NTE5LWNlcnQtdjAxQG9wZW5zc2guY29tAAAAIFnHByOSs9oyjoM3FSMYa4CyEkl9qj7cPldTCWBGw3soAAAAIB8WYDicxYHAvQ5QE8w24ZO0pod+x5Y7Zcjdk8D3kOpZAAAAAAAAACoAAAABAAAAC3Rlc3Qta2V5LWlkAAAAEAAAAAVhbGljZQAAAANib2IAAAAAaVW5AAAAAABrNuyAAAAAJgAAAA5zb3VyY2UtYWRkcmVzcwAAABAAAAAMMTkyLjAuMi4wLzI0AAAAEgAAAApwZXJtaXQtcHR5AAAAAAAAAAAAAAAzAAAAC3NzaC1lZDI1NTE5AAAAIOkAWA6QeBu6LNDfyV4zAgonPK7XpSmq9aFdozDaQr76AAAAUwAAAAtzc2gtZWQyNTUxOQAAAEAEeDetmfpeDeQHbXOGfLlLg9XHjJQpaXg1foE9TuNXWP3Bx3oCk4Foa8S7VkuXtK0geecTqa4WZGF9dM6VSWgI user
+```
+
+Expected decode: type `ssh-ed25519-cert-v01@openssh.com`, serial `42`, cert_type `1` (user), key_id `test-key-id`, principals `["alice", "bob"]`, valid_after `1767225600` (2026-01-01 00:00:00 UTC), valid_before `1798761600` (2027-01-01 00:00:00 UTC), critical_options `[("source-address", "192.0.2.0/24")]`, extensions `["permit-pty"]`.
+
+- [ ] **Step 1: Write the failing tests** (bottom of the new `ssh_cert.rs`; the file must exist with at least the module docstring for the test to compile against — write the full test module first)
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use keyroost_proto::codec::base64_decode;
+
+    /// Real ed25519 user certificate produced by ssh-keygen from throwaway
+    /// keys (see the Tier A plan for the exact invocation). The base64 body
+    /// is the wire-format certificate blob.
+    const FIXTURE_CERT_PUB: &str = "ssh-ed25519-cert-v01@openssh.com AAAAIHNzaC1lZDI1NTE5LWNlcnQtdjAxQG9wZW5zc2guY29tAAAAIFnHByOSs9oyjoM3FSMYa4CyEkl9qj7cPldTCWBGw3soAAAAIB8WYDicxYHAvQ5QE8w24ZO0pod+x5Y7Zcjdk8D3kOpZAAAAAAAAACoAAAABAAAAC3Rlc3Qta2V5LWlkAAAAEAAAAAVhbGljZQAAAANib2IAAAAAaVW5AAAAAABrNuyAAAAAJgAAAA5zb3VyY2UtYWRkcmVzcwAAABAAAAAMMTkyLjAuMi4wLzI0AAAAEgAAAApwZXJtaXQtcHR5AAAAAAAAAAAAAAAzAAAAC3NzaC1lZDI1NTE5AAAAIOkAWA6QeBu6LNDfyV4zAgonPK7XpSmq9aFdozDaQr76AAAAUwAAAAtzc2gtZWQyNTUxOQAAAEAEeDetmfpeDeQHbXOGfLlLg9XHjJQpaXg1foE9TuNXWP3Bx3oCk4Foa8S7VkuXtK0geecTqa4WZGF9dM6VSWgI user";
+
+    fn fixture_wire() -> Vec<u8> {
+        let b64 = FIXTURE_CERT_PUB.split_ascii_whitespace().nth(1).unwrap();
+        base64_decode(b64).unwrap()
+    }
+
+    #[test]
+    fn parses_real_ed25519_user_cert() {
+        let info = parse_wire(&fixture_wire()).unwrap();
+        assert_eq!(info.key_type, "ssh-ed25519-cert-v01@openssh.com");
+        assert_eq!(info.serial, 42);
+        assert_eq!(info.cert_type, CERT_TYPE_USER);
+        assert_eq!(info.key_id, "test-key-id");
+        assert_eq!(info.principals, vec!["alice".to_string(), "bob".to_string()]);
+        assert_eq!(info.valid_after, 1767225600);
+        assert_eq!(info.valid_before, 1798761600);
+        assert_eq!(
+            info.critical_options,
+            vec![("source-address".to_string(), "192.0.2.0/24".to_string())]
+        );
+        assert_eq!(info.extensions, vec!["permit-pty".to_string()]);
+    }
+
+    #[test]
+    fn rejects_non_certificates() {
+        // Not even a length-prefixed string.
+        assert!(parse_wire(&[0xde, 0xad, 0xbe, 0xef]).is_none());
+        // Empty input.
+        assert!(parse_wire(&[]).is_none());
+        // A valid-looking type string but nothing after it.
+        let mut b = Vec::new();
+        b.extend_from_slice(&32u32.to_be_bytes());
+        b.extend_from_slice(b"ssh-ed25519-cert-v01@openssh.com");
+        assert!(parse_wire(&b).is_none());
+        // Truncated real cert: cut the last 10 bytes off.
+        let wire = fixture_wire();
+        assert!(parse_wire(&wire[..wire.len() - 10]).is_none());
+        // Trailing junk after a real cert must also be rejected (strictness
+        // keeps classification from matching almost-certs).
+        let mut padded = fixture_wire();
+        padded.push(0x00);
+        assert!(parse_wire(&padded).is_none());
+    }
+
+    #[test]
+    fn formats_timestamps_and_validity() {
+        assert_eq!(format_timestamp(1767225600), "2026-01-01 00:00:00 UTC");
+        assert_eq!(format_timestamp(0), "1970-01-01 00:00:00 UTC");
+        // OpenSSH convention: the all-1s valid_before means "forever".
+        assert_eq!(format_validity(0, u64::MAX), "always valid");
+        assert_eq!(
+            format_validity(1767225600, 1798761600),
+            "2026-01-01 00:00:00 UTC to 2027-01-01 00:00:00 UTC"
+        );
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cargo test -p keyroost-ctap --offline ssh_cert`
+Expected: FAIL — module doesn't exist yet (compile error after adding `pub mod ssh_cert;`).
+
+- [ ] **Step 3: Implement the parser** (top of `ssh_cert.rs`, above the tests)
+
+```rust
+//! Read-only decoding of OpenSSH certificates (the `*-cert-v01@openssh.com`
+//! wire format described in OpenSSH's PROTOCOL.certkeys). This exists so the
+//! large-blob Storage views can *recognize and display* a certificate an SSH
+//! CA workflow parked on the key — type, key id, principals, validity,
+//! critical options. It deliberately does NOT verify the CA signature; that
+//! is the relying server's job, not a display surface's.
+
+/// Certificate type field values (PROTOCOL.certkeys).
+pub const CERT_TYPE_USER: u32 = 1;
+pub const CERT_TYPE_HOST: u32 = 2;
+
+/// The human-relevant fields of an OpenSSH certificate.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SshCertInfo {
+    /// e.g. `ssh-ed25519-cert-v01@openssh.com`.
+    pub key_type: String,
+    pub serial: u64,
+    /// [`CERT_TYPE_USER`] or [`CERT_TYPE_HOST`].
+    pub cert_type: u32,
+    pub key_id: String,
+    pub principals: Vec<String>,
+    /// Unix seconds; 0 = no lower bound.
+    pub valid_after: u64,
+    /// Unix seconds; `u64::MAX` = no upper bound ("forever").
+    pub valid_before: u64,
+    /// `(name, value)` pairs; value is empty for flag-style options.
+    pub critical_options: Vec<(String, String)>,
+    /// Extension names (values are conventionally empty).
+    pub extensions: Vec<String>,
+}
+
+/// Cursor over SSH wire data: big-endian integers and u32-length-prefixed
+/// byte strings.
+struct Reader<'a> {
+    buf: &'a [u8],
+    pos: usize,
+}
+
+impl<'a> Reader<'a> {
+    fn new(buf: &'a [u8]) -> Self {
+        Reader { buf, pos: 0 }
+    }
+
+    fn take(&mut self, n: usize) -> Option<&'a [u8]> {
+        let end = self.pos.checked_add(n)?;
+        let out = self.buf.get(self.pos..end)?;
+        self.pos = end;
+        Some(out)
+    }
+
+    fn u32(&mut self) -> Option<u32> {
+        self.take(4).map(|b| u32::from_be_bytes(b.try_into().unwrap()))
+    }
+
+    fn u64(&mut self) -> Option<u64> {
+        self.take(8).map(|b| u64::from_be_bytes(b.try_into().unwrap()))
+    }
+
+    fn bytes(&mut self) -> Option<&'a [u8]> {
+        let n = self.u32()? as usize;
+        self.take(n)
+    }
+
+    fn string(&mut self) -> Option<String> {
+        std::str::from_utf8(self.bytes()?).ok().map(str::to_owned)
+    }
+
+    fn done(&self) -> bool {
+        self.pos == self.buf.len()
+    }
+}
+
+/// How many wire fields the embedded public key occupies for each supported
+/// certificate type (they sit between the nonce and the serial). `mpint`s and
+/// `string`s share the same length-prefixed wire shape, so a count suffices.
+fn pubkey_field_count(key_type: &str) -> Option<usize> {
+    Some(match key_type {
+        "ssh-ed25519-cert-v01@openssh.com" => 1, // pk
+        "ssh-rsa-cert-v01@openssh.com" => 2,     // e, n
+        "ecdsa-sha2-nistp256-cert-v01@openssh.com"
+        | "ecdsa-sha2-nistp384-cert-v01@openssh.com"
+        | "ecdsa-sha2-nistp521-cert-v01@openssh.com" => 2, // curve, point
+        "sk-ssh-ed25519-cert-v01@openssh.com" => 2, // pk, application
+        "sk-ecdsa-sha2-nistp256-cert-v01@openssh.com" => 3, // curve, point, application
+        _ => return None,
+    })
+}
+
+/// Parse a wire-format OpenSSH certificate. Returns `None` on anything that
+/// is not a complete, well-formed certificate of a supported type — including
+/// trailing bytes — so this can double as a classifier over arbitrary
+/// large-blob entry bytes without false positives.
+pub fn parse_wire(blob: &[u8]) -> Option<SshCertInfo> {
+    let mut r = Reader::new(blob);
+    let key_type = r.string()?;
+    let pubkey_fields = pubkey_field_count(&key_type)?;
+    let _nonce = r.bytes()?;
+    for _ in 0..pubkey_fields {
+        r.bytes()?;
+    }
+    let serial = r.u64()?;
+    let cert_type = r.u32()?;
+    if cert_type != CERT_TYPE_USER && cert_type != CERT_TYPE_HOST {
+        return None;
+    }
+    let key_id = r.string()?;
+    let principals = packed_strings(r.bytes()?)?;
+    let valid_after = r.u64()?;
+    let valid_before = r.u64()?;
+    let critical_options = packed_pairs(r.bytes()?)?;
+    let extensions = packed_pairs(r.bytes()?)?
+        .into_iter()
+        .map(|(name, _)| name)
+        .collect();
+    let _reserved = r.bytes()?;
+    let _signature_key = r.bytes()?;
+    let _signature = r.bytes()?;
+    if !r.done() {
+        return None;
+    }
+    Some(SshCertInfo {
+        key_type,
+        serial,
+        cert_type,
+        key_id,
+        principals,
+        valid_after,
+        valid_before,
+        critical_options,
+        extensions,
+    })
+}
+
+/// A buffer holding zero or more concatenated wire strings (the principals
+/// section).
+fn packed_strings(buf: &[u8]) -> Option<Vec<String>> {
+    let mut r = Reader::new(buf);
+    let mut out = Vec::new();
+    while !r.done() {
+        out.push(r.string()?);
+    }
+    Some(out)
+}
+
+/// A buffer holding zero or more `(string name, string data)` tuples, where
+/// `data` is either empty or itself a single wire string (the critical
+/// options and extensions sections).
+fn packed_pairs(buf: &[u8]) -> Option<Vec<(String, String)>> {
+    let mut r = Reader::new(buf);
+    let mut out = Vec::new();
+    while !r.done() {
+        let name = r.string()?;
+        let data = r.bytes()?;
+        let value = if data.is_empty() {
+            String::new()
+        } else {
+            let mut inner = Reader::new(data);
+            let v = inner.string()?;
+            if !inner.done() {
+                return None;
+            }
+            v
+        };
+        out.push((name, value));
+    }
+    Some(out)
+}
+
+/// Render a Unix timestamp as `YYYY-MM-DD HH:MM:SS UTC` without pulling in a
+/// date crate. Civil-from-days per Howard Hinnant's algorithm.
+pub fn format_timestamp(secs: u64) -> String {
+    let days = (secs / 86_400) as i64;
+    let rem = secs % 86_400;
+    let (y, m, d) = civil_from_days(days);
+    format!(
+        "{:04}-{:02}-{:02} {:02}:{:02}:{:02} UTC",
+        y,
+        m,
+        d,
+        rem / 3600,
+        (rem % 3600) / 60,
+        rem % 60
+    )
+}
+
+/// Human validity window. OpenSSH treats `(0, u64::MAX)` as unbounded.
+pub fn format_validity(valid_after: u64, valid_before: u64) -> String {
+    if valid_after == 0 && valid_before == u64::MAX {
+        return "always valid".to_string();
+    }
+    let from = if valid_after == 0 {
+        "beginning of time".to_string()
+    } else {
+        format_timestamp(valid_after)
+    };
+    let to = if valid_before == u64::MAX {
+        "forever".to_string()
+    } else {
+        format_timestamp(valid_before)
+    };
+    format!("{from} to {to}")
+}
+
+fn civil_from_days(z: i64) -> (i64, u32, u32) {
+    let z = z + 719_468;
+    let era = if z >= 0 { z } else { z - 146_096 } / 146_097;
+    let doe = (z - era * 146_097) as u64;
+    let yoe = (doe - doe / 1_460 + doe / 36_524 - doe / 146_096) / 365;
+    let y = yoe as i64 + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = (doy - (153 * mp + 2) / 5 + 1) as u32;
+    let m = if mp < 10 { mp + 3 } else { mp - 9 } as u32;
+    (y + i64::from(m <= 2), m, d)
+}
+```
+
+Add to `crates/keyroost-ctap/src/lib.rs` (alphabetical with the other `pub mod` lines):
+
+```rust
+pub mod ssh_cert;
+```
+
+And the Cargo.toml dep shown in **Files** above.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `cargo test -p keyroost-ctap --offline ssh_cert`
+Expected: PASS (3 tests). Then `cargo test --workspace --offline` — everything green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/keyroost-ctap/src/ssh_cert.rs crates/keyroost-ctap/src/lib.rs crates/keyroost-ctap/Cargo.toml Cargo.lock
+git -c commit.gpgsign=false commit -m "feat(ctap): decode OpenSSH certificates for large-blob legibility"
+```
+
+---
+
+### Task 4: Text-form certificates and `-cert.pub` re-encoding
+
+**Files:**
+- Modify: `crates/keyroost-ctap/src/ssh_cert.rs`
+- Test: same file's tests module
+
+**Interfaces:**
+- Consumes: `parse_wire`, `SshCertInfo` (Task 3); `keyroost_proto::codec::{base64_decode, base64_encode}`.
+- Produces (used by Tasks 5–7):
+  - `pub fn parse_text(s: &str) -> Option<(SshCertInfo, Vec<u8>)>` — parses a `-cert.pub`-style line, returning the decoded info plus the raw wire blob.
+  - `pub fn to_cert_pub(wire: &[u8]) -> Option<String>` — re-encodes a wire cert as a one-line `-cert.pub` file body (trailing newline included).
+
+- [ ] **Step 1: Write the failing tests**
+
+```rust
+    #[test]
+    fn parses_text_form_and_roundtrips_to_cert_pub() {
+        let (info, wire) = parse_text(FIXTURE_CERT_PUB).unwrap();
+        assert_eq!(info.key_id, "test-key-id");
+        assert_eq!(wire, fixture_wire());
+
+        // Re-encoding the wire form yields a line OpenSSH accepts: same type,
+        // same base64 body (comment is not preserved — it isn't part of the
+        // certificate).
+        let line = to_cert_pub(&wire).unwrap();
+        let mut parts = line.split_ascii_whitespace();
+        assert_eq!(parts.next(), Some("ssh-ed25519-cert-v01@openssh.com"));
+        assert_eq!(
+            parts.next(),
+            FIXTURE_CERT_PUB.split_ascii_whitespace().nth(1)
+        );
+        assert!(line.ends_with('\n'));
+        // And the re-encoded line parses back.
+        assert!(parse_text(&line).is_some());
+    }
+
+    #[test]
+    fn text_form_rejects_mismatch_and_garbage() {
+        // Declared type must match the type inside the blob.
+        let b64 = FIXTURE_CERT_PUB.split_ascii_whitespace().nth(1).unwrap();
+        let lied = format!("ssh-rsa-cert-v01@openssh.com {b64}");
+        assert!(parse_text(&lied).is_none());
+        // Ordinary public keys (not certs) are not recognized.
+        assert!(parse_text("ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIB8WYDicxYHAvQ5QE8w24ZO0pod+x5Y7Zcjdk8D3kOpZ user").is_none());
+        // Not base64 / not a cert at all.
+        assert!(parse_text("hello world").is_none());
+        assert!(parse_text("").is_none());
+    }
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cargo test -p keyroost-ctap --offline ssh_cert`
+Expected: FAIL — `parse_text` not found (compile error).
+
+- [ ] **Step 3: Implement** (in `ssh_cert.rs`, after `parse_wire`)
+
+```rust
+use keyroost_proto::codec::{base64_decode, base64_encode};
+
+/// Parse the text form of a certificate — the single `-cert.pub` line
+/// (`<type> <base64> [comment]`). Returns the decoded fields plus the raw
+/// wire blob so callers can export or re-store the canonical bytes. The
+/// declared type must match the type embedded in the blob.
+pub fn parse_text(s: &str) -> Option<(SshCertInfo, Vec<u8>)> {
+    let mut parts = s.split_ascii_whitespace();
+    let declared = parts.next()?;
+    if !declared.ends_with("-cert-v01@openssh.com") {
+        return None;
+    }
+    let wire = base64_decode(parts.next()?).ok()?;
+    let info = parse_wire(&wire)?;
+    if info.key_type != declared {
+        return None;
+    }
+    Some((info, wire))
+}
+
+/// Re-encode a wire-format certificate as the body of a `-cert.pub` file:
+/// `<type> <base64>\n`. Returns `None` if the bytes are not a certificate.
+pub fn to_cert_pub(wire: &[u8]) -> Option<String> {
+    let info = parse_wire(wire)?;
+    Some(format!("{} {}\n", info.key_type, base64_encode(wire)))
+}
+```
+
+Move the tests' `use keyroost_proto::codec::base64_decode;` up into this module-level `use` if clippy flags the duplication.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `cargo test -p keyroost-ctap --offline ssh_cert` — PASS (5 tests), then `cargo clippy -p keyroost-ctap --all-targets --offline -- -D warnings` — clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/keyroost-ctap/src/ssh_cert.rs
+git -c commit.gpgsign=false commit -m "feat(ctap): parse cert.pub text form and re-encode wire certs for export"
+```
+
+---
+
+### Task 5: Entry classification (`EntryKind` + `classify()`)
+
+**Files:**
+- Modify: `crates/keyroost-ctap/src/large_blobs.rs`
+- Test: same file's tests module
+
+**Interfaces:**
+- Consumes: `ssh_cert::{parse_wire, parse_text, SshCertInfo}` (Tasks 3–4); `KR_NOTE_MAGIC` / `as_text()` (existing).
+- Produces (used by Tasks 6–7):
+
+```rust
+pub enum EntryKind {
+    /// keyroost plaintext note (magic-prefixed); payload is the note text.
+    Note(String),
+    /// A recognized OpenSSH certificate; `wire` is the canonical binary blob
+    /// (decoded from base64 when the entry stored the text form).
+    SshCert { info: ssh_cert::SshCertInfo, wire: Vec<u8> },
+    /// Anything else — treated as RP-owned AEAD data, shown raw only.
+    Opaque,
+}
+impl LargeBlobEntry { pub fn classify(&self) -> EntryKind }
+```
+
+- [ ] **Step 1: Write the failing tests**
+
+The certificate fixture currently lives inside `ssh_cert`'s private tests. To share it, in `ssh_cert.rs` move the constant out of `mod tests` into a test-support module:
+
+```rust
+/// Test fixture shared with large_blobs' classification tests.
+#[cfg(test)]
+pub(crate) mod tests_fixture {
+    pub const FIXTURE_CERT_PUB: &str = "<the same fixture line as Task 3>";
+}
+```
+
+…and have `ssh_cert`'s own tests `use super::tests_fixture::FIXTURE_CERT_PUB;` instead of a local const. Then in `large_blobs.rs`:
+
+```rust
+    #[test]
+    fn classify_note_ssh_cert_and_opaque() {
+        use crate::ssh_cert::tests_fixture::FIXTURE_CERT_PUB;
+        use keyroost_proto::codec::base64_decode;
+
+        // Note wins (even if a note happens to contain a cert line).
+        let note = LargeBlobEntry::from_text("hello");
+        assert!(matches!(note.classify(), EntryKind::Note(t) if t == "hello"));
+
+        // Wire-format certificate.
+        let wire = base64_decode(FIXTURE_CERT_PUB.split_ascii_whitespace().nth(1).unwrap()).unwrap();
+        let wire_entry = LargeBlobEntry { ciphertext: wire.clone(), nonce: vec![0; 12], orig_size: wire.len() as u64 };
+        match wire_entry.classify() {
+            EntryKind::SshCert { info, wire: w } => {
+                assert_eq!(info.key_id, "test-key-id");
+                assert_eq!(w, wire);
+            }
+            other => panic!("expected SshCert, got {other:?}"),
+        }
+
+        // Text-form certificate (a -cert.pub file dropped in verbatim).
+        let text_entry = LargeBlobEntry {
+            ciphertext: FIXTURE_CERT_PUB.as_bytes().to_vec(),
+            nonce: vec![0; 12],
+            orig_size: FIXTURE_CERT_PUB.len() as u64,
+        };
+        match text_entry.classify() {
+            EntryKind::SshCert { info, wire: w } => {
+                assert_eq!(info.serial, 42);
+                assert_eq!(w, wire); // canonical wire bytes, not the text
+            }
+            other => panic!("expected SshCert, got {other:?}"),
+        }
+
+        // Random RP bytes stay opaque.
+        let rp = LargeBlobEntry { ciphertext: vec![0xde, 0xad, 0xbe, 0xef], nonce: vec![1; 12], orig_size: 4 };
+        assert!(matches!(rp.classify(), EntryKind::Opaque));
+    }
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cargo test -p keyroost-ctap --offline classify_`
+Expected: FAIL — `EntryKind` not found (compile error).
+
+- [ ] **Step 3: Implement** (in `large_blobs.rs`, after the `LargeBlobEntry` impl; add `use crate::ssh_cert;` at the top with the existing imports)
+
+```rust
+/// What a large-blob entry *is*, as far as keyroost can honestly tell.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EntryKind {
+    /// keyroost plaintext note (magic-prefixed).
+    Note(String),
+    /// A recognized OpenSSH certificate. `wire` holds the canonical binary
+    /// certificate (decoded from base64 when the entry stored the text form),
+    /// ready for export as a `-cert.pub`.
+    SshCert {
+        info: ssh_cert::SshCertInfo,
+        wire: Vec<u8>,
+    },
+    /// Anything unrecognized — treated as RP-owned AEAD data: shown raw,
+    /// never reinterpreted, never rewritten.
+    Opaque,
+}
+
+impl LargeBlobEntry {
+    /// Classify this entry. Conservative by construction: the keyroost note
+    /// magic wins outright, certificate recognition requires a complete,
+    /// well-formed parse, and everything else is opaque.
+    pub fn classify(&self) -> EntryKind {
+        if let Some(text) = self.as_text() {
+            return EntryKind::Note(text);
+        }
+        if let Some(info) = ssh_cert::parse_wire(&self.ciphertext) {
+            return EntryKind::SshCert {
+                info,
+                wire: self.ciphertext.clone(),
+            };
+        }
+        if let Ok(s) = std::str::from_utf8(&self.ciphertext) {
+            if let Some((info, wire)) = ssh_cert::parse_text(s.trim()) {
+                return EntryKind::SshCert { info, wire };
+            }
+        }
+        EntryKind::Opaque
+    }
+}
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `cargo test -p keyroost-ctap --offline` — PASS, and `cargo clippy -p keyroost-ctap --all-targets --offline -- -D warnings` — clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/keyroost-ctap/src/large_blobs.rs crates/keyroost-ctap/src/ssh_cert.rs
+git -c commit.gpgsign=false commit -m "feat(ctap): classify large-blob entries (note / ssh-cert / opaque)"
+```
+
+---
+
+### Task 6: CLI — kind-aware `list`/`get`, capacity line, `export` subcommand
+
+**Files:**
+- Modify: `crates/keyroostctl/src/main.rs`:
+  - `json_out` module (~line 246): extend list/get JSON, add capacity + cert structs
+  - `enum LargeBlobCmd` (~line 1614): add `Export`
+  - dispatcher `run_fido_large_blob` (~line 4963)
+  - `large_blob_list_json` / `run_fido_large_blob_list` / `run_fido_large_blob_get` (~lines 5031–5115)
+- Test: pure helpers in `main.rs`'s existing `#[cfg(test)]` module if present; otherwise verification is build + clippy + the JSON snapshot below (the functions are hardware-bound).
+
+**Interfaces:**
+- Consumes: `EntryKind`/`classify()` (Task 5), `capacity()` (Task 2), `ssh_cert::{format_validity, to_cert_pub, CERT_TYPE_USER}` (Tasks 3–4).
+- Produces: `keyroostctl fido large-blob export <INDEX> <FILE> [--as-cert]`; JSON additions are strictly additive (existing `is_note`/`text`/`size` fields keep their meaning).
+
+- [ ] **Step 1: JSON shapes** — in the `json_out` module, extend:
+
+```rust
+    /// `keyroostctl fido large-blob --json list` — one entry per stored blob.
+    #[derive(Serialize)]
+    pub struct FidoLargeBlobListJson {
+        pub entries: Vec<FidoLargeBlobEntryJson>,
+        pub capacity: FidoLargeBlobCapacityJson,
+    }
+
+    /// Space accounting for the whole array (serialized form incl. checksum).
+    #[derive(Serialize)]
+    pub struct FidoLargeBlobCapacityJson {
+        pub max_bytes: u64,
+        pub used_bytes: u64,
+        pub free_bytes: u64,
+    }
+
+    /// Decoded fields of a recognized OpenSSH certificate entry.
+    #[derive(Serialize)]
+    pub struct FidoLargeBlobSshCertJson {
+        pub key_type: String,
+        pub serial: u64,
+        /// "user" or "host".
+        pub cert_type: &'static str,
+        pub key_id: String,
+        pub principals: Vec<String>,
+        pub valid_after: u64,
+        pub valid_before: u64,
+        /// Human validity window, e.g. "2026-01-01 00:00:00 UTC to …".
+        pub validity: String,
+        /// "name=value" (or bare "name") per critical option.
+        pub critical_options: Vec<String>,
+        pub extensions: Vec<String>,
+    }
+```
+
+and add to **both** `FidoLargeBlobEntryJson` and `FidoLargeBlobGetJson`:
+
+```rust
+        /// Entry classification: "note", "ssh-cert", or "opaque".
+        pub kind: &'static str,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub ssh_cert: Option<FidoLargeBlobSshCertJson>,
+```
+
+- [ ] **Step 2: Shared shaping helpers** — near `large_blob_list_json`:
+
+```rust
+/// Classification results shaped for both the human and JSON views.
+fn large_blob_kind(
+    entry: &keyroost_ctap::large_blobs::LargeBlobEntry,
+) -> (
+    &'static str,
+    Option<json_out::FidoLargeBlobSshCertJson>,
+    keyroost_ctap::large_blobs::EntryKind,
+) {
+    use keyroost_ctap::large_blobs::EntryKind;
+    let kind = entry.classify();
+    match &kind {
+        EntryKind::Note(_) => ("note", None, kind),
+        EntryKind::Opaque => ("opaque", None, kind),
+        EntryKind::SshCert { info, .. } => {
+            let cert = json_out::FidoLargeBlobSshCertJson {
+                key_type: info.key_type.clone(),
+                serial: info.serial,
+                cert_type: if info.cert_type == keyroost_ctap::ssh_cert::CERT_TYPE_USER {
+                    "user"
+                } else {
+                    "host"
+                },
+                key_id: info.key_id.clone(),
+                principals: info.principals.clone(),
+                valid_after: info.valid_after,
+                valid_before: info.valid_before,
+                validity: keyroost_ctap::ssh_cert::format_validity(
+                    info.valid_after,
+                    info.valid_before,
+                ),
+                critical_options: info
+                    .critical_options
+                    .iter()
+                    .map(|(n, v)| {
+                        if v.is_empty() {
+                            n.clone()
+                        } else {
+                            format!("{n}={v}")
+                        }
+                    })
+                    .collect(),
+                extensions: info.extensions.clone(),
+            };
+            ("ssh-cert", Some(cert), kind)
+        }
+    }
+}
+```
+
+Replace `large_blob_list_json` with (and adjust its one call site; `AuthenticatorInfo`'s path is whatever `open_and_read_large_blobs`'s signature already names it):
+
+```rust
+/// Shape a parsed large-blob array into the JSON `list` view.
+fn large_blob_list_json(
+    array: &keyroost_ctap::large_blobs::LargeBlobArray,
+    info: &keyroost_ctap::cmd::AuthenticatorInfo,
+) -> json_out::FidoLargeBlobListJson {
+    let entries = array
+        .entries
+        .iter()
+        .enumerate()
+        .map(|(index, e)| {
+            let (kind, ssh_cert, _) = large_blob_kind(e);
+            json_out::FidoLargeBlobEntryJson {
+                index,
+                size: e.orig_size,
+                is_note: e.is_kr_note(),
+                text: e.as_text(),
+                kind,
+                ssh_cert,
+            }
+        })
+        .collect();
+    let cap = array.capacity(info);
+    json_out::FidoLargeBlobListJson {
+        entries,
+        capacity: json_out::FidoLargeBlobCapacityJson {
+            max_bytes: cap.max_bytes,
+            used_bytes: cap.used_bytes,
+            free_bytes: cap.free_bytes,
+        },
+    }
+}
+```
+
+In `run_fido_large_blob_get`, fill the two new `FidoLargeBlobGetJson` fields the same way (`let (kind, ssh_cert, _) = large_blob_kind(entry);`). Update `run_fido_large_blob_list`/`run_fido_large_blob_get` to bind `info` instead of `_info` from `open_and_read_large_blobs`.
+
+- [ ] **Step 3: Human views** — in `run_fido_large_blob_list`, replace the per-entry `if let Some(text) = e.as_text()` branching with a match on `large_blob_kind(e)`:
+
+```rust
+    for (i, e) in array.entries.iter().enumerate() {
+        use keyroost_ctap::large_blobs::EntryKind;
+        match e.classify() {
+            EntryKind::Note(text) => {
+                println!("[{}] {} bytes  note      {}", i, e.orig_size, preview_note(&text))
+            }
+            EntryKind::SshCert { info, .. } => println!(
+                "[{}] {} bytes  ssh-cert  {} ({})",
+                i,
+                e.orig_size,
+                info.key_id,
+                info.principals.join(",")
+            ),
+            EntryKind::Opaque => println!(
+                "[{}] {} bytes  opaque    {}",
+                i,
+                e.orig_size,
+                preview_opaque(&e.ciphertext)
+            ),
+        }
+    }
+    let cap = array.capacity(&info);
+    println!();
+    println!(
+        "Capacity: {} of {} bytes used, {} free",
+        cap.used_bytes, cap.max_bytes, cap.free_bytes
+    );
+```
+
+(keep the existing "(large-blob array is empty)" early-out, but print the capacity line in that case too — free space is exactly what an empty-store user wants to know).
+
+In `run_fido_large_blob_get`, add an `EntryKind::SshCert` arm before the opaque fallthrough:
+
+```rust
+        EntryKind::SshCert { info, .. } => {
+            println!("Entry {}: OpenSSH certificate, {} bytes", index, entry.orig_size);
+            println!("  Type:        {} ({})", info.key_type,
+                if info.cert_type == keyroost_ctap::ssh_cert::CERT_TYPE_USER { "user" } else { "host" });
+            println!("  Key ID:      {}", info.key_id);
+            println!("  Serial:      {}", info.serial);
+            println!("  Principals:  {}", if info.principals.is_empty() { "(any)".to_string() } else { info.principals.join(", ") });
+            println!("  Valid:       {}", keyroost_ctap::ssh_cert::format_validity(info.valid_after, info.valid_before));
+            for (n, v) in &info.critical_options {
+                if v.is_empty() { println!("  Critical:    {n}"); } else { println!("  Critical:    {n}={v}"); }
+            }
+            for ext in &info.extensions {
+                println!("  Extension:   {ext}");
+            }
+            println!("\nExport with: keyroostctl fido large-blob export {index} <FILE> --as-cert");
+        }
+```
+
+- [ ] **Step 4: `export` subcommand** — add to `enum LargeBlobCmd` (after `Get`):
+
+```rust
+    /// Save one entry's bytes to a file (read-only; no PIN needed).
+    ///
+    /// By default writes the entry's raw stored bytes. With --as-cert, a
+    /// recognized OpenSSH certificate entry is written as a `-cert.pub` text
+    /// line instead (the format `ssh` and `ssh-keygen` consume).
+    Export {
+        /// Zero-based entry index as printed by `large-blob list`.
+        index: usize,
+        /// Destination file (overwritten if it exists).
+        output: std::path::PathBuf,
+        /// Write a recognized SSH certificate in `-cert.pub` text form.
+        #[arg(long)]
+        as_cert: bool,
+        #[arg(long, value_name = "PATH")]
+        path: Option<std::path::PathBuf>,
+    },
+```
+
+dispatcher arm in `run_fido_large_blob`:
+
+```rust
+        LargeBlobCmd::Export { index, output, as_cert, path } => {
+            run_fido_large_blob_export(path.as_deref(), *index, output, *as_cert)
+        }
+```
+
+handler (next to the other `run_fido_large_blob_*` functions):
+
+```rust
+fn run_fido_large_blob_export(
+    path: Option<&std::path::Path>,
+    index: usize,
+    output: &std::path::Path,
+    as_cert: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    use keyroost_ctap::large_blobs::EntryKind;
+    let (_dev, _info, array) = open_and_read_large_blobs(path)?;
+    let entry = array
+        .entries
+        .get(index)
+        .ok_or_else(|| large_blob_bad_index(index, array.entries.len()))?;
+    let bytes: Vec<u8> = if as_cert {
+        match entry.classify() {
+            EntryKind::SshCert { wire, .. } => keyroost_ctap::ssh_cert::to_cert_pub(&wire)
+                .expect("classified cert must re-encode")
+                .into_bytes(),
+            _ => return Err(format!(
+                "entry {index} is not a recognized SSH certificate; drop --as-cert to export raw bytes"
+            )
+            .into()),
+        }
+    } else {
+        entry.ciphertext.clone()
+    };
+    std::fs::write(output, &bytes)?;
+    println!("Wrote {} bytes to {}", bytes.len(), output.display());
+    Ok(())
+}
+```
+
+- [ ] **Step 5: Verify**
+
+Run: `cargo clippy -p keyroostctl --all-targets --offline -- -D warnings` — clean; `cargo test --workspace --offline` — green; `cargo run -p keyroostctl -- fido large-blob --help` — shows `export`.
+Hardware smoke (user has test keys): `keyroostctl fido large-blob list` on a key with a note shows the capacity line; `add` a note, `export 0 /tmp/note.bin`, confirm bytes are `KR1\0hello…`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/keyroostctl/src/main.rs
+git -c commit.gpgsign=false commit -m "feat(cli): kind-aware large-blob list/get, capacity line, and export subcommand"
+```
+
+---
+
+### Task 7: GUI — capacity meter, classification, cert view, export
+
+**Files:**
+- Modify: `crates/keyroost/src/main.rs`:
+  - `SecurityKeys`-ish state near `large_blobs: Option<…>` (~line 154): add `lb_capacity` and `lb_export_idx`
+  - `FileTarget` enum (~line 1297) + `drain_file_dialogs` (~line 1367)
+  - `render_large_blobs` (~line 8176) and every load/re-read closure that assigns `security_keys.large_blobs` (`load_large_blobs`, `add_large_blob_note` ~7861, `edit_large_blob_note` ~7929, the delete and clear flows)
+- Modify: `crates/keyroost/src/ui/help.rs` — the `"large_blobs"` help entry
+
+**Interfaces:**
+- Consumes: `BlobCapacity`/`capacity()` (Task 2), `EntryKind`/`classify()` (Task 5), `ssh_cert::{format_validity, to_cert_pub, CERT_TYPE_USER}` (Tasks 3–4).
+- Produces: no programmatic interface — GUI surfaces only.
+
+- [ ] **Step 1: State + capacity plumbing**
+
+Next to `large_blobs: Option<keyroost_ctap::large_blobs::LargeBlobArray>` add:
+
+```rust
+    /// Capacity snapshot computed at load/reload time (needs the device's
+    /// getInfo, which only the worker thread holds).
+    lb_capacity: Option<keyroost_ctap::large_blobs::BlobCapacity>,
+    /// Entry index awaiting an export-dialog result.
+    lb_export_idx: Option<usize>,
+```
+
+In every worker closure that ends with `large_blobs::read(&mut dev, &info)` and assigns the result into `app.security_keys.large_blobs`, also compute `let cap = array.capacity(&info);` inside the closure (where `info` is in scope) and assign `app.security_keys.lb_capacity = Some(cap);` alongside the array. There are five such sites: initial load, add, edit, delete, clear. Where the array is cleared/reset (`security_keys.large_blobs = None` at ~line 4159), also set `lb_capacity = None`.
+
+- [ ] **Step 2: Capacity meter** — in `render_large_blobs`, directly under the existing world-readable caption label:
+
+```rust
+        if let Some(cap) = self.security_keys.lb_capacity {
+            ui.add_space(8.0);
+            let frac = if cap.max_bytes == 0 {
+                0.0
+            } else {
+                (cap.used_bytes as f32 / cap.max_bytes as f32).clamp(0.0, 1.0)
+            };
+            ui.horizontal(|ui| {
+                ui.add(
+                    egui::ProgressBar::new(frac)
+                        .desired_width(160.0)
+                        .desired_height(8.0),
+                );
+                ui.add_space(8.0);
+                ui.label(
+                    egui::RichText::new(format!(
+                        "{} of {} bytes used \u{00b7} {} free \u{00b7} {} {}",
+                        cap.used_bytes,
+                        cap.max_bytes,
+                        cap.free_bytes,
+                        cap.entry_count,
+                        if cap.entry_count == 1 { "entry" } else { "entries" },
+                    ))
+                    .font(theme::f_reg(11.5))
+                    .color(p.txt2),
+                );
+            });
+        }
+```
+
+- [ ] **Step 3: Classification in the entry rows**
+
+In the entry list inside `render_large_blobs`, the rows currently branch on `as_text()` (note vs opaque hex). Rework that branch to `match entry.classify()`:
+- `Note(text)` — existing note rendering, unchanged.
+- `Opaque` — existing hex/ASCII rendering, unchanged.
+- `SshCert { info, .. }` — a labeled parsed view in the entry's expanded body (keep whatever badge/label style the row header uses, with text `ssh-cert`):
+
+```rust
+                egui::Grid::new(format!("lb_cert_{i}"))
+                    .num_columns(2)
+                    .spacing([12.0, 2.0])
+                    .show(ui, |ui| {
+                        let row = |ui: &mut egui::Ui, k: &str, v: String| {
+                            ui.label(egui::RichText::new(k).font(theme::f_reg(11.5)).color(p.txt3));
+                            ui.label(egui::RichText::new(v).font(theme::f_reg(11.5)).color(p.txt));
+                            ui.end_row();
+                        };
+                        let kind = if info.cert_type == keyroost_ctap::ssh_cert::CERT_TYPE_USER {
+                            "user"
+                        } else {
+                            "host"
+                        };
+                        row(ui, "Type", format!("{} ({kind})", info.key_type));
+                        row(ui, "Key ID", info.key_id.clone());
+                        row(ui, "Serial", info.serial.to_string());
+                        row(
+                            ui,
+                            "Principals",
+                            if info.principals.is_empty() {
+                                "(any)".to_string()
+                            } else {
+                                info.principals.join(", ")
+                            },
+                        );
+                        row(
+                            ui,
+                            "Valid",
+                            keyroost_ctap::ssh_cert::format_validity(info.valid_after, info.valid_before),
+                        );
+                        for (n, v) in &info.critical_options {
+                            row(ui, "Critical", if v.is_empty() { n.clone() } else { format!("{n}={v}") });
+                        }
+                        for ext in &info.extensions {
+                            row(ui, "Extension", ext.clone());
+                        }
+                    });
+```
+
+(Adapt the closure-vs-helper shape to the file's existing grid helpers if one fits better — `mds_cell` exists for a different view; don't force it.)
+
+- [ ] **Step 4: Export button + dialog plumbing**
+
+Add a `FileTarget` variant and drain arm. In the enum:
+
+```rust
+    /// Storage tab "Export…" destination for a large-blob entry
+    /// (`lb_export_idx` holds which entry).
+    LbExport,
+```
+
+In each entry row's action area (next to the existing per-entry buttons), always available (export is read-only):
+
+```rust
+                if theme::button(ui, p, BtnKind::Ghost, "Export\u{2026}").clicked() {
+                    self.security_keys.lb_export_idx = Some(i);
+                    let is_cert = matches!(
+                        entry.classify(),
+                        keyroost_ctap::large_blobs::EntryKind::SshCert { .. }
+                    );
+                    let default_name = if is_cert {
+                        format!("entry-{i}-cert.pub")
+                    } else {
+                        format!("large-blob-entry-{i}.bin")
+                    };
+                    self.spawn_file_dialog(
+                        FileTarget::LbExport,
+                        true,
+                        &[("All files", &["*"])],
+                        Some(&default_name),
+                    );
+                }
+```
+
+In `drain_file_dialogs`, the existing arms assign the path string to a text field; `LbExport` instead performs the write immediately (the array is already in memory; no device I/O on the UI thread):
+
+```rust
+                            FileTarget::LbExport => {
+                                if let (Some(idx), Some(arr)) = (
+                                    self.security_keys.lb_export_idx.take(),
+                                    self.security_keys.large_blobs.as_ref(),
+                                ) {
+                                    if let Some(entry) = arr.entries.get(idx) {
+                                        use keyroost_ctap::large_blobs::EntryKind;
+                                        let bytes = match entry.classify() {
+                                            EntryKind::SshCert { wire, .. } => {
+                                                keyroost_ctap::ssh_cert::to_cert_pub(&wire)
+                                                    .expect("classified cert must re-encode")
+                                                    .into_bytes()
+                                            }
+                                            _ => entry.ciphertext.clone(),
+                                        };
+                                        self.security_keys.lb_status =
+                                            Some(match std::fs::write(&path, &bytes) {
+                                                Ok(()) => format!(
+                                                    "Exported entry {idx} ({} bytes) to {text}",
+                                                    bytes.len()
+                                                ),
+                                                Err(e) => format!("Export failed: {e}"),
+                                            });
+                                    }
+                                }
+                            }
+```
+
+(The other arms use `text`; this arm needs the `path: PathBuf` too — bind both from the dialog result, mirroring how `text` is currently derived from `path`.)
+
+- [ ] **Step 5: Help copy** — in `crates/keyroost/src/ui/help.rs`, extend the `"large_blobs"` entry's text with one sentence:
+
+```text
+keyroost recognizes its own notes and OpenSSH certificates and shows a capacity meter; anything else is relying-party data, displayed raw and never modified. Any entry can be exported to a file.
+```
+
+- [ ] **Step 6: Verify**
+
+Run: `cargo clippy -p keyroost --all-targets --offline -- -D warnings` — clean; `cargo test --workspace --offline` — green; then `cargo build --release -p keyroost` (**required** — the user launches the GUI via a PATH symlink into `target/release`, so a debug-only build looks like "nothing changed").
+Hardware smoke with a test key: Storage tab shows the meter; add a note → meter shrinks by the note's size; Export a note entry → file starts `KR1\0`; store the fixture cert (`keyroostctl fido large-blob add "$(cat user_key-cert.pub)" --pin-stdin`) → row shows ssh-cert with key ID `test-key-id`, principals alice, bob, validity 2026-01-01…2027-01-01; Export… with the `-cert.pub` default name → `ssh-keygen -L -f <exported>` prints the certificate.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/keyroost/src/main.rs crates/keyroost/src/ui/help.rs
+git -c commit.gpgsign=false commit -m "feat(gui): storage capacity meter, entry classification, ssh-cert view, export"
+```
+
+---
+
+## Completion checklist
+
+- [ ] `cargo test --workspace --offline` green
+- [ ] `cargo clippy --workspace --all-targets --locked -- -D warnings` and `cargo clippy -p keyroost --features qr --all-targets --locked -- -D warnings` clean (mirror CI)
+- [ ] `cargo build --release -p keyroost` rebuilt (GUI symlink freshness)
+- [ ] Hardware smoke on a test key per Tasks 6–7
+- [ ] Spec check against Tier A: entry recognition (note / encrypted-note*/ opaque / SSH cert), views (hex exists + parsed + capacity meter), export — *the encrypted-note magic doesn't exist until C1; classification for it lands with C1 by design
+- [ ] Branch ready for user re-sign + PR/land per repo flow


### PR DESCRIPTION
## What

Tier A ("Legibility") of the large-blob storage roadmap (`docs/superpowers/specs/2026-06-30-largeblob-storage-roadmap-design.md`): every entry in a FIDO2 large-blob array is now classified, decoded where recognized, capacity-metered, and exportable — in the CLI and the GUI. All read-only inspection plus local-file export; no new write shapes, no new crypto.

## What you get

- **Entry classification** (`keyroost-ctap`): each entry is a keyroost **note**, a recognized **OpenSSH certificate**, or **opaque** RP data. Classification is conservative by construction — the note magic wins outright, certificate recognition requires a complete well-formed parse (trailing bytes rejected), and everything else stays opaque, displayed raw, never reinterpreted or rewritten.
- **OpenSSH certificate decoding** (new `ssh_cert` module): wire + `-cert.pub` text forms of the `*-cert-v01@openssh.com` family (ed25519, RSA, ECDSA, sk-*). Decodes the human-relevant fields — type, key ID, serial, principals, validity window, critical options, extensions. Display-grade only: no CA-signature verification, by design. The known-answer test embeds a real `ssh-keygen`-produced certificate (throwaway keys).
- **Capacity meter**: `used / free / max` computed from the serialized array (CBOR + 16-byte checksum trailer, the exact quantity `maxSerializedLargeBlobArray` bounds), using the authenticator's advertised getInfo `0x0B` value with the spec-minimum 1024 fallback. Shown as a `Capacity:` line in the CLI and a progress meter in the GUI Storage tab.
- **Export**: new read-only `keyroostctl fido large-blob export <INDEX> <FILE>` (no PIN) writing the entry's raw stored bytes, with `--as-cert` to re-encode a recognized certificate as a `-cert.pub` line. The GUI gets a per-entry Export… button via the native save dialog, cert-aware default filenames included.
- **JSON**: strictly additive — `kind` per entry, decoded `ssh_cert` fields where recognized, and a `capacity` object; the existing `index/size/is_note/text/hex` fields are untouched in meaning.

## Notable decisions

- The one dependency change is **in-tree**: `keyroost-ctap` now uses `keyroost-proto`'s vendored base64. External dependency set is unchanged everywhere.
- Cert-derived strings (key IDs, principals, options) are attacker-suppliable, so the CLI flattens control characters out of them before printing — same defense the note preview already used — closing a terminal escape-injection hole found in review.
- The GUI export dialog carries its entry index inside the `FileTarget` enum rather than shared app state, so a cancelled or overlapping dialog can't export the wrong entry.
- Keys without the `largeBlobs` option now get a plain "this key does not support the FIDO2 large-blob store" from the CLI instead of a raw CTAP status (pre-existing gap; the GUI already gated on the option).

## Verified

- Full workspace test suite green; both CI clippy invocations (`--workspace` and `-p keyroost --features qr`) clean under `-D warnings`; new unit coverage for capacity math, cert parsing (real-fixture known-answer + adversarial rejection), classification precedence, and text/wire round-trips.
- **Hardware:** on a YubiKey 5.7.4 — advertised 4096-byte capacity read via getInfo `0x0B`; add → list → get → export → delete cycle with correct capacity movement; exported bytes byte-exact; `--as-cert` misuse errors cleanly; JSON additive. On a Solo 2 (no large-blob support) — the friendly unsupported message.
- Not exercised on hardware: storing a genuine third-party certificate entry (nothing in keyroost writes non-note entries, by design — the cert path is covered by the known-answer fixture).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
