### PR TITLE
Support PIV pin/touch policy in UI, display slot's current key algorithm

### DIFF
--- a/crates/keyroost-piv/src/lib.rs
+++ b/crates/keyroost-piv/src/lib.rs
@@ -90,6 +90,11 @@ pub enum Instruction {
     SetPinRetries = 0xFA,
     /// Yubico extension: RESET the PIV application (only when PIN and PUK blocked).
     Reset = 0xFB,
+    /// Yubico extension: ATTEST — a self-signed certificate for a slot's key,
+    /// proving on-card generation (fw 4.3+). On firmware older than 5.3 (GET
+    /// METADATA's policy support), this certificate's key-policy extension is
+    /// also the only source for the slot's PIN/touch policy.
+    Attest = 0xF9,
 }
 
 impl Instruction {
@@ -356,6 +361,19 @@ impl PinPolicy {
             PinPolicy::Always => 0x03,
         }
     }
+
+    /// Resolve a PIN policy byte, as reported by GET METADATA (tag `0x02`'s
+    /// first byte) or the ATTEST certificate's key-policy extension.
+    #[must_use]
+    pub const fn from_id(id: u8) -> Option<Self> {
+        match id {
+            0x00 => Some(PinPolicy::Default),
+            0x01 => Some(PinPolicy::Never),
+            0x02 => Some(PinPolicy::Once),
+            0x03 => Some(PinPolicy::Always),
+            _ => None,
+        }
+    }
 }
 
 /// Touch policy for a generated key (whether the key requires a physical touch).
@@ -375,6 +393,19 @@ impl TouchPolicy {
             TouchPolicy::Never => 0x01,
             TouchPolicy::Always => 0x02,
             TouchPolicy::Cached => 0x03,
+        }
+    }
+
+    /// Resolve a touch policy byte, as reported by GET METADATA (tag `0x02`'s
+    /// second byte) or the ATTEST certificate's key-policy extension.
+    #[must_use]
+    pub const fn from_id(id: u8) -> Option<Self> {
+        match id {
+            0x00 => Some(TouchPolicy::Default),
+            0x01 => Some(TouchPolicy::Never),
+            0x02 => Some(TouchPolicy::Always),
+            0x03 => Some(TouchPolicy::Cached),
+            _ => None,
         }
     }
 }
@@ -806,6 +837,16 @@ pub fn get_metadata(key_ref: u8) -> Vec<u8> {
 #[must_use]
 pub fn reset() -> Vec<u8> {
     vec![0x00, Instruction::Reset.code(), 0x00, 0x00]
+}
+
+/// Yubico ATTEST (case 2): request the self-signed attestation certificate for
+/// the key in `key_ref`'s slot. `P1` is the slot's key reference, `P2` is
+/// `0x00`; no data field. Requires firmware 4.3+. The certificate can exceed
+/// 256 bytes, so the reply chains through `61xx`/GET RESPONSE the same way a
+/// GET DATA certificate read does.
+#[must_use]
+pub fn attest(key_ref: u8) -> Vec<u8> {
+    build_apdu_get(0x00, Instruction::Attest.code(), key_ref, 0x00, 0x00)
 }
 
 /// Yubico extension: DELETE a slot's private key by issuing MOVE KEY with the
@@ -1244,6 +1285,37 @@ mod tests {
         assert_eq!(set_pin_retries(5, 3), vec![0x00, 0xFA, 0x05, 0x03]);
         assert_eq!(reset(), vec![0x00, 0xFB, 0x00, 0x00]);
         assert_eq!(get_metadata(0x9B), vec![0x00, 0xF7, 0x00, 0x9B]);
+    }
+
+    #[test]
+    fn attest_apdu_bytes() {
+        // 00 F9 <slot key ref> 00 00 — P1 is the slot, P2 is 0x00, Le=0x00 (256,
+        // chained via GET RESPONSE for the certificate's full length).
+        assert_eq!(attest(0x9A), vec![0x00, 0xF9, 0x9A, 0x00, 0x00]);
+        assert_eq!(attest(0x9C), vec![0x00, 0xF9, 0x9C, 0x00, 0x00]);
+    }
+
+    #[test]
+    fn pin_touch_policy_id_round_trips() {
+        for p in [
+            PinPolicy::Default,
+            PinPolicy::Never,
+            PinPolicy::Once,
+            PinPolicy::Always,
+        ] {
+            assert_eq!(PinPolicy::from_id(p.id()), Some(p));
+        }
+        assert_eq!(PinPolicy::from_id(0x04), None);
+
+        for t in [
+            TouchPolicy::Default,
+            TouchPolicy::Never,
+            TouchPolicy::Always,
+            TouchPolicy::Cached,
+        ] {
+            assert_eq!(TouchPolicy::from_id(t.id()), Some(t));
+        }
+        assert_eq!(TouchPolicy::from_id(0x04), None);
     }
 
     #[test]

--- a/crates/keyroost-piv/src/x509_parse.rs
+++ b/crates/keyroost-piv/src/x509_parse.rs
@@ -320,6 +320,96 @@ fn parse_name(mut input: &[u8]) -> Result<SubjectDn, X509ParseError> {
     Ok(SubjectDn { rdns })
 }
 
+// ---------------------------------------------------------------------------
+// Yubico key-policy extension (ATTEST certificates)
+// ---------------------------------------------------------------------------
+
+/// Yubico PIV key-policy extension OID `1.3.6.1.4.1.41482.3.8`, as DER OBJECT
+/// IDENTIFIER content (tag/length stripped). Carried on a slot's ATTEST
+/// certificate; its `extnValue` is exactly 2 raw bytes, `[pin_policy,
+/// touch_policy]`, using the same byte values as [`crate::PinPolicy::id`] /
+/// [`crate::TouchPolicy::id`] (never/once/always = 1/2/3 for PIN;
+/// never/always/cached = 1/2/3 for touch).
+const KEY_POLICY_EXT_OID: &[u8] = &[0x2B, 0x06, 0x01, 0x04, 0x01, 0x82, 0xC4, 0x0A, 0x03, 0x08];
+
+/// Parse the PIN/touch policy bytes out of a slot's ATTEST certificate, if the
+/// Yubico key-policy extension is present. Returns `Ok(None)` — not an error —
+/// when the extension is simply absent: a certificate that predates it, or
+/// isn't a Yubico attestation cert at all, is a normal case for a caller that
+/// is only using this as a fallback source (GET METADATA firmware < 5.3).
+///
+/// Navigates `Certificate -> tbsCertificate -> extensions` per RFC 5280,
+/// continuing past where [`parse_subject_dn`] stops: `subject Name,
+/// subjectPublicKeyInfo SEQUENCE, issuerUniqueID [1] OPTIONAL, subjectUniqueID
+/// [2] OPTIONAL, extensions [3] EXPLICIT SEQUENCE OF Extension OPTIONAL`.
+pub fn parse_key_policy_extension(cert_der: &[u8]) -> Result<Option<(u8, u8)>, X509ParseError> {
+    // Certificate ::= SEQUENCE { tbsCertificate, signatureAlgorithm, signature }
+    let (cert, _) = expect_tag(cert_der, 0x30)?;
+    // tbsCertificate ::= SEQUENCE { ... }
+    let (tbs, _) = expect_tag(cert.content, 0x30)?;
+    let mut rest = tbs.content;
+
+    // Optional version [0] (context-specific constructed tag 0xA0): skip it.
+    {
+        let (peek, after) = read_tlv(rest)?;
+        if peek.tag == 0xA0 {
+            rest = after;
+        }
+    }
+    // serialNumber INTEGER, signature SEQUENCE, issuer Name, validity SEQUENCE,
+    // subject Name, subjectPublicKeyInfo SEQUENCE: skip each in turn.
+    let (_, rest) = expect_tag(rest, 0x02)?;
+    let (_, rest) = expect_tag(rest, 0x30)?;
+    let (_, rest) = expect_tag(rest, 0x30)?;
+    let (_, rest) = expect_tag(rest, 0x30)?;
+    let (_, rest) = expect_tag(rest, 0x30)?;
+    let (_, mut rest) = expect_tag(rest, 0x30)?;
+
+    // issuerUniqueID [1] (0x81) / subjectUniqueID [2] (0x82) are optional and,
+    // if present, precede extensions [3] (0xA3). Anything else here (nothing
+    // left, or a tag that isn't one of these three) means no extensions block
+    // — a normal, not malformed, shape for an older or non-Yubico cert.
+    loop {
+        if rest.is_empty() {
+            return Ok(None);
+        }
+        let (peek, after) = read_tlv(rest)?;
+        match peek.tag {
+            0x81 | 0x82 => rest = after,
+            0xA3 => {
+                // extensions [3] EXPLICIT SEQUENCE OF Extension
+                let (exts, _) = expect_tag(peek.content, 0x30)?;
+                return find_key_policy(exts.content);
+            }
+            _ => return Ok(None),
+        }
+    }
+}
+
+/// Scan a `SEQUENCE OF Extension` for the Yubico key-policy extension and
+/// return its 2 policy bytes, if found.
+fn find_key_policy(mut input: &[u8]) -> Result<Option<(u8, u8)>, X509ParseError> {
+    while !input.is_empty() {
+        // Extension ::= SEQUENCE { extnID OID, critical BOOLEAN DEFAULT FALSE, extnValue OCTET STRING }
+        let (seq, after_seq) = expect_tag(input, 0x30)?;
+        input = after_seq;
+        let (oid_tlv, after_oid) = expect_tag(seq.content, 0x06)?;
+        // Optional `critical` BOOLEAN (0x01): skip if present.
+        let after_oid = match read_tlv(after_oid) {
+            Ok((peek, after)) if peek.tag == 0x01 => after,
+            _ => after_oid,
+        };
+        let (val_tlv, _) = expect_tag(after_oid, 0x04)?;
+        if oid_tlv.content == KEY_POLICY_EXT_OID {
+            return match val_tlv.content {
+                [pin, touch] => Ok(Some((*pin, *touch))),
+                _ => Err(X509ParseError::Malformed),
+            };
+        }
+    }
+    Ok(None)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -463,6 +553,110 @@ mod tests {
         assert_eq!(
             read_tlv(&[0x30, 0x80]).err(),
             Some(X509ParseError::LengthTooLarge)
+        );
+    }
+
+    /// Build a minimal-but-well-formed `Certificate` DER, with an optional
+    /// `extensions [3]` field containing the given already-DER-encoded
+    /// `Extension` SEQUENCEs. Every field before `extensions` is an empty
+    /// placeholder (`parse_key_policy_extension` only needs to walk past
+    /// them, not read them), so lengths stay in short form throughout.
+    fn build_cert(extension_seqs: &[Vec<u8>]) -> Vec<u8> {
+        let serial = [0x02u8, 0x01, 0x01]; // INTEGER 1
+        let sig_alg = [0x30u8, 0x00]; // empty SEQUENCE
+        let issuer = [0x30u8, 0x00]; // empty Name SEQUENCE
+        let validity = [0x30u8, 0x00]; // empty SEQUENCE
+        let subject = [0x30u8, 0x00]; // empty Name SEQUENCE
+        let spki = [0x30u8, 0x00]; // empty SubjectPublicKeyInfo SEQUENCE
+
+        let mut tbs_content = Vec::new();
+        tbs_content.extend_from_slice(&serial);
+        tbs_content.extend_from_slice(&sig_alg);
+        tbs_content.extend_from_slice(&issuer);
+        tbs_content.extend_from_slice(&validity);
+        tbs_content.extend_from_slice(&subject);
+        tbs_content.extend_from_slice(&spki);
+
+        if !extension_seqs.is_empty() {
+            let exts_content: Vec<u8> = extension_seqs.iter().flatten().copied().collect();
+            let mut exts_seq = vec![0x30, exts_content.len() as u8];
+            exts_seq.extend_from_slice(&exts_content);
+            tbs_content.push(0xA3); // extensions [3] EXPLICIT
+            tbs_content.push(exts_seq.len() as u8);
+            tbs_content.extend_from_slice(&exts_seq);
+        }
+
+        let mut tbs = vec![0x30, tbs_content.len() as u8];
+        tbs.extend_from_slice(&tbs_content);
+        let mut cert = vec![0x30, tbs.len() as u8];
+        cert.extend_from_slice(&tbs);
+        cert
+    }
+
+    /// `Extension ::= SEQUENCE { extnID OID, extnValue OCTET STRING }`
+    /// (`critical` omitted — it's DEFAULT FALSE and optional).
+    fn build_extension(oid_content: &[u8], value: &[u8]) -> Vec<u8> {
+        let mut oid = vec![0x06, oid_content.len() as u8];
+        oid.extend_from_slice(oid_content);
+        let mut octets = vec![0x04, value.len() as u8];
+        octets.extend_from_slice(value);
+        let mut content = oid;
+        content.extend_from_slice(&octets);
+        let mut seq = vec![0x30, content.len() as u8];
+        seq.extend_from_slice(&content);
+        seq
+    }
+
+    #[test]
+    fn key_policy_extension_absent_is_none_not_an_error() {
+        // No extensions field at all (older/non-attestation cert shape).
+        assert_eq!(parse_key_policy_extension(&build_cert(&[])), Ok(None));
+    }
+
+    #[test]
+    fn key_policy_extension_ignores_unrelated_extensions() {
+        let other = build_extension(&[0x55, 0x1D, 0x0F], &[0x03, 0x02, 0x05, 0xA0]); // keyUsage, unrelated
+        assert_eq!(
+            parse_key_policy_extension(&build_cert(&[other])),
+            Ok(None)
+        );
+    }
+
+    #[test]
+    fn key_policy_extension_decodes_pin_and_touch_bytes() {
+        // PinPolicy::Always (0x03), TouchPolicy::Never (0x01).
+        let policy_ext = build_extension(KEY_POLICY_EXT_OID, &[0x03, 0x01]);
+        let other = build_extension(&[0x55, 0x1D, 0x0F], &[0x03, 0x02, 0x05, 0xA0]);
+        assert_eq!(
+            parse_key_policy_extension(&build_cert(&[other, policy_ext])),
+            Ok(Some((0x03, 0x01)))
+        );
+    }
+
+    #[test]
+    fn key_policy_extension_rejects_wrong_length_value() {
+        // A key-policy extension whose value isn't exactly 2 bytes is
+        // malformed, not merely "policy unknown" — this OID is only ever
+        // meant to carry 2 bytes, so anything else is a corrupt certificate.
+        let bad = build_extension(KEY_POLICY_EXT_OID, &[0x03]);
+        assert_eq!(
+            parse_key_policy_extension(&build_cert(&[bad])),
+            Err(X509ParseError::Malformed)
+        );
+    }
+
+    #[test]
+    fn key_policy_extension_survives_critical_flag() {
+        // Extension ::= SEQUENCE { extnID OID, critical BOOLEAN TRUE, extnValue OCTET STRING }
+        let mut content = vec![0x06, KEY_POLICY_EXT_OID.len() as u8];
+        content.extend_from_slice(KEY_POLICY_EXT_OID);
+        content.extend_from_slice(&[0x01, 0x01, 0xFF]); // BOOLEAN TRUE
+        content.extend_from_slice(&[0x04, 0x02, 0x02, 0x03]); // OCTET STRING [once, cached]
+        let mut seq = vec![0x30, content.len() as u8];
+        seq.extend_from_slice(&content);
+        assert_eq!(
+            parse_key_policy_extension(&build_cert(&[seq])),
+            Ok(Some((0x02, 0x03)))
         );
     }
 }

--- a/crates/keyroost-piv/src/x509_parse.rs
+++ b/crates/keyroost-piv/src/x509_parse.rs
@@ -23,6 +23,8 @@
 
 use std::fmt;
 
+use crate::KeyAlg;
+
 /// Errors from reading a Subject DN out of a DER certificate.
 #[derive(Debug, PartialEq, Eq)]
 pub enum X509ParseError {
@@ -410,6 +412,99 @@ fn find_key_policy(mut input: &[u8]) -> Result<Option<(u8, u8)>, X509ParseError>
     Ok(None)
 }
 
+// ---------------------------------------------------------------------------
+// subjectPublicKeyInfo key algorithm
+// ---------------------------------------------------------------------------
+
+// Pre-encoded OBJECT IDENTIFIER *content* (tag/length stripped), matching the
+// OIDs [`crate::spki::subject_public_key_info`] writes — this is that
+// encoder's inverse, read back off a certificate rather than a card response.
+const OID_RSA_ENCRYPTION: &[u8] = &[0x2A, 0x86, 0x48, 0x86, 0xF7, 0x0D, 0x01, 0x01, 0x01];
+const OID_EC_PUBLIC_KEY: &[u8] = &[0x2A, 0x86, 0x48, 0xCE, 0x3D, 0x02, 0x01];
+const OID_P256: &[u8] = &[0x2A, 0x86, 0x48, 0xCE, 0x3D, 0x03, 0x01, 0x07];
+const OID_P384: &[u8] = &[0x2B, 0x81, 0x04, 0x00, 0x22];
+const OID_ED25519: &[u8] = &[0x2B, 0x65, 0x70];
+const OID_X25519: &[u8] = &[0x2B, 0x65, 0x6E];
+
+/// Read the key algorithm out of a certificate's `subjectPublicKeyInfo`, for
+/// PIV cards that don't answer GET METADATA (pre-5.3 firmware, or a
+/// non-Yubico card): the certificate stored in the slot was built (or
+/// imported) over the same key, so its own SPKI is a reliable fallback source
+/// for the algorithm shown in the slot state line.
+///
+/// Navigates `Certificate -> tbsCertificate -> subjectPublicKeyInfo` per RFC
+/// 5280, continuing past where [`parse_subject_dn`] stops. Returns `Ok(None)`
+/// — not an error — for an SPKI algorithm this crate has no [`KeyAlg`]
+/// variant for (an unusual curve, an RSA modulus that isn't one of the four
+/// PIV sizes): this is a display-only fallback, so "can't tell" is a normal
+/// outcome, not a malformed certificate.
+pub fn parse_spki_key_alg(cert_der: &[u8]) -> Result<Option<KeyAlg>, X509ParseError> {
+    // Certificate ::= SEQUENCE { tbsCertificate, signatureAlgorithm, signature }
+    let (cert, _) = expect_tag(cert_der, 0x30)?;
+    // tbsCertificate ::= SEQUENCE { ... }
+    let (tbs, _) = expect_tag(cert.content, 0x30)?;
+    let mut rest = tbs.content;
+
+    // Optional version [0] (context-specific constructed tag 0xA0): skip it.
+    {
+        let (peek, after) = read_tlv(rest)?;
+        if peek.tag == 0xA0 {
+            rest = after;
+        }
+    }
+    // serialNumber INTEGER, signature SEQUENCE, issuer Name, validity
+    // SEQUENCE, subject Name: skip each in turn.
+    let (_, rest) = expect_tag(rest, 0x02)?;
+    let (_, rest) = expect_tag(rest, 0x30)?;
+    let (_, rest) = expect_tag(rest, 0x30)?;
+    let (_, rest) = expect_tag(rest, 0x30)?;
+    let (_, rest) = expect_tag(rest, 0x30)?;
+    // subjectPublicKeyInfo ::= SEQUENCE { algorithm AlgorithmIdentifier, subjectPublicKey BIT STRING }
+    let (spki, _) = expect_tag(rest, 0x30)?;
+    // AlgorithmIdentifier ::= SEQUENCE { algorithm OID, parameters ANY OPTIONAL }
+    let (alg_id, spk_rest) = expect_tag(spki.content, 0x30)?;
+    let (oid_tlv, params) = expect_tag(alg_id.content, 0x06)?;
+
+    match oid_tlv.content {
+        OID_RSA_ENCRYPTION => rsa_key_size(spk_rest),
+        OID_EC_PUBLIC_KEY => {
+            // parameters is the namedCurve OID for a NIST curve.
+            let (curve, _) = expect_tag(params, 0x06)?;
+            Ok(match curve.content {
+                OID_P256 => Some(KeyAlg::EccP256),
+                OID_P384 => Some(KeyAlg::EccP384),
+                _ => None,
+            })
+        }
+        OID_ED25519 => Ok(Some(KeyAlg::Ed25519)),
+        OID_X25519 => Ok(Some(KeyAlg::X25519)),
+        _ => Ok(None),
+    }
+}
+
+/// Recover the PIV RSA [`KeyAlg`] (1024/2048/3072/4096) from the modulus size
+/// in an SPKI's `subjectPublicKey` BIT STRING, which wraps `RSAPublicKey ::=
+/// SEQUENCE { modulus INTEGER, publicExponent INTEGER }`. `None` for a
+/// modulus that isn't one of PIV's four sizes.
+fn rsa_key_size(bitstring_and_after: &[u8]) -> Result<Option<KeyAlg>, X509ParseError> {
+    let (bitstr, _) = expect_tag(bitstring_and_after, 0x03)?;
+    // First content byte is the unused-bits count (0 for a byte-aligned DER
+    // encoding, which an RSAPublicKey SEQUENCE always is).
+    let inner = bitstr.content.get(1..).ok_or(X509ParseError::Truncated)?;
+    let (rsa_pub, _) = expect_tag(inner, 0x30)?;
+    let (modulus, _) = expect_tag(rsa_pub.content, 0x02)?;
+    // Strip the sign-guard `0x00` prefix (present whenever the modulus's top
+    // bit is set, i.e. almost always) before sizing.
+    let bytes = modulus.content.len() - modulus.content.iter().take_while(|&&b| b == 0).count();
+    Ok(match bytes {
+        128 => Some(KeyAlg::Rsa1024),
+        256 => Some(KeyAlg::Rsa2048),
+        384 => Some(KeyAlg::Rsa3072),
+        512 => Some(KeyAlg::Rsa4096),
+        _ => None,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -593,6 +688,25 @@ mod tests {
         cert
     }
 
+    /// Like [`build_cert`] but with a real `subjectPublicKeyInfo` in place of
+    /// the empty placeholder, for [`parse_spki_key_alg`] tests. Lengths can
+    /// exceed short form once a real SPKI is in play (an RSA-4096 SPKI is
+    /// well over 127 bytes), so this reuses [`crate::spki`]'s own DER
+    /// primitives rather than the single-byte lengths `build_cert` gets away
+    /// with.
+    fn build_cert_with_spki(spki: &[u8]) -> Vec<u8> {
+        use crate::spki::{der_seq, der_tlv};
+
+        let serial = der_tlv(0x02, &[0x01]); // INTEGER 1
+        let sig_alg = der_seq(&[]); // empty SEQUENCE
+        let issuer = der_seq(&[]); // empty Name SEQUENCE
+        let validity = der_seq(&[]); // empty SEQUENCE
+        let subject = der_seq(&[]); // empty Name SEQUENCE
+
+        let tbs = der_seq(&[&serial, &sig_alg, &issuer, &validity, &subject, spki]);
+        der_seq(&[&tbs])
+    }
+
     /// `Extension ::= SEQUENCE { extnID OID, extnValue OCTET STRING }`
     /// (`critical` omitted — it's DEFAULT FALSE and optional).
     fn build_extension(oid_content: &[u8], value: &[u8]) -> Vec<u8> {
@@ -658,5 +772,123 @@ mod tests {
             parse_key_policy_extension(&build_cert(&[seq])),
             Ok(Some((0x02, 0x03)))
         );
+    }
+
+    #[test]
+    fn spki_key_alg_round_trips_every_piv_algorithm() {
+        // Each `KeyAlg` fed through the real encoder (`subject_public_key_info`)
+        // must come back out of `parse_spki_key_alg` unchanged — the fallback
+        // path this exercises has to agree with what a card/cert actually
+        // carries, not just with a hand-built fixture.
+        let ecc_point = {
+            let mut p = vec![0x04];
+            p.extend(std::iter::repeat_n(0xAB, 64));
+            p
+        };
+        let eddsa_point = vec![0x11u8; 32];
+        let cases = [
+            (
+                KeyAlg::Rsa1024,
+                crate::PublicKey::Rsa {
+                    modulus: vec![0xFFu8; 128],
+                    exponent: vec![0x01, 0x00, 0x01],
+                },
+            ),
+            (
+                KeyAlg::Rsa2048,
+                crate::PublicKey::Rsa {
+                    modulus: vec![0xFFu8; 256],
+                    exponent: vec![0x01, 0x00, 0x01],
+                },
+            ),
+            (
+                KeyAlg::Rsa3072,
+                crate::PublicKey::Rsa {
+                    modulus: vec![0xFFu8; 384],
+                    exponent: vec![0x01, 0x00, 0x01],
+                },
+            ),
+            (
+                KeyAlg::Rsa4096,
+                crate::PublicKey::Rsa {
+                    modulus: vec![0xFFu8; 512],
+                    exponent: vec![0x01, 0x00, 0x01],
+                },
+            ),
+            (
+                KeyAlg::EccP256,
+                crate::PublicKey::Ecc {
+                    point: ecc_point.clone(),
+                },
+            ),
+            (
+                KeyAlg::EccP384,
+                crate::PublicKey::Ecc {
+                    point: ecc_point.clone(),
+                },
+            ),
+            (
+                KeyAlg::Ed25519,
+                crate::PublicKey::Ecc {
+                    point: eddsa_point.clone(),
+                },
+            ),
+            (
+                KeyAlg::X25519,
+                crate::PublicKey::Ecc {
+                    point: eddsa_point,
+                },
+            ),
+        ];
+        for (alg, key) in cases {
+            let spki = crate::spki::subject_public_key_info(&key, alg).unwrap();
+            let cert = build_cert_with_spki(&spki);
+            assert_eq!(
+                parse_spki_key_alg(&cert),
+                Ok(Some(alg)),
+                "algorithm {alg:?} did not round-trip"
+            );
+        }
+    }
+
+    #[test]
+    fn spki_key_alg_rsa_modulus_with_high_bit_set_still_sizes_correctly() {
+        // A modulus whose top bit is set gets a DER sign-guard `0x00` prefix,
+        // one byte longer than the "raw" key size — the size calc must strip
+        // that prefix, not count it.
+        let key = crate::PublicKey::Rsa {
+            modulus: {
+                let mut m = vec![0xFFu8; 256]; // top bit set -> DER prefixes 0x00
+                m[0] = 0xFF;
+                m
+            },
+            exponent: vec![0x01, 0x00, 0x01],
+        };
+        let spki = crate::spki::subject_public_key_info(&key, KeyAlg::Rsa2048).unwrap();
+        let cert = build_cert_with_spki(&spki);
+        assert_eq!(parse_spki_key_alg(&cert), Ok(Some(KeyAlg::Rsa2048)));
+    }
+
+    #[test]
+    fn spki_key_alg_unrecognized_oid_is_none_not_an_error() {
+        use crate::spki::{der_seq, der_tlv};
+        // e.g. DSA (1.2.840.10040.4.1) — not a PIV algorithm, so this must
+        // degrade to "can't tell", not fail the whole read.
+        let dsa_oid = der_tlv(0x06, &[0x2A, 0x86, 0x48, 0xCE, 0x38, 0x04, 0x01]);
+        let alg_id = der_seq(&[&dsa_oid]);
+        let spk = der_seq(&[&alg_id, &[0x03, 0x01, 0x00]]); // dummy empty BIT STRING
+        let cert = build_cert_with_spki(&spk);
+        assert_eq!(parse_spki_key_alg(&cert), Ok(None));
+    }
+
+    #[test]
+    fn spki_key_alg_ec_unrecognized_curve_is_none() {
+        use crate::spki::{der_seq, der_tlv};
+        // secp256k1 (1.3.132.0.10) — a real EC curve, but not one PIV supports.
+        let secp256k1 = [0x2B, 0x81, 0x04, 0x00, 0x0A];
+        let alg_id = der_seq(&[&der_tlv(0x06, OID_EC_PUBLIC_KEY), &der_tlv(0x06, &secp256k1)]);
+        let spk = der_seq(&[&alg_id, &[0x03, 0x02, 0x00, 0x04]]);
+        let cert = build_cert_with_spki(&spk);
+        assert_eq!(parse_spki_key_alg(&cert), Ok(None));
     }
 }

--- a/crates/keyroost-transport/src/piv.rs
+++ b/crates/keyroost-transport/src/piv.rs
@@ -462,6 +462,47 @@ impl PivSession {
         Ok(piv::find_tlv(inner, 0x70).map(<[u8]>::to_vec))
     }
 
+    /// Yubico ATTEST: the self-signed attestation certificate for `slot`'s key
+    /// (DER), proving it was generated on-card. Firmware 4.3+ (older firmware,
+    /// and non-Yubico PIV cards, refuse this instruction). No PIN required.
+    pub fn attest(&mut self, slot: Slot) -> Result<Vec<u8>, TransportError> {
+        let (data, sw) = self.transmit_full(&piv::attest(slot.key_ref()))?;
+        ok_or_write("piv attest", sw)?;
+        Ok(data)
+    }
+
+    /// Read `slot`'s PIN/touch policy for display:
+    ///
+    /// 1. GET METADATA, tried unconditionally — cards that don't support it
+    ///    (pre-5.3 firmware, or non-Yubico PIV) simply answer with something
+    ///    other than `9000`/no policy, which falls through to step 2.
+    /// 2. The ATTEST certificate's Yubico key-policy extension
+    ///    (`1.3.6.1.4.1.41482.3.8`) — GET METADATA predates policy reporting,
+    ///    but ATTEST itself has existed since 4.3. ATTEST is itself a Yubico
+    ///    vendor instruction, so a non-Yubico PIV card refuses it too; that
+    ///    refusal is handled the same as everything else here, not specially.
+    ///
+    /// `None` throughout means "not available for display", not a wire
+    /// error — this is an informational read, not a precondition for a write,
+    /// so every failure mode (missing extension, unparsable metadata, ATTEST
+    /// itself being unsupported) collapses to the same answer.
+    pub fn slot_policy(&mut self, slot: Slot) -> Option<(PinPolicy, TouchPolicy)> {
+        let (pin, touch) =
+            if let Some(policy) = self.metadata(slot.key_ref()).and_then(|m| m.policy) {
+                policy
+            } else {
+                // Non-Yubico PIV cards refuse this vendor instruction outright
+                // (a status word, not `9000`) — `.ok()?` turns that refusal
+                // into the same "no policy available" `None` as every other
+                // failure mode here.
+                let cert = self.attest(slot).ok()?;
+                keyroost_piv::x509_parse::parse_key_policy_extension(&cert)
+                    .ok()
+                    .flatten()?
+            };
+        Some((PinPolicy::from_id(pin)?, TouchPolicy::from_id(touch)?))
+    }
+
     /// Ask `slot`'s private key to sign a *prepared* block via GENERAL
     /// AUTHENTICATE: a full PKCS#1 v1.5 padded block for RSA, the raw hash for
     /// ECDSA, or the raw message for Ed25519 (see

--- a/crates/keyroost/src/main.rs
+++ b/crates/keyroost/src/main.rs
@@ -1399,6 +1399,16 @@ struct PivState {
         Option<keyroost_piv::KeyAlg>,
         Option<String>,
     )>,
+    /// Per-slot PIN/touch policy, gathered alongside `slot_keys` on each
+    /// refresh (GET VERSION, then GET METADATA on firmware 5.3+ or the
+    /// ATTEST certificate's key-policy extension on older firmware — see
+    /// [`keyroost_transport::PivSession::slot_policy`]). `None` per-slot means
+    /// unavailable: no YubiKey-compatible extensions answered, not
+    /// necessarily an empty slot.
+    slot_policies: Vec<(
+        keyroost_piv::Slot,
+        Option<(keyroost_piv::PinPolicy, keyroost_piv::TouchPolicy)>,
+    )>,
     /// User-facing error from the last read/write.
     error: Option<String>,
     /// Success/info line from the last write operation.
@@ -1498,6 +1508,7 @@ impl Default for PivState {
         PivState {
             status: None,
             slot_keys: Vec::new(),
+            slot_policies: Vec::new(),
             error: None,
             notice: None,
             loaded: false,
@@ -6226,39 +6237,44 @@ impl App {
             // or firmware without the metadata extension.
             let result = keyroost_transport::PivSession::open(&reader).map(|mut s| {
                 let status = s.status();
-                let slot_keys: Vec<_> = keyroost_piv::Slot::all()
-                    .into_iter()
-                    .map(|slot| {
-                        let alg = s
-                            .metadata(slot.key_ref())
-                            .and_then(|m| m.algorithm)
-                            .and_then(keyroost_piv::KeyAlg::from_id);
-                        // Pull the slot's certificate (if any) and extract its
-                        // Subject DN for display. Any failure — no cert, read
-                        // error, or unparseable DER — degrades to `None` so the
-                        // pane never breaks on a malformed certificate.
-                        let subject = s
-                            .read_certificate(slot)
-                            .ok()
-                            .flatten()
-                            .and_then(|der| keyroost_piv::x509_parse::parse_subject_dn(&der).ok())
-                            .map(|dn| dn.to_string());
-                        (slot, alg, subject)
-                    })
-                    .collect();
-                (status, slot_keys)
+                let mut slot_keys = Vec::with_capacity(4);
+                let mut slot_policies = Vec::with_capacity(4);
+                for slot in keyroost_piv::Slot::all() {
+                    let alg = s
+                        .metadata(slot.key_ref())
+                        .and_then(|m| m.algorithm)
+                        .and_then(keyroost_piv::KeyAlg::from_id);
+                    // Pull the slot's certificate (if any) and extract its
+                    // Subject DN for display. Any failure — no cert, read
+                    // error, or unparseable DER — degrades to `None` so the
+                    // pane never breaks on a malformed certificate.
+                    let subject = s
+                        .read_certificate(slot)
+                        .ok()
+                        .flatten()
+                        .and_then(|der| keyroost_piv::x509_parse::parse_subject_dn(&der).ok())
+                        .map(|dn| dn.to_string());
+                    slot_keys.push((slot, alg, subject));
+                    // PIN/touch policy for display — GET VERSION, then GET
+                    // METADATA (fw 5.3+) or the ATTEST certificate's
+                    // key-policy extension (older fw). `None` means
+                    // unavailable, not necessarily an empty slot.
+                    slot_policies.push((slot, s.slot_policy(slot)));
+                }
+                (status, slot_keys, slot_policies)
             });
             Box::new(move |app: &mut App| {
                 if !completion_still_valid(for_device.as_ref(), app.selected_device.as_ref()) {
                     return; // selection changed mid-read; discard
                 }
                 match result {
-                    Ok((Ok(status), slot_keys)) => {
+                    Ok((Ok(status), slot_keys, slot_policies)) => {
                         app.piv.status = Some(status);
                         app.piv.slot_keys = slot_keys;
+                        app.piv.slot_policies = slot_policies;
                         app.piv.loaded = true;
                     }
-                    Ok((Err(e), _)) | Err(e) => app.piv.error = Some(e.to_string()),
+                    Ok((Err(e), _, _)) | Err(e) => app.piv.error = Some(e.to_string()),
                 }
             })
         });
@@ -13037,17 +13053,38 @@ impl App {
             let entry = self.piv.slot_keys.iter().find(|(s, _, _)| *s == sel_slot);
             let alg = entry.and_then(|(_, a, _)| *a);
             let dn = entry.and_then(|(_, _, d)| d.as_deref());
-            let base = if cert_present {
-                "certificate present"
-            } else if alg.is_some() {
-                "key present, no certificate"
-            } else {
-                "empty"
+            // "key present" and "certificate present" both get the algorithm
+            // parenthesized right after the state word they describe — for
+            // the no-certificate case that's "key present (…), no
+            // certificate", not "…, no certificate (…)": the algorithm
+            // belongs to the key, and there's no certificate for it to
+            // trail.
+            let mut s = match (cert_present, alg) {
+                (true, Some(a)) => format!("certificate present ({})", a.label()),
+                (true, None) => "certificate present".to_string(),
+                (false, Some(a)) => format!("key present ({}), no certificate", a.label()),
+                (false, None) => "empty".to_string(),
             };
-            let mut s = base.to_string();
-            if let Some(a) = alg {
+            // PIN/touch policy, only alongside an actual key — an empty slot
+            // has no policy to report, and showing "not available" there
+            // would read as a hardware problem rather than just "no key yet".
+            if cert_present || alg.is_some() {
+                let policy = self
+                    .piv
+                    .slot_policies
+                    .iter()
+                    .find(|(s, _)| *s == sel_slot)
+                    .and_then(|(_, p)| *p);
                 s.push_str(" \u{00B7} ");
-                s.push_str(a.label());
+                match policy {
+                    Some((pin, touch)) => {
+                        s.push_str("pin: ");
+                        s.push_str(pin.label());
+                        s.push_str(", touch: ");
+                        s.push_str(touch.label());
+                    }
+                    None => s.push_str("pin/touch policy not available"),
+                }
             }
             if let Some(dn) = dn {
                 s.push_str(" \u{00B7} ");

--- a/crates/keyroost/src/main.rs
+++ b/crates/keyroost/src/main.rs
@@ -6234,7 +6234,9 @@ impl App {
             // Alongside the status, probe each slot's key algorithm via GET
             // METADATA. This surfaces an algorithm (and confirms a key exists)
             // even for a slot with no certificate; `None` covers an empty slot
-            // or firmware without the metadata extension.
+            // or firmware without the metadata extension — unless a
+            // certificate is present, in which case its own SPKI fills the
+            // algorithm back in (see the fallback below).
             let result = keyroost_transport::PivSession::open(&reader).map(|mut s| {
                 let status = s.status();
                 let mut slot_keys = Vec::with_capacity(4);
@@ -6244,16 +6246,25 @@ impl App {
                         .metadata(slot.key_ref())
                         .and_then(|m| m.algorithm)
                         .and_then(keyroost_piv::KeyAlg::from_id);
-                    // Pull the slot's certificate (if any) and extract its
-                    // Subject DN for display. Any failure — no cert, read
-                    // error, or unparseable DER — degrades to `None` so the
-                    // pane never breaks on a malformed certificate.
-                    let subject = s
-                        .read_certificate(slot)
-                        .ok()
-                        .flatten()
-                        .and_then(|der| keyroost_piv::x509_parse::parse_subject_dn(&der).ok())
+                    // Pull the slot's certificate (if any); any failure — no
+                    // cert, read error, or unparseable DER — degrades to
+                    // `None` so the pane never breaks on a malformed
+                    // certificate.
+                    let cert = s.read_certificate(slot).ok().flatten();
+                    let subject = cert
+                        .as_deref()
+                        .and_then(|der| keyroost_piv::x509_parse::parse_subject_dn(der).ok())
                         .map(|dn| dn.to_string());
+                    // Cards without GET METADATA (pre-5.3 firmware, or
+                    // non-Yubico PIV) leave `alg` empty even when the slot
+                    // holds a key — fall back to the algorithm recorded in
+                    // the certificate's own subjectPublicKeyInfo, which was
+                    // built (or imported) over that same key.
+                    let alg = alg.or_else(|| {
+                        cert.as_deref()
+                            .and_then(|der| keyroost_piv::x509_parse::parse_spki_key_alg(der).ok())
+                            .flatten()
+                    });
                     slot_keys.push((slot, alg, subject));
                     // PIN/touch policy for display — GET VERSION, then GET
                     // METADATA (fw 5.3+) or the ATTEST certificate's

--- a/crates/keyroost/src/main.rs
+++ b/crates/keyroost/src/main.rs
@@ -1434,6 +1434,14 @@ struct PivState {
     selected_slot: PivSlotSel,
     /// Key-generation algorithm selector.
     gen_alg: PivKeyAlgSel,
+    /// PIN/touch policy selectors in the Generate key modal. `Default`/
+    /// `Default` (the initial selection) sends the plain PIV GENERATE
+    /// ASYMMETRIC KEY PAIR APDU, with no policy tags, which is what every PIV
+    /// card accepts; selecting anything else appends the Yubico extended
+    /// policy tags (0xAA/0xAB), which only a YubiKey or compatible token
+    /// honors. Reset per modal open.
+    gen_pin_policy: keyroost_piv::PinPolicy,
+    gen_touch_policy: keyroost_piv::TouchPolicy,
     /// PEM of the most recently generated public key, shown for copying.
     gen_pubkey_pem: Option<String>,
     /// Certificate import file path.
@@ -1508,6 +1516,8 @@ impl Default for PivState {
             retries_pin_auth: String::new(),
             selected_slot: PivSlotSel::default(),
             gen_alg: PivKeyAlgSel::default(),
+            gen_pin_policy: keyroost_piv::PinPolicy::Default,
+            gen_touch_policy: keyroost_piv::TouchPolicy::Default,
             gen_pubkey_pem: None,
             cert_path: String::new(),
             export_path: String::new(),
@@ -6451,6 +6461,7 @@ impl App {
         };
         let slot = self.piv.selected_slot.to_slot();
         let alg = self.piv.gen_alg.to_alg();
+        let (pin_policy, touch_policy) = (self.piv.gen_pin_policy, self.piv.gen_touch_policy);
         self.piv.notice = None;
         self.piv.gen_pubkey_pem = None;
         self.spawn_job("Generating key\u{2026} (touch if it blinks)", move || {
@@ -6461,12 +6472,7 @@ impl App {
                 let mut s = keyroost_transport::PivSession::open(&name)?;
                 let mgmt_alg = s.management_key_algorithm();
                 s.authenticate_management(mgmt_alg, &mgmt)?;
-                let pubkey = s.generate_key(
-                    slot,
-                    alg,
-                    keyroost_piv::PinPolicy::Default,
-                    keyroost_piv::TouchPolicy::Default,
-                )?;
+                let pubkey = s.generate_key(slot, alg, pin_policy, touch_policy)?;
                 Ok((pubkey, s.status()?))
             })();
             Box::new(move |app: &mut App| {
@@ -7370,6 +7376,53 @@ fn piv_keyalg_combo(ui: &mut egui::Ui, id: &str, sel: &mut PivKeyAlgSel) {
         .selected_text(sel.label())
         .show_ui(ui, |ui| {
             for opt in PivKeyAlgSel::ALL {
+                ui.selectable_value(sel, opt, opt.label());
+            }
+        });
+}
+
+/// A PIV PIN/touch policy value selectable in the Generate key modal's combo
+/// boxes: its display label and the full set of choices, in menu order.
+/// `Default` is always first — it's the initial selection, and the plain PIV
+/// APDU every card accepts. Also used for the slot state line's "pin: …,
+/// touch: …" display.
+trait PivPolicyOption: Copy + PartialEq + 'static {
+    const ALL: &'static [Self];
+    fn label(self) -> &'static str;
+}
+
+impl PivPolicyOption for keyroost_piv::PinPolicy {
+    const ALL: &'static [Self] = &[Self::Default, Self::Never, Self::Once, Self::Always];
+    fn label(self) -> &'static str {
+        match self {
+            Self::Never => "never",
+            Self::Once => "once",
+            Self::Always => "always",
+            Self::Default => "default",
+        }
+    }
+}
+
+impl PivPolicyOption for keyroost_piv::TouchPolicy {
+    const ALL: &'static [Self] = &[Self::Default, Self::Never, Self::Cached, Self::Always];
+    fn label(self) -> &'static str {
+        match self {
+            Self::Never => "never",
+            Self::Cached => "cached",
+            Self::Always => "always",
+            Self::Default => "default",
+        }
+    }
+}
+
+/// PIN/Touch Policy picker combo (Generate key modal). Generic over
+/// [`PivPolicyOption`] — the type of `sel` alone picks the right option list
+/// and labels.
+fn piv_policy_combo<T: PivPolicyOption>(ui: &mut egui::Ui, id: &str, sel: &mut T) {
+    egui::ComboBox::from_id_salt(id)
+        .selected_text(sel.label())
+        .show_ui(ui, |ui| {
+            for &opt in T::ALL {
                 ui.selectable_value(sel, opt, opt.label());
             }
         });
@@ -11720,6 +11773,40 @@ impl App {
                             }
                             self.piv_modal_mgmt_field(ui, p, kind);
                             card_note(ui, p, "Authorizes overwriting the slot with a fresh key.");
+                            ui.add_space(8.0);
+                            ui.horizontal(|ui| {
+                                ui.label(
+                                    egui::RichText::new("Pin Policy")
+                                        .font(theme::f_reg(13.0))
+                                        .color(p.txt2),
+                                );
+                                ui.add_space(8.0);
+                                piv_policy_combo(
+                                    ui,
+                                    "piv-gen-pin-policy",
+                                    &mut self.piv.gen_pin_policy,
+                                );
+                            });
+                            ui.add_space(4.0);
+                            ui.horizontal(|ui| {
+                                ui.label(
+                                    egui::RichText::new("Touch Policy")
+                                        .font(theme::f_reg(13.0))
+                                        .color(p.txt2),
+                                );
+                                ui.add_space(8.0);
+                                piv_policy_combo(
+                                    ui,
+                                    "piv-gen-touch-policy",
+                                    &mut self.piv.gen_touch_policy,
+                                );
+                            });
+                            card_note(
+                                ui,
+                                p,
+                                "Policy other than `default` requires YubiKey or compatible \
+                                 token.",
+                            );
                         }
                         PivCredKind::ImportCert => {
                             self.piv_modal_mgmt_field(ui, p, kind);
@@ -11961,6 +12048,8 @@ impl App {
         wipe(&mut self.piv.retries_pin_auth);
         self.piv.use_default_mgmt = false;
         self.piv.move_dest = None;
+        self.piv.gen_pin_policy = keyroost_piv::PinPolicy::Default;
+        self.piv.gen_touch_policy = keyroost_piv::TouchPolicy::Default;
         self.piv.cred_modal = None;
     }
 
@@ -15764,6 +15853,23 @@ mod tests {
         piv.unblock_puk = "12345678".into();
         piv.unblock_new_pin = "1234".into();
         assert_eq!(piv_cred_mismatch(&piv, PivCredKind::UnblockPin), None);
+    }
+
+    /// The Pin Policy / Touch Policy dropdowns' initial selection, both on a
+    /// fresh `PivState` and after the modal-close reset: `default` / `default`
+    /// — the plain PIV APDU every card accepts.
+    #[test]
+    fn piv_gen_policy_dropdowns_default_to_default() {
+        let fresh = PivState::default();
+        assert_eq!(fresh.gen_pin_policy, keyroost_piv::PinPolicy::Default);
+        assert_eq!(fresh.gen_touch_policy, keyroost_piv::TouchPolicy::Default);
+
+        let mut app = App::default();
+        app.piv.gen_pin_policy = keyroost_piv::PinPolicy::Never;
+        app.piv.gen_touch_policy = keyroost_piv::TouchPolicy::Always;
+        app.piv_cred_modal_close();
+        assert_eq!(app.piv.gen_pin_policy, keyroost_piv::PinPolicy::Default);
+        assert_eq!(app.piv.gen_touch_policy, keyroost_piv::TouchPolicy::Default);
     }
 
     /// Each flow maps to its own title, busy caption, and success text.


### PR DESCRIPTION
his PR adds UI options to set the PIN/touch policy during key generation, including a Default option compatible with any PIV-compliant card.

Additionally, the current policy state is now retrieved and displayed as part of the PIV slot information, along with the key algorithm. The implementation takes care to properly support cards that don't implement Yubico's GET METADATA extension (this includes YubiKeys prior to firmware v5.3.0).