### PR TITLE
feat(otp): PIN protection for Token2 R3.4+ keys (CLI + GUI)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+- **OTP codes on a Token2 key can be put behind a PIN.** Keys running the
+  R3.4 OTP applet can require a PIN before they hand out codes: `otp
+  set-pin` protects a key, `otp verify` opens the read window,
+  `otp change-pin` / `otp remove-pin` manage it, `otp pin-status` reports
+  whether one is set and how many attempts remain, and `list` / `add` /
+  `delete` take `--pin-env` or `--pin-stdin` to unlock in passing (the
+  PIN is never an argument). The GUI's OTP pane grows an unlock prompt, a
+  set/change/remove dialog and a "Lock now" action. The PIN travels
+  encrypted under a per-connection ECDH session and is never sent in the
+  clear. Two things to know before setting one: there is no reset — an
+  exhausted retry counter is recoverable only by erasing every OTP entry
+  on the key — and keyroost does not verify the device's P-521 agreement
+  signature, so over NFC an attacker who runs the key agreement can take
+  one verify blob away and brute-force a numeric PIN offline without
+  touching the retry counter. Keys without the feature are unaffected:
+  they answer the capability probe with "no such command" and everything
+  behaves exactly as before. Contributed by @token2. ([#107])
+
 ## [0.8.0] - 2026-08-24
 
 **Why 0.8.0 and not 0.7.9:** this release changes the published library
@@ -906,6 +925,7 @@ multi-vendor hardware-security-key manager, then took its neutral name. Highligh
 [#98]: https://github.com/framefilter/keyroost/issues/98
 [#101]: https://github.com/framefilter/keyroost/pull/101
 [#102]: https://github.com/framefilter/keyroost/pull/102
+[#107]: https://github.com/framefilter/keyroost/issues/107
 [Unreleased]: https://github.com/framefilter/keyroost/compare/v0.8.0...HEAD
 [0.8.0]: https://github.com/framefilter/keyroost/compare/v0.7.8...v0.8.0
 [0.7.8]: https://github.com/framefilter/keyroost/compare/v0.7.7...v0.7.8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   they answer the capability probe with "no such command" and everything
   behaves exactly as before. Contributed by @token2. ([#107])
 
+### Changed
+- Library API (`keyroost-token2otp`): `EncryptError` gains a `BadLength`
+  variant (an exhaustive `match` needs a new arm).
+
 ## [0.8.0] - 2026-08-24
 
 **Why 0.8.0 and not 0.7.9:** this release changes the published library

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,7 @@ tool. Workspace contains:
 | `keyroost-oath` | Pure-Rust Yubico/Trussed OATH (TOTP/HOTP) byte layer (APDU + TLV) | `zeroize` |
 | `keyroost-openpgp` | Pure-Rust OpenPGP Card v3.4 byte layer (APDU + BER-TLV) | `zeroize` |
 | `keyroost-piv` | Pure-Rust PIV (SP 800-73-4) byte layer; full management (status, GENERAL AUTHENTICATE, key-gen, cert import, PIN/PUK/mgmt-key, reset) + SPKI/PEM | `zeroize` |
-| `keyroost-token2otp` | Pure-Rust Token2 OTP-on-FIDO management byte layer (APDU + HID framing, ECDH+AES seed encryption) | RustCrypto (`sha2`/`aes`/`cbc`/`p256`), `rand_core`, `zeroize` |
+| `keyroost-token2otp` | Pure-Rust Token2 OTP-on-FIDO management byte layer (APDU + HID framing, ECDH+AES seed encryption) | RustCrypto (`sha2`/`hmac`/`aes`/`cbc`/`p256`), `rand_core`, `zeroize` |
 | `keyroost-token2prog` | Pure-Rust Token2 2nd-gen single-profile programmable-token protocol (SM4 seed/MAC, config TLV); reuses `keyroost-proto` | `zeroize` |
 | `keyroost-keyring` | Friendly-name registry (`keys.json`); serial matching, no hardware | `serde`, `serde_json` |
 | `keyroost-resolve` | Shared key-identity resolution (USB + CCID serials, topology match) | in-tree only |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2047,6 +2047,7 @@ version = "0.8.0"
 dependencies = [
  "aes",
  "cbc",
+ "hmac",
  "p256",
  "rand_core 0.6.4",
  "sha2",

--- a/README.md
+++ b/README.md
@@ -88,6 +88,10 @@ a short, vendor-neutral tour of what FIDO2, OATH, OpenPGP, and PIV actually do.
   directly on a Token2 FIDO security key and read their codes over USB-HID, NFC,
   or CCID; configure the single HOTP-on-touch keystroke slot; read the serial;
   and enable / disable the key's USB interfaces (FIDO / keyboard-HID / CCID).
+  On R3.4+ keys the codes can be put behind an OTP PIN (`otp set-pin`,
+  `otp verify`, `otp change-pin`, `otp remove-pin`, `otp pin-status`); note
+  there is no PIN reset — a blocked PIN is recoverable only by erasing every
+  OTP entry.
 - **One-shot factory reset** — `keyroostctl factory-reset --yes` (and a card on
   the GUI device Overview tab) resets every resettable applet on a key in turn:
   OATH, OpenPGP, PIV, Token2 OTP, then FIDO2. On a USB key the FIDO2 step ends
@@ -176,7 +180,10 @@ Beyond the maintainers, keyroost is grateful for community contributions:
   and QR-from-screen import ([#50](https://github.com/framefilter/keyroost/pull/50));
   and the OTP secret-reveal toggle plus a Windows key-naming / anti-spoofing
   fix ([#52](https://github.com/framefilter/keyroost/pull/52),
-  [#56](https://github.com/framefilter/keyroost/pull/56)). Signs the Windows
+  [#56](https://github.com/framefilter/keyroost/pull/56)); and OTP-PIN
+  protection for R3.4+ keys, in the CLI and the GUI
+  ([#107](https://github.com/framefilter/keyroost/issues/107),
+  [#108](https://github.com/framefilter/keyroost/pull/108)). Signs the Windows
   and macOS release builds out-of-band.
 - **[@Algoritter](https://github.com/Algoritter)** — the project's first
   external code contribution: found, fixed and hardware-verified two
@@ -620,7 +627,7 @@ old script.
 | `keyroost-oath` | Pure-Rust Yubico/Trussed OATH (TOTP/HOTP) byte layer | `zeroize` |
 | `keyroost-openpgp` | Pure-Rust OpenPGP Card v3.4 byte layer (APDU + BER-TLV) | `zeroize` |
 | `keyroost-piv` | Pure-Rust PIV (SP 800-73-4) byte layer; full management + SPKI/PEM | `zeroize` |
-| `keyroost-token2otp` | Pure-Rust Token2 OTP-on-FIDO byte/codec layer (APDU + HID framing) | RustCrypto (`sha2`/`aes`/`cbc`/`p256`/`rand_core`) for ECDH seed encryption, `zeroize` |
+| `keyroost-token2otp` | Pure-Rust Token2 OTP-on-FIDO byte/codec layer (APDU + HID framing) | RustCrypto (`sha2`/`hmac`/`aes`/`cbc`/`p256`/`rand_core`) for ECDH seed encryption and the OTP-PIN session, `zeroize` |
 | `keyroost-token2prog` | Pure-Rust Token2 single-profile programmable-token wire protocol (SM4 seed/MAC, fixed device key, config TLV); reuses `keyroost-proto` | `zeroize` |
 | `keyroost-keyring` | Friendly-name registry (`keys.json`); serial matching | `serde`, `serde_json` |
 | `keyroost-resolve` | Shared key-identity resolution (USB + CCID serials, topology match) | none |

--- a/crates/keyroost-token2otp/Cargo.toml
+++ b/crates/keyroost-token2otp/Cargo.toml
@@ -18,6 +18,7 @@ workspace = true
 # are RustCrypto-audited and not something forbid(unsafe_code) lets us hand-roll.
 sha2 = { version = "0.10", default-features = false }
 aes = { version = "0.8", default-features = false }
+hmac = { version = "0.12", default-features = false }
 cbc = { version = "0.1", default-features = false, features = ["block-padding", "alloc"] }
 p256 = { version = "0.13", default-features = false, features = ["arithmetic", "ecdh"] }
 # OsRng for the per-command ephemeral keypair (freshness; the IVs are constants).

--- a/crates/keyroost-token2otp/src/crypto.rs
+++ b/crates/keyroost-token2otp/src/crypto.rs
@@ -14,7 +14,8 @@
 //! device-side decryption.
 
 use aes::Aes256;
-use cbc::cipher::{block_padding::Pkcs7, BlockEncryptMut, KeyIvInit};
+use cbc::cipher::{block_padding::Pkcs7, BlockDecryptMut, BlockEncryptMut, KeyIvInit};
+use hmac::{Hmac, Mac};
 use p256::ecdh::diffie_hellman;
 use p256::elliptic_curve::sec1::{FromEncodedPoint, ToEncodedPoint};
 use p256::{EncodedPoint, PublicKey, SecretKey};
@@ -23,6 +24,8 @@ use sha2::{Digest, Sha256};
 use zeroize::Zeroizing;
 
 type Aes256CbcEnc = cbc::Encryptor<Aes256>;
+type Aes256CbcDec = cbc::Decryptor<Aes256>;
+type HmacSha256 = Hmac<Sha256>;
 
 /// IV-1 — used when writing or deleting OTP entries (`WRITE_SEED`, spec §7.2).
 pub const IV_OTP: [u8; 16] = [
@@ -40,6 +43,10 @@ pub enum EncryptError {
     BadDevicePubkey,
     /// The OS RNG failed while generating the ephemeral keypair.
     RngFailed,
+    /// A session ciphertext failed to decrypt (bad length / padding).
+    BadCiphertext,
+    /// A session HMAC authentication tag did not match.
+    BadAuthTag,
 }
 
 impl std::fmt::Display for EncryptError {
@@ -49,6 +56,8 @@ impl std::fmt::Display for EncryptError {
                 write!(f, "device ECDH public key was not a valid P-256 point")
             }
             EncryptError::RngFailed => write!(f, "host RNG failed generating ephemeral key"),
+            EncryptError::BadCiphertext => write!(f, "session ciphertext failed to decrypt"),
+            EncryptError::BadAuthTag => write!(f, "session HMAC authentication tag mismatch"),
         }
     }
 }
@@ -187,4 +196,300 @@ mod tests {
             .unwrap();
         assert_eq!(plain, cleartext);
     }
+}
+
+// --- OTP PIN session crypto (R3.4 privacy protection) -----------------------
+// Ported from the Token2 reference client. ECDH-P256 session keys + the
+// AES-CBC/HMAC PIN proof builders used by SET/VERIFY/CHANGE_OTP_PIN.
+
+/// The two 32-byte session keys derived from a `READ_AGREEMENT_PUBKEY` exchange.
+///
+/// Derivation (all HMAC-SHA256), per the protocol document:
+/// ```text
+/// shared        = ECDH-P256(hostPriv, devPub).X          (32 bytes)
+/// pu1PRKey      = HMAC(key = 0x00*32, data = shared)
+/// SessionMacKey = HMAC(key = pu1PRKey, data = "TOTP HMAC key" || 0x01)
+/// SessionEncKey = HMAC(key = pu1PRKey, data = "TOTP AES key"  || 0x01)
+/// ```
+pub struct SessionKeys {
+    pub enc: Zeroizing<[u8; 32]>,
+    pub mac: Zeroizing<[u8; 32]>,
+}
+
+fn hmac256(key: &[u8], data: &[u8]) -> [u8; 32] {
+    let mut m = HmacSha256::new_from_slice(key).expect("HMAC accepts any key length");
+    m.update(data);
+    m.finalize().into_bytes().into()
+}
+
+/// Derive the session keys from an existing host secret and the device's
+/// 64-byte agreement pubkey (`X || Y`, no leading `0x04`).
+pub fn derive_session_keys(
+    host_secret: &SecretKey,
+    device_agreement_xy: &[u8],
+) -> Result<SessionKeys, EncryptError> {
+    if device_agreement_xy.len() != 64 {
+        return Err(EncryptError::BadDevicePubkey);
+    }
+    let mut sec1 = [0u8; 65];
+    sec1[0] = 0x04;
+    sec1[1..].copy_from_slice(device_agreement_xy);
+    let dev_point = EncodedPoint::from_bytes(sec1).map_err(|_| EncryptError::BadDevicePubkey)?;
+    let dev_pub = Option::<PublicKey>::from(PublicKey::from_encoded_point(&dev_point))
+        .ok_or(EncryptError::BadDevicePubkey)?;
+
+    let shared = diffie_hellman(host_secret.to_nonzero_scalar(), dev_pub.as_affine());
+    let pu1_pr = Zeroizing::new(hmac256(&[0u8; 32], shared.raw_secret_bytes()));
+    // Session-key ladder per the Token2 reference client (token2-otp-cli):
+    //   pu1PRKey      = HMAC(0x00*32, sharedX)
+    //   SessionMacKey = HMAC(pu1PRKey, "TOTP HMAC key" || 0x01)
+    //   SessionEncKey = HMAC(pu1PRKey, "TOTP AES key"  || 0x01)
+    let mut mac_info = b"TOTP HMAC key".to_vec();
+    mac_info.push(0x01);
+    let mut enc_info = b"TOTP AES key".to_vec();
+    enc_info.push(0x01);
+    Ok(SessionKeys {
+        enc: Zeroizing::new(hmac256(pu1_pr.as_slice(), &enc_info)),
+        mac: Zeroizing::new(hmac256(pu1_pr.as_slice(), &mac_info)),
+    })
+}
+
+/// Generate a host ephemeral P-256 keypair and derive session keys against the
+/// device's 64-byte agreement pubkey. Returns the host public key as raw
+/// `X || Y` (to send in `READ_AGREEMENT_PUBKEY`) and the derived keys.
+///
+/// Convenience wrapper around [`derive_session_keys`] for callers that do not
+/// need to keep the secret around; `transport` uses the split form so the
+/// pubkey it sends matches the keys it derives.
+pub fn establish_session(
+    device_agreement_xy: &[u8],
+) -> Result<([u8; 64], SessionKeys), EncryptError> {
+    let host_secret = SecretKey::random(&mut OsRng);
+    let keys = derive_session_keys(&host_secret, device_agreement_xy)?;
+    let host_point = host_secret.public_key().to_encoded_point(false);
+    let mut host_xy = [0u8; 64];
+    host_xy.copy_from_slice(&host_point.as_bytes()[1..]);
+    Ok((host_xy, keys))
+}
+
+/// AES-256-CBC encrypt `cleartext` (PKCS#7) under the session key with an
+/// explicit `iv`.
+pub fn session_encrypt(key: &[u8; 32], iv: &[u8; 16], cleartext: &[u8]) -> Vec<u8> {
+    let mut work = Zeroizing::new(cleartext.to_vec());
+    let pad_room = 16 - (cleartext.len() % 16);
+    work.resize(cleartext.len() + pad_room, 0);
+    let ct_len = cleartext.len();
+    Aes256CbcEnc::new(key.into(), iv.into())
+        .encrypt_padded_mut::<Pkcs7>(&mut work, ct_len)
+        .expect("buffer sized for PKCS7 padding above")
+        .to_vec()
+}
+
+/// AES-256-CBC decrypt WITHOUT unpadding — for diagnostics only, so debug
+/// output can show the raw plaintext even when PKCS#7 would reject it.
+pub fn session_decrypt_raw(key: &[u8; 32], iv: &[u8; 16], ciphertext: &[u8]) -> Vec<u8> {
+    if ciphertext.is_empty() || ciphertext.len() % 16 != 0 {
+        return Vec::new();
+    }
+    let mut buf = ciphertext.to_vec();
+    Aes256CbcDec::new(key.into(), iv.into())
+        .decrypt_padded_mut::<cbc::cipher::block_padding::NoPadding>(&mut buf)
+        .map(|s| s.to_vec())
+        .unwrap_or_default()
+}
+
+/// AES-256-CBC decrypt+unpad a session ciphertext under the session key.
+pub fn session_decrypt(
+    key: &[u8; 32],
+    iv: &[u8; 16],
+    ciphertext: &[u8],
+) -> Result<Zeroizing<Vec<u8>>, EncryptError> {
+    if ciphertext.is_empty() || ciphertext.len() % 16 != 0 {
+        return Err(EncryptError::BadCiphertext);
+    }
+    let mut buf = Zeroizing::new(ciphertext.to_vec());
+    let plain = Aes256CbcDec::new(key.into(), iv.into())
+        .decrypt_padded_mut::<Pkcs7>(&mut buf)
+        .map_err(|_| EncryptError::BadCiphertext)?;
+    Ok(Zeroizing::new(plain.to_vec()))
+}
+
+/// The first 16 bytes of `HMAC(mac_key, data)` — the auth-tag form the PIN
+/// commands use (`NewPinAuth`, `EncDataAuth`).
+pub fn session_auth_tag(mac_key: &[u8; 32], data: &[u8]) -> [u8; 16] {
+    let full = hmac256(mac_key, data);
+    let mut tag = [0u8; 16];
+    tag.copy_from_slice(&full[..16]);
+    tag
+}
+
+/// Constant-time-ish check of a 16-byte session auth tag.
+pub fn verify_auth_tag(mac_key: &[u8; 32], data: &[u8], tag: &[u8]) -> Result<(), EncryptError> {
+    if tag.len() != 16 {
+        return Err(EncryptError::BadAuthTag);
+    }
+    let expect = session_auth_tag(mac_key, data);
+    let mut diff = 0u8;
+    for (a, b) in expect.iter().zip(tag.iter()) {
+        diff |= a ^ b;
+    }
+    if diff == 0 {
+        Ok(())
+    } else {
+        Err(EncryptError::BadAuthTag)
+    }
+}
+
+/// Build the `SET_OTP_PIN` data field: `IV || NewPinEnc || NewPinAuth`, where
+/// `NewPin = alg(0x07) || retry(0x64) || pinLen || pin`, PKCS#7-padded to 16.
+/// Build the data field for a **PIN-protected seed write** (`WRITE_SEED` while a
+/// PIN window is open). Unlike an unprotected write — which is an ECDH blob keyed
+/// by a fresh `GET_ECDH_PUBKEY` — a protected write reuses the verified PIN
+/// session keys, exactly like PIN-mode reads in reverse:
+///
+///   `IV(16) || AES-CBC(SessionEncKey, IV, cleartext) || HMAC(SessionMacKey, EncData)[:16]`
+///
+/// (`GET_ECDH_PUBKEY` is rejected with 6A81 on a protected key, so no ECDH blob
+/// is possible; this session-key format is what the Token2 companion app sends.)
+pub fn build_protected_write_data(keys: &SessionKeys, cleartext: &[u8]) -> Vec<u8> {
+    let iv = random_iv();
+    let enc = session_encrypt(&keys.enc, &iv, cleartext);
+    let auth = session_auth_tag(&keys.mac, &enc);
+    let mut out = Vec::with_capacity(16 + enc.len() + 16);
+    out.extend_from_slice(&iv);
+    out.extend_from_slice(&enc);
+    out.extend_from_slice(&auth);
+    out
+}
+
+pub fn build_set_pin_data(keys: &SessionKeys, pin: &[u8], retry: u8) -> Vec<u8> {
+    let iv = random_iv();
+    let mut newpin = Vec::with_capacity(3 + pin.len());
+    newpin.push(0x07); // AlgId = AES256
+    newpin.push(retry);
+    newpin.push(pin.len() as u8);
+    newpin.extend_from_slice(pin);
+    let enc = session_encrypt(&keys.enc, &iv, &newpin);
+    let auth = session_auth_tag(&keys.mac, &enc);
+    let mut out = Vec::with_capacity(16 + enc.len() + 16);
+    out.extend_from_slice(&iv);
+    out.extend_from_slice(&enc);
+    out.extend_from_slice(&auth);
+    out
+}
+
+/// Build the `VERIFY_OTP_PIN` data field, matching the Token2 reference client:
+///
+/// ```text
+/// PinHash      = SHA256(pin)                         # 32 bytes
+/// IV2          = SHA256(Rand)[0:16]
+/// PinHashEnc   = AES-256-CBC(key = PinHash, IV2, data = Rand)   # inner, keyed by PIN
+/// IV           = random(16)
+/// PinHashEnc2  = AES-256-CBC(SessionEncKey, IV, PinHashEnc)     # outer, session key
+/// data field   = IV || PinHashEnc2
+/// ```
+///
+/// `rand` is the 16-byte challenge recovered from the `Lc=0x29` flag read
+/// (`Rand = AES-256-CBC-dec(SessionEncKey, flag.IV, flag.EncRand)`).
+pub fn build_verify_pin_data(keys: &SessionKeys, pin: &[u8], rand: &[u8]) -> Vec<u8> {
+    // Inner layer: key = SHA256(pin) (32 bytes => AES-256), IV = SHA256(rand)[:16].
+    let pin_hash = sha256(pin);
+    let iv2_full = sha256(rand);
+    let mut iv2 = [0u8; 16];
+    iv2.copy_from_slice(&iv2_full[..16]);
+    // Encrypt exactly the 16-byte Rand (no padding: it is already one block).
+    let inner = aes256_cbc_encrypt_nopad(&pin_hash, &iv2, rand);
+
+    // Outer layer under the session key with a fresh IV.
+    let iv = random_iv();
+    let outer = aes256_cbc_encrypt_nopad(keys.enc.as_slice().try_into().unwrap(), &iv, &inner);
+
+    let mut out = Vec::with_capacity(16 + outer.len());
+    out.extend_from_slice(&iv);
+    out.extend_from_slice(&outer);
+    out
+}
+
+/// Build the `CHANGE_OTP_PIN` data field, matching the Token2 reference client:
+///
+/// ```text
+/// body           = 0x07 || max_retry || len(newPin) || newPin      # newPin empty => remove
+/// body           = PKCS#7 pad to 16
+/// IV             = random(16)
+/// NewPinEnc      = AES-256-CBC(SessionEncKey, IV, body)
+/// OldPinHash     = SHA256(oldPin)[0:16]
+/// OldPinHashEnc  = AES-256-CBC(SessionEncKey, IV, OldPinHash)       # SAME IV
+/// NewPinAuth     = HMAC(SessionMacKey, NewPinEnc || OldPinHashEnc)[0:16]
+/// data field     = IV || NewPinEnc || NewPinAuth || OldPinHashEnc
+/// ```
+pub fn build_change_pin_data(
+    keys: &SessionKeys,
+    new_pin: &[u8],
+    current_pin: &[u8],
+    _rand: &[u8],
+) -> Vec<u8> {
+    let enc_key: &[u8; 32] = keys.enc.as_slice().try_into().unwrap();
+    let mut body = Vec::with_capacity(3 + new_pin.len());
+    body.push(0x07);
+    body.push(0x64);
+    body.push(new_pin.len() as u8);
+    body.extend_from_slice(new_pin);
+    let body = pkcs7_pad16(&body);
+
+    let iv = random_iv();
+    let new_pin_enc = aes256_cbc_encrypt_nopad(enc_key, &iv, &body);
+
+    let old_hash_full = sha256(current_pin);
+    let old_pin_hash = &old_hash_full[..16]; // 16 bytes, one block
+    let old_pin_hash_enc = aes256_cbc_encrypt_nopad(enc_key, &iv, old_pin_hash);
+
+    let mut mac_input = Vec::with_capacity(new_pin_enc.len() + old_pin_hash_enc.len());
+    mac_input.extend_from_slice(&new_pin_enc);
+    mac_input.extend_from_slice(&old_pin_hash_enc);
+    let new_pin_auth = session_auth_tag(&keys.mac, &mac_input);
+
+    let mut out = Vec::new();
+    out.extend_from_slice(&iv);
+    out.extend_from_slice(&new_pin_enc);
+    out.extend_from_slice(&new_pin_auth);
+    out.extend_from_slice(&old_pin_hash_enc);
+    out
+}
+
+/// SHA-256 convenience.
+fn sha256(data: &[u8]) -> [u8; 32] {
+    let mut h = Sha256::new();
+    h.update(data);
+    h.finalize().into()
+}
+
+/// AES-256-CBC encrypt data that is already a whole number of 16-byte blocks,
+/// with NO padding added. Panics if `data` is not block-aligned.
+fn aes256_cbc_encrypt_nopad(key: &[u8; 32], iv: &[u8; 16], data: &[u8]) -> Vec<u8> {
+    assert!(
+        !data.is_empty() && data.len() % 16 == 0,
+        "aes256_cbc_encrypt_nopad needs block-aligned input"
+    );
+    let mut buf = data.to_vec();
+    let n = buf.len();
+    // encrypt_padded_mut with NoPadding requires buf already block-aligned.
+    Aes256CbcEnc::new(key.into(), iv.into())
+        .encrypt_padded_mut::<cbc::cipher::block_padding::NoPadding>(&mut buf, n)
+        .expect("block-aligned, NoPadding")
+        .to_vec()
+}
+
+/// PKCS#7 pad to a 16-byte boundary (always adds 1..=16 bytes).
+fn pkcs7_pad16(data: &[u8]) -> Vec<u8> {
+    let n = 16 - (data.len() % 16);
+    let mut out = data.to_vec();
+    out.extend(std::iter::repeat(n as u8).take(n));
+    out
+}
+
+fn random_iv() -> [u8; 16] {
+    use rand_core::RngCore;
+    let mut iv = [0u8; 16];
+    OsRng.fill_bytes(&mut iv);
+    iv
 }

--- a/crates/keyroost-token2otp/src/crypto.rs
+++ b/crates/keyroost-token2otp/src/crypto.rs
@@ -590,3 +590,280 @@ fn random_iv() -> [u8; 16] {
     OsRng.fill_bytes(&mut iv);
     iv
 }
+
+/// The PIN session crypto, pinned byte-for-byte.
+///
+/// No R3.4 key was available while this was written, so these tests are the
+/// only oracle the layout has: they fix what keyroost sends, so a later change
+/// to the ladder or to any data field has to be a deliberate, argued one rather
+/// than a silent re-framing. Each builder is checked by taking the device's
+/// side — deriving the same keys, decrypting what was sent, and comparing the
+/// recovered plaintext against the exact bytes the protocol calls for.
+#[cfg(test)]
+mod pin_crypto_tests {
+    use super::*;
+    use cbc::cipher::block_padding::NoPadding;
+
+    /// Two fixed scalars, so the whole ladder is deterministic. Values chosen
+    /// only for being valid, in-range P-256 private keys.
+    const HOST_SCALAR: [u8; 32] = [
+        0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F,
+        0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1A, 0x1B, 0x1C, 0x1D, 0x1E,
+        0x1F, 0x20,
+    ];
+    const DEVICE_SCALAR: [u8; 32] = [
+        0xA1, 0xA2, 0xA3, 0xA4, 0xA5, 0xA6, 0xA7, 0xA8, 0xA9, 0xAA, 0xAB, 0xAC, 0xAD, 0xAE, 0xAF,
+        0xB0, 0xB1, 0xB2, 0xB3, 0xB4, 0xB5, 0xB6, 0xB7, 0xB8, 0xB9, 0xBA, 0xBB, 0xBC, 0xBD, 0xBE,
+        0xBF, 0xC0,
+    ];
+
+    fn fixed_pair() -> (SecretKey, Vec<u8>) {
+        let host = SecretKey::from_slice(&HOST_SCALAR).expect("valid P-256 scalar");
+        let device = SecretKey::from_slice(&DEVICE_SCALAR).expect("valid P-256 scalar");
+        let pt = device.public_key().to_encoded_point(false);
+        (host, pt.as_bytes()[1..].to_vec())
+    }
+
+    fn fixed_keys() -> SessionKeys {
+        let (host, device_xy) = fixed_pair();
+        derive_session_keys(&host, &device_xy).expect("fixed vector must derive")
+    }
+
+    fn hex(b: &[u8]) -> String {
+        b.iter().map(|x| format!("{x:02x}")).collect()
+    }
+
+    /// Decrypt as the device would: session key, caller's IV, no unpadding.
+    fn dec_nopad(key: &[u8; 32], iv: &[u8; 16], ct: &[u8]) -> Vec<u8> {
+        let mut buf = ct.to_vec();
+        Aes256CbcDec::new(key.into(), iv.into())
+            .decrypt_padded_mut::<NoPadding>(&mut buf)
+            .expect("block-aligned")
+            .to_vec()
+    }
+
+    #[test]
+    fn session_key_ladder_against_a_fixed_ecdh_vector() {
+        let keys = fixed_keys();
+        // Pinned from the ladder as documented on `SessionKeys`:
+        //   pu1PRKey      = HMAC(0x00*32, sharedX)
+        //   SessionEncKey = HMAC(pu1PRKey, "TOTP AES key"  || 0x01)
+        //   SessionMacKey = HMAC(pu1PRKey, "TOTP HMAC key" || 0x01)
+        assert_eq!(
+            hex(&*keys.enc),
+            "6dd62146130f4f4a162b48ac4e222a6536eccdaac56008d020390e74c5efa9b8"
+        );
+        assert_eq!(
+            hex(&*keys.mac),
+            "175cdcb14128c03413a80403459b512fd5f23d71533276e991a25503ac77a091"
+        );
+    }
+
+    #[test]
+    fn the_ladder_is_a_real_ecdh_both_sides_can_walk() {
+        // The device runs the same ladder from its own private key and the
+        // host's public half; if the two disagree, nothing decrypts on-device.
+        let (host, device_xy) = fixed_pair();
+        let device = SecretKey::from_slice(&DEVICE_SCALAR).unwrap();
+        let host_pt = host.public_key().to_encoded_point(false);
+        let host_xy = &host_pt.as_bytes()[1..];
+
+        let from_host = derive_session_keys(&host, &device_xy).unwrap();
+        let from_device = derive_session_keys(&device, host_xy).unwrap();
+        assert_eq!(*from_host.enc, *from_device.enc);
+        assert_eq!(*from_host.mac, *from_device.mac);
+    }
+
+    #[test]
+    fn agreement_public_half_is_the_raw_xy_the_command_wants() {
+        let a = HostAgreement::new();
+        // 64 bytes, no SEC1 0x04 tag, and a real point (the device rebuilds it).
+        assert_eq!(a.public_xy().len(), 64);
+        let mut sec1 = [0u8; 65];
+        sec1[0] = 0x04;
+        sec1[1..].copy_from_slice(a.public_xy());
+        assert!(PublicKey::from_sec1_bytes(&sec1).is_ok());
+        // A wrong-length device answer is rejected, not assumed. (SessionKeys
+        // has no Debug/PartialEq on purpose — key material does not print.)
+        assert!(matches!(
+            a.establish_session(&[0u8; 63]),
+            Err(EncryptError::BadDevicePubkey)
+        ));
+    }
+
+    #[test]
+    fn set_pin_data_field_layout() {
+        let keys = fixed_keys();
+        let pin = b"246813";
+        let out = build_set_pin_data(&keys, pin, PIN_DEFAULT_MAX_RETRY).unwrap();
+
+        // IV(16) || NewPinEnc(32: a 9-byte block PKCS#7-padded to 16 -> 16) || auth(16)
+        assert_eq!(out.len(), 16 + 16 + 16, "IV || NewPinEnc || NewPinAuth");
+        let iv: [u8; 16] = out[..16].try_into().unwrap();
+        let enc = &out[16..32];
+        let auth = &out[32..];
+
+        // The cleartext block, byte for byte: AlgId, retry, len, pin, PKCS#7.
+        let plain = dec_nopad(&keys.enc, &iv, enc);
+        assert_eq!(
+            plain,
+            vec![
+                0x07, // AlgId = AES256
+                0x64, // max retry
+                0x06, // pin length
+                b'2', b'4', b'6', b'8', b'1', b'3', // the PIN
+                0x07, 0x07, 0x07, 0x07, 0x07, 0x07, 0x07, // PKCS#7 to 16
+            ]
+        );
+        assert_eq!(auth, session_auth_tag(&keys.mac, enc));
+    }
+
+    #[test]
+    fn verify_pin_data_field_is_the_two_layer_proof() {
+        let keys = fixed_keys();
+        let pin = b"246813";
+        let rand = [0x5Au8; 16];
+        let out = build_verify_pin_data(&keys, pin, &rand).unwrap();
+
+        assert_eq!(out.len(), 16 + 16, "IV || PinHashEnc2");
+        let iv: [u8; 16] = out[..16].try_into().unwrap();
+
+        // Outer layer off with the session key…
+        let inner = dec_nopad(&keys.enc, &iv, &out[16..]);
+        // …inner layer off with the key the PIN itself derives, IV = SHA256(Rand)[:16].
+        let pin_key = sha256(pin);
+        let iv2_full = sha256(&rand);
+        let iv2: [u8; 16] = iv2_full[..16].try_into().unwrap();
+        let recovered = dec_nopad(&pin_key, &iv2, &inner);
+        // What the device gets back is exactly its own challenge — the proof.
+        assert_eq!(recovered, rand.to_vec());
+    }
+
+    #[test]
+    fn change_pin_data_field_layout() {
+        let keys = fixed_keys();
+        let out = build_change_pin_data(&keys, b"975312", b"246813", &[0u8; 16]).unwrap();
+
+        // IV(16) || NewPinEnc(16) || NewPinAuth(16) || OldPinHashEnc(16)
+        assert_eq!(out.len(), 64);
+        let iv: [u8; 16] = out[..16].try_into().unwrap();
+        let new_pin_enc = &out[16..32];
+        let auth = &out[32..48];
+        let old_hash_enc = &out[48..64];
+
+        assert_eq!(
+            dec_nopad(&keys.enc, &iv, new_pin_enc),
+            vec![
+                0x07, 0x64, 0x06, b'9', b'7', b'5', b'3', b'1', b'2', //
+                0x07, 0x07, 0x07, 0x07, 0x07, 0x07, 0x07,
+            ]
+        );
+        // The old PIN goes over as SHA256(old)[:16], never in the clear.
+        assert_eq!(
+            dec_nopad(&keys.enc, &iv, old_hash_enc),
+            sha256(b"246813")[..16].to_vec()
+        );
+        // The tag covers both ciphertexts, in that order.
+        let mut mac_input = new_pin_enc.to_vec();
+        mac_input.extend_from_slice(old_hash_enc);
+        assert_eq!(auth, session_auth_tag(&keys.mac, &mac_input));
+    }
+
+    #[test]
+    fn removing_a_pin_is_a_change_to_length_zero() {
+        let keys = fixed_keys();
+        let out = build_change_pin_data(&keys, b"", b"246813", &[0u8; 16]).unwrap();
+        let iv: [u8; 16] = out[..16].try_into().unwrap();
+        // 3-byte body pads to one block; length byte says 0 => no PIN.
+        assert_eq!(
+            dec_nopad(&keys.enc, &iv, &out[16..32]),
+            vec![0x07, 0x64, 0x00, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13]
+        );
+    }
+
+    #[test]
+    fn the_change_proof_does_not_bind_rand() {
+        // Pins the behaviour the code actually has, so the open question stays
+        // visible: two changes differing only in the device challenge produce
+        // the same protected content. See the TODO on `build_change_pin_data`.
+        let keys = fixed_keys();
+        let a = build_change_pin_data(&keys, b"975312", b"246813", &[0x11u8; 16]).unwrap();
+        let b = build_change_pin_data(&keys, b"975312", b"246813", &[0x22u8; 16]).unwrap();
+        // The IVs differ (they are random), so compare what is under them.
+        let iv_a: [u8; 16] = a[..16].try_into().unwrap();
+        let iv_b: [u8; 16] = b[..16].try_into().unwrap();
+        assert_eq!(
+            dec_nopad(&keys.enc, &iv_a, &a[16..32]),
+            dec_nopad(&keys.enc, &iv_b, &b[16..32]),
+        );
+    }
+
+    #[test]
+    fn protected_write_data_field_layout() {
+        let keys = fixed_keys();
+        let cleartext = [0xABu8; 23];
+        let out = build_protected_write_data(&keys, &cleartext);
+
+        // IV(16) || AES-CBC(EncKey, IV, pt)(32 after PKCS#7) || HMAC[:16]
+        assert_eq!(out.len(), 16 + 32 + 16);
+        let iv: [u8; 16] = out[..16].try_into().unwrap();
+        let enc = &out[16..48];
+        assert_eq!(&out[48..], &session_auth_tag(&keys.mac, enc)[..]);
+        let plain = session_decrypt(&keys.enc, &iv, enc).unwrap();
+        assert_eq!(&*plain, &cleartext[..]);
+    }
+
+    #[test]
+    fn a_tag_over_other_bytes_does_not_verify() {
+        let keys = fixed_keys();
+        let tag = session_auth_tag(&keys.mac, b"page");
+        assert!(verify_auth_tag(&keys.mac, b"page", &tag).is_ok());
+        assert_eq!(
+            verify_auth_tag(&keys.mac, b"pagf", &tag),
+            Err(EncryptError::BadAuthTag)
+        );
+        // A short tag is refused rather than compared against a prefix.
+        assert_eq!(
+            verify_auth_tag(&keys.mac, b"page", &tag[..15]),
+            Err(EncryptError::BadAuthTag)
+        );
+    }
+
+    #[test]
+    fn out_of_range_inputs_are_errors_not_panics() {
+        // These builders are public API on a published crate, and both of the
+        // values below can arrive from the other end of a cable.
+        let keys = fixed_keys();
+        let long = vec![b'1'; 256];
+        assert_eq!(
+            build_set_pin_data(&keys, &long, 0x64),
+            Err(EncryptError::BadLength)
+        );
+        assert_eq!(
+            build_change_pin_data(&keys, &long, b"246813", &[0u8; 16]),
+            Err(EncryptError::BadLength)
+        );
+        // A challenge that is not a whole AES block (device-supplied).
+        for bad in [&[][..], &[0u8; 15][..], &[0u8; 17][..]] {
+            assert_eq!(
+                build_verify_pin_data(&keys, b"246813", bad),
+                Err(EncryptError::BadLength)
+            );
+        }
+    }
+
+    #[test]
+    fn session_decrypt_rejects_misaligned_or_empty_input() {
+        let keys = fixed_keys();
+        assert_eq!(
+            session_decrypt(&keys.enc, &[0u8; 16], &[]),
+            Err(EncryptError::BadCiphertext)
+        );
+        assert_eq!(
+            session_decrypt(&keys.enc, &[0u8; 16], &[0u8; 17]),
+            Err(EncryptError::BadCiphertext)
+        );
+        // The unpadded form used for Rand answers empty rather than panicking.
+        assert!(session_decrypt_raw(&keys.enc, &[0u8; 16], &[0u8; 17]).is_empty());
+    }
+}

--- a/crates/keyroost-token2otp/src/crypto.rs
+++ b/crates/keyroost-token2otp/src/crypto.rs
@@ -13,6 +13,7 @@
 //! The two IVs are **constants** by design (spec §7.2). Randomizing them breaks
 //! device-side decryption.
 
+use crate::cmd::{PIN_ALG_AES256, PIN_DEFAULT_MAX_RETRY};
 use aes::Aes256;
 use cbc::cipher::{block_padding::Pkcs7, BlockDecryptMut, BlockEncryptMut, KeyIvInit};
 use hmac::{Hmac, Mac};
@@ -47,6 +48,12 @@ pub enum EncryptError {
     BadCiphertext,
     /// A session HMAC authentication tag did not match.
     BadAuthTag,
+    /// An input to a PIN-proof builder was the wrong size: a PIN longer than
+    /// the single length byte the block format carries, or a challenge that is
+    /// not a whole number of AES blocks. Returned rather than panicking,
+    /// because both values can arrive from a device on the other end of a
+    /// cable and these builders are public API.
+    BadLength,
 }
 
 impl std::fmt::Display for EncryptError {
@@ -58,6 +65,12 @@ impl std::fmt::Display for EncryptError {
             EncryptError::RngFailed => write!(f, "host RNG failed generating ephemeral key"),
             EncryptError::BadCiphertext => write!(f, "session ciphertext failed to decrypt"),
             EncryptError::BadAuthTag => write!(f, "session HMAC authentication tag mismatch"),
+            EncryptError::BadLength => {
+                write!(
+                    f,
+                    "PIN or challenge length is out of range for this command"
+                )
+            }
         }
     }
 }
@@ -254,22 +267,50 @@ pub fn derive_session_keys(
     })
 }
 
-/// Generate a host ephemeral P-256 keypair and derive session keys against the
-/// device's 64-byte agreement pubkey. Returns the host public key as raw
-/// `X || Y` (to send in `READ_AGREEMENT_PUBKEY`) and the derived keys.
+/// A host-side ephemeral keypair for one PIN session, held across the two
+/// halves of the `READ_AGREEMENT_PUBKEY` exchange.
 ///
-/// Convenience wrapper around [`derive_session_keys`] for callers that do not
-/// need to keep the secret around; `transport` uses the split form so the
-/// pubkey it sends matches the keys it derives.
-pub fn establish_session(
-    device_agreement_xy: &[u8],
-) -> Result<([u8; 64], SessionKeys), EncryptError> {
-    let host_secret = SecretKey::random(&mut OsRng);
-    let keys = derive_session_keys(&host_secret, device_agreement_xy)?;
-    let host_point = host_secret.public_key().to_encoded_point(false);
-    let mut host_xy = [0u8; 64];
-    host_xy.copy_from_slice(&host_point.as_bytes()[1..]);
-    Ok((host_xy, keys))
+/// The exchange is inherently two-step — the host must send its public half
+/// *before* the device answers with its own — so a one-shot "generate and
+/// derive" function cannot express it: the keys would be derived against a
+/// different keypair than the one the device saw. Keeping the secret here lets
+/// the transport stay free of any curve arithmetic; it holds an opaque handle
+/// between the two transmits.
+pub struct HostAgreement {
+    secret: SecretKey,
+    public_xy: [u8; 64],
+}
+
+impl HostAgreement {
+    /// Generate a fresh ephemeral P-256 keypair for one session.
+    pub fn new() -> Self {
+        let secret = SecretKey::random(&mut OsRng);
+        let point = secret.public_key().to_encoded_point(false);
+        let mut public_xy = [0u8; 64];
+        public_xy.copy_from_slice(&point.as_bytes()[1..]);
+        Self { secret, public_xy }
+    }
+
+    /// The host public key as raw `X || Y` — the body of the
+    /// `READ_AGREEMENT_PUBKEY` command.
+    pub fn public_xy(&self) -> &[u8; 64] {
+        &self.public_xy
+    }
+
+    /// Finish the exchange: derive the session keys against the device's
+    /// 64-byte agreement pubkey from the same round trip.
+    pub fn establish_session(
+        &self,
+        device_agreement_xy: &[u8],
+    ) -> Result<SessionKeys, EncryptError> {
+        derive_session_keys(&self.secret, device_agreement_xy)
+    }
+}
+
+impl Default for HostAgreement {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 /// AES-256-CBC encrypt `cleartext` (PKCS#7) under the session key with an
@@ -285,8 +326,12 @@ pub fn session_encrypt(key: &[u8; 32], iv: &[u8; 16], cleartext: &[u8]) -> Vec<u
         .to_vec()
 }
 
-/// AES-256-CBC decrypt WITHOUT unpadding — for diagnostics only, so debug
-/// output can show the raw plaintext even when PKCS#7 would reject it.
+/// AES-256-CBC decrypt WITHOUT unpadding.
+///
+/// The PIN challenge (`Rand`) is exactly one block and carries no PKCS#7
+/// trailer, so unpadding would reject it; this is the production path that
+/// recovers it, not a debug aid. Returns an empty vector for input that is not
+/// a whole number of blocks — callers check the recovered length.
 pub fn session_decrypt_raw(key: &[u8; 32], iv: &[u8; 16], ciphertext: &[u8]) -> Vec<u8> {
     if ciphertext.is_empty() || ciphertext.len() % 16 != 0 {
         return Vec::new();
@@ -323,7 +368,12 @@ pub fn session_auth_tag(mac_key: &[u8; 32], data: &[u8]) -> [u8; 16] {
     tag
 }
 
-/// Constant-time-ish check of a 16-byte session auth tag.
+/// Check a 16-byte session auth tag with a branch-free byte compare: every byte
+/// is XOR-folded into one accumulator, so the comparison takes the same path
+/// whatever the tag is. Rust makes no guarantee the optimizer keeps it that
+/// way, hence "branch-free as written" rather than a hard constant-time claim —
+/// the tag is over device-supplied ciphertext, so a timing leak reveals nothing
+/// secret either way.
 pub fn verify_auth_tag(mac_key: &[u8; 32], data: &[u8], tag: &[u8]) -> Result<(), EncryptError> {
     if tag.len() != 16 {
         return Err(EncryptError::BadAuthTag);
@@ -340,8 +390,6 @@ pub fn verify_auth_tag(mac_key: &[u8; 32], data: &[u8], tag: &[u8]) -> Result<()
     }
 }
 
-/// Build the `SET_OTP_PIN` data field: `IV || NewPinEnc || NewPinAuth`, where
-/// `NewPin = alg(0x07) || retry(0x64) || pinLen || pin`, PKCS#7-padded to 16.
 /// Build the data field for a **PIN-protected seed write** (`WRITE_SEED` while a
 /// PIN window is open). Unlike an unprotected write — which is an ECDH blob keyed
 /// by a fresh `GET_ECDH_PUBKEY` — a protected write reuses the verified PIN
@@ -362,12 +410,25 @@ pub fn build_protected_write_data(keys: &SessionKeys, cleartext: &[u8]) -> Vec<u
     out
 }
 
-pub fn build_set_pin_data(keys: &SessionKeys, pin: &[u8], retry: u8) -> Vec<u8> {
+/// Build the `SET_OTP_PIN` data field: `IV || NewPinEnc || NewPinAuth`, where
+/// `NewPin = alg(0x07) || retry || pinLen || pin`, PKCS#7-padded to 16 by
+/// [`session_encrypt`].
+///
+/// The cleartext `NewPin` block is held in a [`Zeroizing`] buffer: it is the
+/// only place the PIN exists in the clear on this side of the wire.
+pub fn build_set_pin_data(
+    keys: &SessionKeys,
+    pin: &[u8],
+    retry: u8,
+) -> Result<Vec<u8>, EncryptError> {
+    // The block carries the PIN length in one byte; a longer PIN cannot be
+    // expressed and must not be silently truncated into a different PIN.
+    let pin_len = u8::try_from(pin.len()).map_err(|_| EncryptError::BadLength)?;
     let iv = random_iv();
-    let mut newpin = Vec::with_capacity(3 + pin.len());
-    newpin.push(0x07); // AlgId = AES256
+    let mut newpin = Zeroizing::new(Vec::with_capacity(3 + pin.len()));
+    newpin.push(PIN_ALG_AES256);
     newpin.push(retry);
-    newpin.push(pin.len() as u8);
+    newpin.push(pin_len);
     newpin.extend_from_slice(pin);
     let enc = session_encrypt(&keys.enc, &iv, &newpin);
     let auth = session_auth_tag(&keys.mac, &enc);
@@ -375,7 +436,7 @@ pub fn build_set_pin_data(keys: &SessionKeys, pin: &[u8], retry: u8) -> Vec<u8> 
     out.extend_from_slice(&iv);
     out.extend_from_slice(&enc);
     out.extend_from_slice(&auth);
-    out
+    Ok(out)
 }
 
 /// Build the `VERIFY_OTP_PIN` data field, matching the Token2 reference client:
@@ -390,24 +451,32 @@ pub fn build_set_pin_data(keys: &SessionKeys, pin: &[u8], retry: u8) -> Vec<u8> 
 /// ```
 ///
 /// `rand` is the 16-byte challenge recovered from the `Lc=0x29` flag read
-/// (`Rand = AES-256-CBC-dec(SessionEncKey, flag.IV, flag.EncRand)`).
-pub fn build_verify_pin_data(keys: &SessionKeys, pin: &[u8], rand: &[u8]) -> Vec<u8> {
+/// (`Rand = AES-256-CBC-dec(SessionEncKey, flag.IV, flag.EncRand)`). A `rand`
+/// that is not a whole number of blocks is rejected with
+/// [`EncryptError::BadLength`] — it arrives from the device, so it is not a
+/// caller bug to assert on.
+pub fn build_verify_pin_data(
+    keys: &SessionKeys,
+    pin: &[u8],
+    rand: &[u8],
+) -> Result<Vec<u8>, EncryptError> {
     // Inner layer: key = SHA256(pin) (32 bytes => AES-256), IV = SHA256(rand)[:16].
-    let pin_hash = sha256(pin);
+    // Both derive straight from the PIN, so both are wiped on the way out.
+    let pin_hash = Zeroizing::new(sha256(pin));
     let iv2_full = sha256(rand);
     let mut iv2 = [0u8; 16];
     iv2.copy_from_slice(&iv2_full[..16]);
     // Encrypt exactly the 16-byte Rand (no padding: it is already one block).
-    let inner = aes256_cbc_encrypt_nopad(&pin_hash, &iv2, rand);
+    let inner = aes256_cbc_encrypt_nopad(&pin_hash, &iv2, rand)?;
 
     // Outer layer under the session key with a fresh IV.
     let iv = random_iv();
-    let outer = aes256_cbc_encrypt_nopad(keys.enc.as_slice().try_into().unwrap(), &iv, &inner);
+    let outer = aes256_cbc_encrypt_nopad(&keys.enc, &iv, &inner)?;
 
     let mut out = Vec::with_capacity(16 + outer.len());
     out.extend_from_slice(&iv);
     out.extend_from_slice(&outer);
-    out
+    Ok(out)
 }
 
 /// Build the `CHANGE_OTP_PIN` data field, matching the Token2 reference client:
@@ -422,26 +491,48 @@ pub fn build_verify_pin_data(keys: &SessionKeys, pin: &[u8], rand: &[u8]) -> Vec
 /// NewPinAuth     = HMAC(SessionMacKey, NewPinEnc || OldPinHashEnc)[0:16]
 /// data field     = IV || NewPinEnc || NewPinAuth || OldPinHashEnc
 /// ```
+///
+/// Note the single IV shared by `NewPinEnc` and `OldPinHashEnc`: that is what
+/// the reference client sends and what the applet expects, so it is not a
+/// choice we can make differently. It is recorded here as a protocol caveat —
+/// CBC under one key with one IV means identical first blocks encrypt
+/// identically, which is why the *old* PIN is hashed before it is encrypted.
+///
+/// `rand` is read from the same `Lc=0x29` challenge round trip that `verify`
+/// uses, but nothing in the block above binds it: the change proof authenticates
+/// the new PIN block and the old PIN hash, not the device's fresh challenge.
+/// The argument is kept so the signature does not have to change if the binding
+/// turns out to be required.
+// TODO(token2): confirm whether the change proof must bind Rand. If it must,
+// the block layout above is incomplete and CHANGE is replayable within a
+// session; if it must not, the transport's challenge read before a change can
+// go away entirely.
 pub fn build_change_pin_data(
     keys: &SessionKeys,
     new_pin: &[u8],
     current_pin: &[u8],
     _rand: &[u8],
-) -> Vec<u8> {
-    let enc_key: &[u8; 32] = keys.enc.as_slice().try_into().unwrap();
-    let mut body = Vec::with_capacity(3 + new_pin.len());
-    body.push(0x07);
-    body.push(0x64);
-    body.push(new_pin.len() as u8);
+) -> Result<Vec<u8>, EncryptError> {
+    // One length byte, as in SET: a longer PIN cannot be expressed here.
+    let new_len = u8::try_from(new_pin.len()).map_err(|_| EncryptError::BadLength)?;
+    let mut body = Zeroizing::new(Vec::with_capacity(3 + new_pin.len()));
+    body.push(PIN_ALG_AES256);
+    // The max-retry byte is rewritten by every change, so a device configured
+    // with a non-default counter is reset to the default here. We keep the
+    // reference client's fixed value because nothing in the protocol material
+    // we have says whether the applet would honour a different one, and a wrong
+    // guess writes a smaller retry budget onto a live key. See TODO above.
+    body.push(PIN_DEFAULT_MAX_RETRY);
+    body.push(new_len);
     body.extend_from_slice(new_pin);
     let body = pkcs7_pad16(&body);
 
     let iv = random_iv();
-    let new_pin_enc = aes256_cbc_encrypt_nopad(enc_key, &iv, &body);
+    let new_pin_enc = aes256_cbc_encrypt_nopad(&keys.enc, &iv, &body)?;
 
-    let old_hash_full = sha256(current_pin);
+    let old_hash_full = Zeroizing::new(sha256(current_pin));
     let old_pin_hash = &old_hash_full[..16]; // 16 bytes, one block
-    let old_pin_hash_enc = aes256_cbc_encrypt_nopad(enc_key, &iv, old_pin_hash);
+    let old_pin_hash_enc = aes256_cbc_encrypt_nopad(&keys.enc, &iv, old_pin_hash)?;
 
     let mut mac_input = Vec::with_capacity(new_pin_enc.len() + old_pin_hash_enc.len());
     mac_input.extend_from_slice(&new_pin_enc);
@@ -453,7 +544,7 @@ pub fn build_change_pin_data(
     out.extend_from_slice(&new_pin_enc);
     out.extend_from_slice(&new_pin_auth);
     out.extend_from_slice(&old_pin_hash_enc);
-    out
+    Ok(out)
 }
 
 /// SHA-256 convenience.
@@ -464,26 +555,32 @@ fn sha256(data: &[u8]) -> [u8; 32] {
 }
 
 /// AES-256-CBC encrypt data that is already a whole number of 16-byte blocks,
-/// with NO padding added. Panics if `data` is not block-aligned.
-fn aes256_cbc_encrypt_nopad(key: &[u8; 32], iv: &[u8; 16], data: &[u8]) -> Vec<u8> {
-    assert!(
-        !data.is_empty() && data.len() % 16 == 0,
-        "aes256_cbc_encrypt_nopad needs block-aligned input"
-    );
+/// with NO padding added. Misaligned or empty input is an
+/// [`EncryptError::BadLength`], not a panic: one caller feeds this a challenge
+/// the device chose.
+fn aes256_cbc_encrypt_nopad(
+    key: &[u8; 32],
+    iv: &[u8; 16],
+    data: &[u8],
+) -> Result<Vec<u8>, EncryptError> {
+    if data.is_empty() || data.len() % 16 != 0 {
+        return Err(EncryptError::BadLength);
+    }
     let mut buf = data.to_vec();
     let n = buf.len();
     // encrypt_padded_mut with NoPadding requires buf already block-aligned.
-    Aes256CbcEnc::new(key.into(), iv.into())
+    Ok(Aes256CbcEnc::new(key.into(), iv.into())
         .encrypt_padded_mut::<cbc::cipher::block_padding::NoPadding>(&mut buf, n)
-        .expect("block-aligned, NoPadding")
-        .to_vec()
+        .map_err(|_| EncryptError::BadLength)?
+        .to_vec())
 }
 
-/// PKCS#7 pad to a 16-byte boundary (always adds 1..=16 bytes).
-fn pkcs7_pad16(data: &[u8]) -> Vec<u8> {
+/// PKCS#7 pad to a 16-byte boundary (always adds 1..=16 bytes). The result is
+/// wiped on drop — its only caller pads a block holding a cleartext PIN.
+fn pkcs7_pad16(data: &[u8]) -> Zeroizing<Vec<u8>> {
     let n = 16 - (data.len() % 16);
-    let mut out = data.to_vec();
-    out.extend(std::iter::repeat(n as u8).take(n));
+    let mut out = Zeroizing::new(data.to_vec());
+    out.extend(std::iter::repeat_n(n as u8, n));
     out
 }
 

--- a/crates/keyroost-token2otp/src/lib.rs
+++ b/crates/keyroost-token2otp/src/lib.rs
@@ -204,13 +204,28 @@ impl OtpError {
             sw::PIN_CONDITIONS_NOT_SATISFIED => Err(OtpError::PinConditionsNotSatisfied),
             sw::PIN_INVALID => Err(OtpError::PinInvalid),
             sw::PIN_LOCKED => Err(OtpError::PinLocked),
+            other => Err(OtpError::BadStatusCode(other)),
+        }
+    }
+
+    /// [`check`](OtpError::check) for the commands that can answer `63NN`.
+    ///
+    /// Only the PIN commands (set / verify / change) return a retry counter, so
+    /// only they get the `63NN` reading. ISO 7816 gives `63xx` a much broader
+    /// meaning — "state of non-volatile memory changed", with `63Cx` the
+    /// counter form — and the "low byte is the literal remaining count"
+    /// interpretation is Token2's. Applying it crate-wide would make an
+    /// unrelated `63xx` from, say, a seed write report "wrong OTP PIN — N
+    /// attempts remaining", which is worse than an unexplained status word.
+    pub fn check_pin(sw: u16) -> Result<(), OtpError> {
+        match sw {
             // `63NN` — wrong PIN, low byte = attempts remaining before lockout.
             // Token2 firmware counts the literal remaining count here (e.g.
             // 0x6362 -> 98 left, 0x6300 -> 0 left). Surface the count instead of
             // an opaque "unexpected status word". A 0-count means the next state
             // is locked, but the applet still signalled it via 63xx here.
             0x6300..=0x63FF => Err(OtpError::PinInvalidRetries((sw & 0x00FF) as u8)),
-            other => Err(OtpError::BadStatusCode(other)),
+            other => OtpError::check(other),
         }
     }
 
@@ -274,8 +289,11 @@ impl std::fmt::Display for OtpError {
                 write!(f, "wrong OTP PIN (or authentication tag mismatch)")
             }
             OtpError::PinInvalidRetries(n) => {
-                write!(f, "wrong OTP PIN — {n} attempt{} remaining before lockout",
-                    if *n == 1 { "" } else { "s" })
+                write!(
+                    f,
+                    "wrong OTP PIN — {n} attempt{} remaining before lockout",
+                    if *n == 1 { "" } else { "s" }
+                )
             }
             OtpError::PinLocked => write!(
                 f,
@@ -302,7 +320,7 @@ impl std::error::Error for OtpError {}
 pub fn read_otp_pin_flag(len: u8) -> Vec<u8> {
     let mut v = cmd::READ_OTP_PIN_FLAG.to_vec();
     v.push(len);
-    v.extend(std::iter::repeat(0x00).take(len as usize));
+    v.extend(std::iter::repeat_n(0x00, len as usize));
     v
 }
 
@@ -367,70 +385,49 @@ impl PinFlag {
     }
 }
 
-/// Enforce the client-side OTP-PIN policy (protocol doc §9). Mirrors the rules
-/// the firmware rejects with `6A80`, surfaced here as a clear message before we
-/// hit the wire. Returns the PIN's byte length on success.
-pub fn validate_otp_pin(pin: &str) -> Result<u8, &'static str> {
+/// An advisory note about a PIN the user is about to set — never a gate.
+///
+/// The applet decides what it accepts and answers with a status word when it
+/// declines; keyroost does not keep a second copy of that policy, because a
+/// host-side copy can only be wrong in one of two directions (rejecting a PIN
+/// the key would have taken, or blessing one it won't) and it drifts with every
+/// firmware revision. So this returns a *hint* to show alongside the entry
+/// field, and the attempt still goes to the device either way.
+///
+/// `None` means nothing worth saying. The wording describes what Token2 keys
+/// have been observed to want, not a rule this crate enforces.
+#[must_use]
+pub fn otp_pin_hint(pin: &str) -> Option<&'static str> {
     let bytes = pin.as_bytes();
+    if bytes.is_empty() {
+        return Some("the PIN is empty");
+    }
     if bytes.len() > 255 {
-        return Err("PIN is too long");
+        return Some("the PIN is longer than the 255 bytes the command can carry");
     }
-    let all_digits = !bytes.is_empty() && bytes.iter().all(|b| b.is_ascii_digit());
+    let all_digits = bytes.iter().all(|b| b.is_ascii_digit());
     if all_digits {
-        validate_numeric_pin(bytes)?;
-    } else {
-        validate_alphanumeric_pin(pin)?;
-    }
-    Ok(bytes.len() as u8)
-}
-
-fn validate_numeric_pin(b: &[u8]) -> Result<(), &'static str> {
-    if b.len() < 6 {
-        return Err("numeric PIN must be at least 6 digits");
-    }
-    if b.iter().all(|&c| c == b[0]) {
-        return Err("numeric PIN must not be all the same digit");
-    }
-    let asc = b.windows(2).all(|w| w[1] == w[0] + 1);
-    let desc = b.windows(2).all(|w| w[0] == w[1] + 1);
-    if asc || desc {
-        return Err("numeric PIN must not be a simple ascending/descending sequence");
-    }
-    if b.iter().eq(b.iter().rev()) {
-        return Err("numeric PIN must not be a palindrome");
-    }
-    for d in b'0'..=b'9' {
-        if b.iter().filter(|&&c| c == d).count() > 3 {
-            return Err("numeric PIN repeats a single digit too many times");
+        if bytes.len() < 6 {
+            return Some("keys typically want a numeric PIN of at least 6 digits");
         }
+        if bytes.iter().all(|&c| c == bytes[0]) {
+            return Some("keys typically reject a PIN that is one repeated digit");
+        }
+        let asc = bytes.windows(2).all(|w| w[1] == w[0] + 1);
+        let desc = bytes.windows(2).all(|w| w[0] == w[1] + 1);
+        if asc || desc {
+            return Some("keys typically reject a straight ascending/descending run");
+        }
+    } else if pin.chars().count() < 10 {
+        return Some("keys typically want a non-numeric PIN of at least 10 characters");
     }
-    Ok(())
+    None
 }
 
-fn validate_alphanumeric_pin(pin: &str) -> Result<(), &'static str> {
-    if pin.chars().count() < 10 {
-        return Err("alphanumeric PIN must be at least 10 characters");
-    }
-    let mut classes = 0;
-    if pin.chars().any(|c| c.is_ascii_uppercase()) {
-        classes += 1;
-    }
-    if pin.chars().any(|c| c.is_ascii_lowercase()) {
-        classes += 1;
-    }
-    if pin.chars().any(|c| c.is_ascii_digit()) {
-        classes += 1;
-    }
-    if pin.chars().any(|c| !c.is_ascii_alphanumeric() && !c.is_whitespace()) {
-        classes += 1;
-    }
-    if classes < 2 {
-        return Err("alphanumeric PIN must mix at least two of: upper, lower, digit, symbol");
-    }
-    Ok(())
-}
-
-
+/// Build an extended-length APDU: `CLA INS P1 P2 00 Lc_hi Lc_lo data...`
+/// (spec §3). Used for every command except the PC/SC SELECT, which is
+/// short-form via [`build_select`], and the PIN-flag read, which the applet
+/// wants in short form with a placeholder body (see [`read_otp_pin_flag`]).
 ///
 /// The device ignores Le and returns whatever it has, so none is appended.
 pub fn build_apdu(header: [u8; 4], data: &[u8]) -> Vec<u8> {

--- a/crates/keyroost-token2otp/src/lib.rs
+++ b/crates/keyroost-token2otp/src/lib.rs
@@ -385,45 +385,6 @@ impl PinFlag {
     }
 }
 
-/// An advisory note about a PIN the user is about to set — never a gate.
-///
-/// The applet decides what it accepts and answers with a status word when it
-/// declines; keyroost does not keep a second copy of that policy, because a
-/// host-side copy can only be wrong in one of two directions (rejecting a PIN
-/// the key would have taken, or blessing one it won't) and it drifts with every
-/// firmware revision. So this returns a *hint* to show alongside the entry
-/// field, and the attempt still goes to the device either way.
-///
-/// `None` means nothing worth saying. The wording describes what Token2 keys
-/// have been observed to want, not a rule this crate enforces.
-#[must_use]
-pub fn otp_pin_hint(pin: &str) -> Option<&'static str> {
-    let bytes = pin.as_bytes();
-    if bytes.is_empty() {
-        return Some("the PIN is empty");
-    }
-    if bytes.len() > 255 {
-        return Some("the PIN is longer than the 255 bytes the command can carry");
-    }
-    let all_digits = bytes.iter().all(|b| b.is_ascii_digit());
-    if all_digits {
-        if bytes.len() < 6 {
-            return Some("keys typically want a numeric PIN of at least 6 digits");
-        }
-        if bytes.iter().all(|&c| c == bytes[0]) {
-            return Some("keys typically reject a PIN that is one repeated digit");
-        }
-        let asc = bytes.windows(2).all(|w| w[1] == w[0] + 1);
-        let desc = bytes.windows(2).all(|w| w[0] == w[1] + 1);
-        if asc || desc {
-            return Some("keys typically reject a straight ascending/descending run");
-        }
-    } else if pin.chars().count() < 10 {
-        return Some("keys typically want a non-numeric PIN of at least 10 characters");
-    }
-    None
-}
-
 /// Build an extended-length APDU: `CLA INS P1 P2 00 Lc_hi Lc_lo data...`
 /// (spec §3). Used for every command except the PC/SC SELECT, which is
 /// short-form via [`build_select`], and the PIN-flag read, which the applet
@@ -1125,18 +1086,5 @@ mod otp_pin_wire_tests {
         ] {
             assert_eq!(OtpError::check_pin(sw_), OtpError::check(sw_));
         }
-    }
-
-    #[test]
-    fn the_pin_hint_advises_and_never_decides() {
-        // It returns text, not a verdict the caller must obey — the device is
-        // the only thing that gets to reject a PIN.
-        assert!(otp_pin_hint("246813").is_none());
-        assert!(otp_pin_hint("correct horse battery").is_none());
-        assert!(otp_pin_hint("12345").is_some()); // short numeric
-        assert!(otp_pin_hint("111111").is_some()); // one repeated digit
-        assert!(otp_pin_hint("123456").is_some()); // straight run
-        assert!(otp_pin_hint("").is_some());
-        assert!(otp_pin_hint(&"1".repeat(300)).is_some());
     }
 }

--- a/crates/keyroost-token2otp/src/lib.rs
+++ b/crates/keyroost-token2otp/src/lib.rs
@@ -84,6 +84,34 @@ pub mod cmd {
     /// `GET_INFO` on the FIDO applet — read serial number, §6.10 (reference only).
     pub const READ_SERIAL_INS: [u8; 4] = [0x80, 0x33, 0x00, 0x00];
 
+    // --- OTP PIN / privacy protection (R3.4 / manual V1.2) -------------------
+    // On R3.4+ firmware the OTP applet can require a PIN before it returns codes.
+    // These commands read the PIN state, establish an ECDH session, and set /
+    // verify / change / remove the PIN. Rejected as unsupported on older firmware
+    // (the existing `sw::FUNCTION_NOT_SUPPORTED` / `OtpError::FunctionNotSupported`
+    // and `HidNotSupported` cover those status words).
+    /// `READ_OTP_PIN_FLAG` — device returns PIN status; Lc selects how much.
+    pub const READ_OTP_PIN_FLAG: [u8; 4] = [0x80, 0xC5, 0x05, 0x04];
+    /// `SET_OTP_PIN` — set a PIN from the unprotected state.
+    pub const SET_OTP_PIN: [u8; 4] = [0x80, 0xC5, 0x05, 0x05];
+    /// `VERIFY_OTP_PIN` — open a read window (also the lock form, 1-byte body).
+    pub const VERIFY_OTP_PIN: [u8; 4] = [0x80, 0xC5, 0x05, 0x06];
+    /// `CHANGE_OTP_PIN` — change or remove an existing PIN.
+    pub const CHANGE_OTP_PIN: [u8; 4] = [0x80, 0xC5, 0x05, 0x08];
+    /// `READ_AGREEMENT_PUBKEY` — ECDH agreement for the PIN session.
+    pub const READ_AGREEMENT_PUBKEY: [u8; 4] = [0x80, 0xC5, 0x05, 0x09];
+
+    /// Lc for the short PIN-flag read: `PinAlgId,PinRetry,OtpPinLen,PinMaxRetry`.
+    pub const PIN_FLAG_LC_BASE: u8 = 0x04;
+    /// Lc for the priming PIN-flag read done before the ECDH handshake.
+    pub const PIN_FLAG_LC_PRIME: u8 = 0x09;
+    /// Lc for the PIN-flag read that also returns the verify challenge.
+    pub const PIN_FLAG_LC_CHALLENGE: u8 = 0x29;
+    /// AES-256 PIN algorithm id used in the NewPin block.
+    pub const PIN_ALG_AES256: u8 = 0x07;
+    /// Default max-retry value written into a new PIN block.
+    pub const PIN_DEFAULT_MAX_RETRY: u8 = 0x64;
+
     /// ENUM_CODES subcommand: read one entry by name (§6.2).
     pub const SUB_READ_ONE: u8 = 0x01;
     /// ENUM_CODES subcommand: code-only, no metadata (§6, unused by reference).
@@ -153,6 +181,10 @@ pub enum OtpError {
     PinConditionsNotSatisfied,
     /// `6982` — wrong OTP PIN, or an authentication-tag mismatch.
     PinInvalid,
+    /// `63NN` — wrong OTP PIN, with the low byte carrying the number of attempts
+    /// still remaining before the PIN locks. Token2 firmware counts down the
+    /// literal remaining count here (e.g. `0x6362` = 98 left), so we surface it.
+    PinInvalidRetries(u8),
     /// `6983` — OTP PIN locked; a global OTP reset is required to recover it.
     PinLocked,
     /// Any other non-`9000` status word.
@@ -172,6 +204,12 @@ impl OtpError {
             sw::PIN_CONDITIONS_NOT_SATISFIED => Err(OtpError::PinConditionsNotSatisfied),
             sw::PIN_INVALID => Err(OtpError::PinInvalid),
             sw::PIN_LOCKED => Err(OtpError::PinLocked),
+            // `63NN` — wrong PIN, low byte = attempts remaining before lockout.
+            // Token2 firmware counts the literal remaining count here (e.g.
+            // 0x6362 -> 98 left, 0x6300 -> 0 left). Surface the count instead of
+            // an opaque "unexpected status word". A 0-count means the next state
+            // is locked, but the applet still signalled it via 63xx here.
+            0x6300..=0x63FF => Err(OtpError::PinInvalidRetries((sw & 0x00FF) as u8)),
             other => Err(OtpError::BadStatusCode(other)),
         }
     }
@@ -205,6 +243,7 @@ impl OtpError {
             OtpError::FunctionNotSupported => sw::FUNCTION_NOT_SUPPORTED,
             OtpError::PinConditionsNotSatisfied => sw::PIN_CONDITIONS_NOT_SATISFIED,
             OtpError::PinInvalid => sw::PIN_INVALID,
+            OtpError::PinInvalidRetries(n) => 0x6300 | (*n as u16),
             OtpError::PinLocked => sw::PIN_LOCKED,
             OtpError::BadStatusCode(sw) => *sw,
         }
@@ -234,6 +273,10 @@ impl std::fmt::Display for OtpError {
             OtpError::PinInvalid => {
                 write!(f, "wrong OTP PIN (or authentication tag mismatch)")
             }
+            OtpError::PinInvalidRetries(n) => {
+                write!(f, "wrong OTP PIN — {n} attempt{} remaining before lockout",
+                    if *n == 1 { "" } else { "s" })
+            }
             OtpError::PinLocked => write!(
                 f,
                 "the OTP PIN is locked after too many wrong attempts; a global \
@@ -246,9 +289,148 @@ impl std::fmt::Display for OtpError {
 
 impl std::error::Error for OtpError {}
 
-/// Build an extended-length APDU: `CLA INS P1 P2 00 Lc_hi Lc_lo data...`
-/// (spec §3). Used for every command except the PC/SC SELECT, which is
-/// short-form via [`build_select`].
+// --- OTP PIN (R3.4 privacy protection) ---------------------------------------
+// These reuse the existing `OtpError` / `sw` PIN status words (PinInvalid 6982,
+// PinLocked 6983, FunctionNotSupported 6A81, PinConditionsNotSatisfied 6985)
+// already handled by `OtpError::check`. Ported from the Token2 reference client.
+
+/// Build the `READ_OTP_PIN_FLAG` request. The flag read is a short-Lc command
+/// carrying a placeholder body of `len` zero bytes: `CLA INS P1 P2 len || len*00`.
+/// The applet reads `len` (04/09/29), overwrites the placeholder, and returns
+/// `len` bytes of PIN-flag data (chaining via 61xx). A bodyless read is rejected
+/// with 6AF8 (confirmed against R3.4 firmware).
+pub fn read_otp_pin_flag(len: u8) -> Vec<u8> {
+    let mut v = cmd::READ_OTP_PIN_FLAG.to_vec();
+    v.push(len);
+    v.extend(std::iter::repeat(0x00).take(len as usize));
+    v
+}
+
+/// Build the OTP-PIN **lock** request. It shares the `VERIFY_OTP_PIN` header but
+/// is distinguished by a single `0x00` body sent with short-form Lc; the applet
+/// closes the read/write window immediately (the window a verify opens for
+/// ~5 minutes).
+pub fn lock_otp_pin() -> Vec<u8> {
+    let mut v = cmd::VERIFY_OTP_PIN.to_vec();
+    v.push(0x01); // short Lc = 1
+    v.push(0x00); // body
+    v
+}
+
+/// Build the `READ_AGREEMENT_PUBKEY` request. `host_pub_xy` is the host's
+/// ephemeral P-256 public key as raw `X || Y` (64 bytes, no leading `0x04`).
+pub fn read_agreement_pubkey(host_pub_xy: &[u8]) -> Vec<u8> {
+    build_apdu(cmd::READ_AGREEMENT_PUBKEY, host_pub_xy)
+}
+
+/// Decoded fixed head of a `READ_OTP_PIN_FLAG` response.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PinFlag {
+    pub alg_id: u8,
+    pub retries_left: u8,
+    pub pin_len: u8,
+    pub max_retries: u8,
+    /// Present only on the `Lc = 0x29` read: the verify challenge
+    /// (`IV(16) || EncRand(16)`), still encrypted under the session key.
+    pub challenge: Option<([u8; 16], [u8; 16])>,
+}
+
+impl PinFlag {
+    /// A PIN is set iff the reported PIN length is non-zero.
+    pub fn is_set(&self) -> bool {
+        self.pin_len != 0
+    }
+
+    /// Parse the response. Layout matches the Token2 reference client:
+    /// `AlgId(1) Retry(1) PinLen(1) MaxRetry(1) FpEnable(1) PubVer(2) PubCrc(2)`
+    /// then, on the `Lc=0x29` read, `IV(16) EncRand(16)` starting at offset 9.
+    pub fn parse(data: &[u8]) -> Result<Self, ParseError> {
+        if data.len() < 4 {
+            return Err(ParseError::Truncated);
+        }
+        let challenge = if data.len() >= 41 {
+            let mut iv = [0u8; 16];
+            let mut enc = [0u8; 16];
+            iv.copy_from_slice(&data[9..25]);
+            enc.copy_from_slice(&data[25..41]);
+            Some((iv, enc))
+        } else {
+            None
+        };
+        Ok(PinFlag {
+            alg_id: data[0],
+            retries_left: data[1],
+            pin_len: data[2],
+            max_retries: data[3],
+            challenge,
+        })
+    }
+}
+
+/// Enforce the client-side OTP-PIN policy (protocol doc §9). Mirrors the rules
+/// the firmware rejects with `6A80`, surfaced here as a clear message before we
+/// hit the wire. Returns the PIN's byte length on success.
+pub fn validate_otp_pin(pin: &str) -> Result<u8, &'static str> {
+    let bytes = pin.as_bytes();
+    if bytes.len() > 255 {
+        return Err("PIN is too long");
+    }
+    let all_digits = !bytes.is_empty() && bytes.iter().all(|b| b.is_ascii_digit());
+    if all_digits {
+        validate_numeric_pin(bytes)?;
+    } else {
+        validate_alphanumeric_pin(pin)?;
+    }
+    Ok(bytes.len() as u8)
+}
+
+fn validate_numeric_pin(b: &[u8]) -> Result<(), &'static str> {
+    if b.len() < 6 {
+        return Err("numeric PIN must be at least 6 digits");
+    }
+    if b.iter().all(|&c| c == b[0]) {
+        return Err("numeric PIN must not be all the same digit");
+    }
+    let asc = b.windows(2).all(|w| w[1] == w[0] + 1);
+    let desc = b.windows(2).all(|w| w[0] == w[1] + 1);
+    if asc || desc {
+        return Err("numeric PIN must not be a simple ascending/descending sequence");
+    }
+    if b.iter().eq(b.iter().rev()) {
+        return Err("numeric PIN must not be a palindrome");
+    }
+    for d in b'0'..=b'9' {
+        if b.iter().filter(|&&c| c == d).count() > 3 {
+            return Err("numeric PIN repeats a single digit too many times");
+        }
+    }
+    Ok(())
+}
+
+fn validate_alphanumeric_pin(pin: &str) -> Result<(), &'static str> {
+    if pin.chars().count() < 10 {
+        return Err("alphanumeric PIN must be at least 10 characters");
+    }
+    let mut classes = 0;
+    if pin.chars().any(|c| c.is_ascii_uppercase()) {
+        classes += 1;
+    }
+    if pin.chars().any(|c| c.is_ascii_lowercase()) {
+        classes += 1;
+    }
+    if pin.chars().any(|c| c.is_ascii_digit()) {
+        classes += 1;
+    }
+    if pin.chars().any(|c| !c.is_ascii_alphanumeric() && !c.is_whitespace()) {
+        classes += 1;
+    }
+    if classes < 2 {
+        return Err("alphanumeric PIN must mix at least two of: upper, lower, digit, symbol");
+    }
+    Ok(())
+}
+
+
 ///
 /// The device ignores Le and returns whatever it has, so none is appended.
 pub fn build_apdu(header: [u8; 4], data: &[u8]) -> Vec<u8> {

--- a/crates/keyroost-token2otp/src/lib.rs
+++ b/crates/keyroost-token2otp/src/lib.rs
@@ -990,3 +990,153 @@ mod vendor_status_words {
         }
     }
 }
+
+/// The R3.4 OTP-PIN command set, pinned byte-for-byte.
+///
+/// The vendor's announcement (#107) describes the feature, not the wire, and no
+/// R3.4 key was on hand when this landed — so these tests are the record of
+/// what keyroost sends. A later edit to any of these builders has to change a
+/// test and say why, rather than quietly re-framing a command.
+#[cfg(test)]
+mod otp_pin_wire_tests {
+    use super::*;
+
+    #[test]
+    fn pin_flag_read_is_short_lc_with_a_zero_placeholder_body() {
+        // `CLA INS P1 P2 len || len*00` — the applet reads `len`, overwrites the
+        // placeholder, and answers with `len` bytes. NOT build_apdu's form.
+        assert_eq!(
+            read_otp_pin_flag(cmd::PIN_FLAG_LC_BASE),
+            vec![0x80, 0xC5, 0x05, 0x04, 0x04, 0x00, 0x00, 0x00, 0x00]
+        );
+
+        let prime = read_otp_pin_flag(cmd::PIN_FLAG_LC_PRIME);
+        assert_eq!(&prime[..5], &[0x80, 0xC5, 0x05, 0x04, 0x09]);
+        assert_eq!(prime.len(), 5 + 9);
+        assert!(prime[5..].iter().all(|&b| b == 0x00));
+
+        let challenge = read_otp_pin_flag(cmd::PIN_FLAG_LC_CHALLENGE);
+        assert_eq!(&challenge[..5], &[0x80, 0xC5, 0x05, 0x04, 0x29]);
+        assert_eq!(challenge.len(), 5 + 41);
+        assert!(challenge[5..].iter().all(|&b| b == 0x00));
+
+        // Lc = 0 is a bodyless read, which R3.4 rejects with 6AF8; the builder
+        // still produces the honest 5-byte form rather than inventing a body.
+        assert_eq!(read_otp_pin_flag(0), vec![0x80, 0xC5, 0x05, 0x04, 0x00]);
+    }
+
+    #[test]
+    fn lock_is_the_verify_header_with_a_single_zero_byte() {
+        assert_eq!(lock_otp_pin(), vec![0x80, 0xC5, 0x05, 0x06, 0x01, 0x00]);
+    }
+
+    #[test]
+    fn agreement_pubkey_carries_the_raw_64_byte_host_key() {
+        let host_xy = [0xAAu8; 64];
+        let apdu = read_agreement_pubkey(&host_xy);
+        assert_eq!(&apdu[..4], &[0x80, 0xC5, 0x05, 0x09]);
+        assert_eq!(apdu[4], 0x40, "short-form Lc = 64");
+        assert_eq!(&apdu[5..], &host_xy[..]);
+        assert_eq!(apdu.len(), 5 + 64);
+    }
+
+    /// A `Lc = 0x29` flag response: the 9-byte head, then IV(16) || EncRand(16).
+    fn challenge_response() -> Vec<u8> {
+        let mut v = vec![0x07, 0x62, 0x06, 0x64, 0x00, 0x00, 0x01, 0x12, 0x34];
+        v.extend_from_slice(&[0x11u8; 16]); // IV
+        v.extend_from_slice(&[0x22u8; 16]); // EncRand
+        v
+    }
+
+    #[test]
+    fn pin_flag_head_and_challenge_parse_at_the_documented_offsets() {
+        let flag = PinFlag::parse(&challenge_response()).unwrap();
+        assert_eq!(flag.alg_id, 0x07);
+        assert_eq!(flag.retries_left, 0x62);
+        assert_eq!(flag.pin_len, 0x06);
+        assert_eq!(flag.max_retries, 0x64);
+        assert!(flag.is_set());
+        let (iv, enc) = flag.challenge.expect("41 bytes carries the challenge");
+        assert_eq!(iv, [0x11u8; 16]);
+        assert_eq!(enc, [0x22u8; 16]);
+    }
+
+    #[test]
+    fn a_pin_length_of_zero_means_no_pin_is_set() {
+        let flag = PinFlag::parse(&[0x07, 0x64, 0x00, 0x64]).unwrap();
+        assert!(!flag.is_set());
+        assert!(
+            flag.challenge.is_none(),
+            "the short read carries no challenge"
+        );
+    }
+
+    #[test]
+    fn short_and_truncated_flag_responses_are_errors_not_panics() {
+        // Under the 4-byte head: nothing to report.
+        for n in 0..4 {
+            assert_eq!(PinFlag::parse(&vec![0u8; n]), Err(ParseError::Truncated));
+        }
+        // Head present, challenge partially there: the head still parses and the
+        // challenge is simply absent rather than sliced out of bounds.
+        for n in 4..41 {
+            let flag = PinFlag::parse(&vec![0x07u8; n]).expect("head is complete");
+            assert!(
+                flag.challenge.is_none(),
+                "{n} bytes cannot hold a challenge"
+            );
+        }
+        // Longer than expected: trailing bytes are ignored, not misread.
+        let mut long = challenge_response();
+        long.extend_from_slice(&[0xFFu8; 32]);
+        assert_eq!(
+            PinFlag::parse(&long).unwrap(),
+            PinFlag::parse(&challenge_response()).unwrap()
+        );
+    }
+
+    #[test]
+    fn the_retry_count_reading_belongs_to_the_pin_commands_only() {
+        // Token2 firmware puts the literal remaining count in the low byte…
+        assert_eq!(
+            OtpError::check_pin(0x6362),
+            Err(OtpError::PinInvalidRetries(98))
+        );
+        assert_eq!(
+            OtpError::check_pin(0x6300),
+            Err(OtpError::PinInvalidRetries(0))
+        );
+        // …but 63xx means far more than that in ISO 7816, so a command that
+        // cannot be answering about a PIN keeps the raw status word.
+        assert_eq!(
+            OtpError::check(0x6362),
+            Err(OtpError::BadStatusCode(0x6362))
+        );
+        assert_eq!(
+            OtpError::check(0x63C2),
+            Err(OtpError::BadStatusCode(0x63C2))
+        );
+        // Everything else is unchanged between the two.
+        for sw_ in [
+            sw::OK,
+            sw::PIN_INVALID,
+            sw::PIN_LOCKED,
+            sw::FUNCTION_NOT_SUPPORTED,
+        ] {
+            assert_eq!(OtpError::check_pin(sw_), OtpError::check(sw_));
+        }
+    }
+
+    #[test]
+    fn the_pin_hint_advises_and_never_decides() {
+        // It returns text, not a verdict the caller must obey — the device is
+        // the only thing that gets to reject a PIN.
+        assert!(otp_pin_hint("246813").is_none());
+        assert!(otp_pin_hint("correct horse battery").is_none());
+        assert!(otp_pin_hint("12345").is_some()); // short numeric
+        assert!(otp_pin_hint("111111").is_some()); // one repeated digit
+        assert!(otp_pin_hint("123456").is_some()); // straight run
+        assert!(otp_pin_hint("").is_some());
+        assert!(otp_pin_hint(&"1".repeat(300)).is_some());
+    }
+}

--- a/crates/keyroost-transport/Cargo.toml
+++ b/crates/keyroost-transport/Cargo.toml
@@ -22,12 +22,6 @@ keyroost-hid = { path = "../keyroost-hid", version = "0.8.0" }
 # implements it so FIDO2 commands can run over a smart-card reader, not just USB-HID.
 keyroost-ctap = { path = "../keyroost-ctap", version = "0.8.0" }
 pcsc = "2"
-# P-256 ECDH + OS RNG for the OTP-PIN session handshake (READ_AGREEMENT_PUBKEY):
-# the host generates an ephemeral keypair, sends its public half, and derives the
-# session keys against the device's agreement key. Same versions as
-# keyroost-token2otp, which owns the key-derivation itself.
-p256 = { version = "0.13", default-features = false, features = ["arithmetic", "ecdh"] }
-rand_core = { version = "0.6", default-features = false, features = ["getrandom"] }
 # hidapi backs the Token2 OTP USB-HID transport on macOS / Windows; Linux uses
 # the dependency-free hidraw `File` path (same split as keyroost-ctap). Optional
 # + cfg-gated so a default Linux build pulls nothing extra.

--- a/crates/keyroost-transport/Cargo.toml
+++ b/crates/keyroost-transport/Cargo.toml
@@ -22,6 +22,12 @@ keyroost-hid = { path = "../keyroost-hid", version = "0.8.0" }
 # implements it so FIDO2 commands can run over a smart-card reader, not just USB-HID.
 keyroost-ctap = { path = "../keyroost-ctap", version = "0.8.0" }
 pcsc = "2"
+# P-256 ECDH + OS RNG for the OTP-PIN session handshake (READ_AGREEMENT_PUBKEY):
+# the host generates an ephemeral keypair, sends its public half, and derives the
+# session keys against the device's agreement key. Same versions as
+# keyroost-token2otp, which owns the key-derivation itself.
+p256 = { version = "0.13", default-features = false, features = ["arithmetic", "ecdh"] }
+rand_core = { version = "0.6", default-features = false, features = ["getrandom"] }
 # hidapi backs the Token2 OTP USB-HID transport on macOS / Windows; Linux uses
 # the dependency-free hidraw `File` path (same split as keyroost-ctap). Optional
 # + cfg-gated so a default Linux build pulls nothing extra.

--- a/crates/keyroost-transport/src/token2otp.rs
+++ b/crates/keyroost-transport/src/token2otp.rs
@@ -90,9 +90,10 @@ pub enum OtpTransportError {
     /// The key has an OTP PIN set, but no PIN was supplied for an operation that
     /// needs one (the caller — CLI or GUI — should prompt for it and retry).
     PinRequired,
-    /// A supplied PIN failed the client-side policy check (before it was sent to
-    /// the device); the message describes which rule.
-    InvalidPin(&'static str),
+    /// A PIN operation needed the ECDH session keys and none were cached. An
+    /// internal ordering fault, distinct from a short or malformed device
+    /// response — which is what reusing `Parse(Truncated)` for it used to say.
+    PinSessionMissing,
 }
 
 impl std::fmt::Display for OtpTransportError {
@@ -145,7 +146,9 @@ impl std::fmt::Display for OtpTransportError {
                 f,
                 "this key's OTP codes are PIN-protected; supply the OTP PIN to unlock them"
             ),
-            OtpTransportError::InvalidPin(m) => write!(f, "invalid OTP PIN: {}", m),
+            OtpTransportError::PinSessionMissing => {
+                write!(f, "no OTP-PIN session was established before a PIN command")
+            }
         }
     }
 }
@@ -746,6 +749,10 @@ pub struct Token2OtpSession {
     /// Whether a successful `VERIFY_OTP_PIN` has opened the device read window on
     /// this connection.
     pin_verified: bool,
+    /// What the most recent flag read on this connection said: `Some(true)` a
+    /// PIN is set, `Some(false)` the feature is there and no PIN is set, `None`
+    /// nothing has asked yet or the key does not offer the feature.
+    pin_present: Option<bool>,
 }
 
 /// Host-owned caps on the `ENUM_CODES` pagination loop (audit KEY-009). Both
@@ -886,6 +893,7 @@ impl Token2OtpSession {
                         is_pcsc: false,
                         pin_session: None,
                         pin_verified: false,
+                        pin_present: None,
                     }),
                     Err((probe_err, _)) => {
                         // HID present but the applet didn't accept the probe
@@ -897,6 +905,7 @@ impl Token2OtpSession {
                                 is_pcsc: true,
                                 pin_session: None,
                                 pin_verified: false,
+                                pin_present: None,
                             }),
                             // No CCID either. Both outcomes matter now: which
                             // kind of HID failure it was, and why CCID could
@@ -913,6 +922,7 @@ impl Token2OtpSession {
                     is_pcsc: true,
                     pin_session: None,
                     pin_verified: false,
+                    pin_present: None,
                 })
             }
             Err(e) => Err(e),
@@ -930,6 +940,7 @@ impl Token2OtpSession {
             is_pcsc: false,
             pin_session: None,
             pin_verified: false,
+            pin_present: None,
         })
     }
 
@@ -941,6 +952,7 @@ impl Token2OtpSession {
             is_pcsc: true,
             pin_session: None,
             pin_verified: false,
+            pin_present: None,
         })
     }
 
@@ -955,6 +967,7 @@ impl Token2OtpSession {
             is_pcsc: false,
             pin_session: None,
             pin_verified: false,
+            pin_present: None,
         })
     }
 
@@ -967,6 +980,7 @@ impl Token2OtpSession {
             is_pcsc: true,
             pin_session: None,
             pin_verified: false,
+            pin_present: None,
         })
     }
 
@@ -977,6 +991,7 @@ impl Token2OtpSession {
             is_pcsc: false,
             pin_session: None,
             pin_verified: false,
+            pin_present: None,
         }
     }
 
@@ -987,6 +1002,7 @@ impl Token2OtpSession {
             is_pcsc: true,
             pin_session: None,
             pin_verified: false,
+            pin_present: None,
         }
     }
 
@@ -1053,7 +1069,7 @@ impl Token2OtpSession {
         let keys = self
             .pin_session
             .as_ref()
-            .ok_or(OtpTransportError::Parse(ParseError::Truncated))?;
+            .ok_or(OtpTransportError::PinSessionMissing)?;
         if data.len() < 16 + 16 + 16 {
             return Err(OtpTransportError::Parse(ParseError::Truncated));
         }
@@ -1069,16 +1085,49 @@ impl Token2OtpSession {
 
     /// Read the PIN flag (base form): reports whether a PIN is set, retry counts.
     /// Needs no session.
-    pub fn pin_status(&mut self) -> Result<t2::PinFlag, OtpTransportError> {
+    ///
+    /// `Ok(None)` means **the key does not offer the OTP-PIN feature** — not an
+    /// error. keyroost keeps no firmware-version table; it offers the surface
+    /// and lets the attempt report the truth. A key whose applet predates R3.4
+    /// has never heard of `80 C5 05 04` and says so with a status word (`6A81`,
+    /// `6D00`, `6A86`, `6AF8` — the exact one varies by model and channel), and
+    /// a key that answers with a body too short to parse has told us just as
+    /// little. Both mean "no PIN here", and every caller must carry on exactly
+    /// as it did before this feature existed: an unprotected key's list, add and
+    /// delete are not allowed to start failing because a capability probe came
+    /// back negative.
+    ///
+    /// A genuine I/O failure still propagates — that is the transport breaking,
+    /// not the applet declining.
+    pub fn pin_status(&mut self) -> Result<Option<t2::PinFlag>, OtpTransportError> {
         let apdu = t2::read_otp_pin_flag(t2::cmd::PIN_FLAG_LC_BASE);
         let (data, sw) = self.transport.transmit(&apdu, false)?;
-        OtpError::check(sw)?;
-        Ok(t2::PinFlag::parse(&data)?)
+        let flag = if sw == t2::sw::OK {
+            t2::PinFlag::parse(&data).ok()
+        } else {
+            None
+        };
+        self.pin_present = flag.as_ref().map(|f| f.is_set());
+        Ok(flag)
     }
 
-    /// True if the key currently has an OTP PIN set.
+    /// True if the key currently has an OTP PIN set. A key without the PIN
+    /// feature reports `false` — see [`pin_status`](Self::pin_status).
     pub fn pin_is_set(&mut self) -> Result<bool, OtpTransportError> {
-        Ok(self.pin_status()?.is_set())
+        Ok(self.pin_status()?.is_some_and(|f| f.is_set()))
+    }
+
+    /// Whether the last flag read on this connection found a PIN set, without
+    /// spending another round trip. `None` until one has run, and after one that
+    /// found no PIN feature at all.
+    ///
+    /// Only ever filled by [`pin_status`](Self::pin_status), which every
+    /// `*_pinned` call runs first, so a caller that has just enumerated is
+    /// reading what the key said moments ago on this same connection — not a
+    /// value carried across devices or sessions.
+    #[must_use]
+    pub fn pin_set_cached(&self) -> Option<bool> {
+        self.pin_present
     }
 
     /// Establish an authenticated ECDH session and cache the derived keys.
@@ -1091,10 +1140,6 @@ impl Token2OtpSession {
     /// *authenticity* is not cryptographically checked — see the reference
     /// client's identical caveat.
     pub fn open_session(&mut self) -> Result<(), OtpTransportError> {
-        use p256::elliptic_curve::sec1::ToEncodedPoint;
-        use p256::SecretKey;
-        use rand_core::OsRng;
-
         // The reference sequence reads the PIN flag FIRST (Lc=09) before the
         // handshake — this primes the device PIN state. Skipping it makes a
         // subsequent SET fail with 6985.
@@ -1102,12 +1147,11 @@ impl Token2OtpSession {
         let (_pdata, psw) = self.transport.transmit(&prime, false)?;
         OtpError::check(psw)?;
 
-        let host_secret = SecretKey::random(&mut OsRng);
-        let host_point = host_secret.public_key().to_encoded_point(false);
-        let mut host_xy = [0u8; 64];
-        host_xy.copy_from_slice(&host_point.as_bytes()[1..]);
-
-        let apdu = t2::read_agreement_pubkey(&host_xy);
+        // The ephemeral keypair and every curve operation live in the byte
+        // layer, which is where this crate's split puts the crypto; the
+        // transport only carries the two halves of the exchange.
+        let agreement = t2::crypto::HostAgreement::new();
+        let apdu = t2::read_agreement_pubkey(agreement.public_xy());
         let (data, sw) = self.transport.transmit(&apdu, false)?;
         OtpError::check(sw)?;
         // Response: devPub(64) || sig(132). We consume devPub; sig is unverified.
@@ -1116,7 +1160,7 @@ impl Token2OtpSession {
         }
         let dev_xy = &data[..64];
 
-        let keys = t2::crypto::derive_session_keys(&host_secret, dev_xy)?;
+        let keys = agreement.establish_session(dev_xy)?;
         self.pin_session = Some(keys);
         self.pin_verified = false;
         Ok(())
@@ -1131,14 +1175,21 @@ impl Token2OtpSession {
     }
 
     /// Set an OTP PIN on a currently-unprotected key.
+    ///
+    /// The PIN is not screened here: the applet owns that policy and reports
+    /// what it will not take (`keyroost_token2otp::otp_pin_hint` exists to
+    /// *advise* a user before they commit, not to gate the attempt).
     pub fn set_pin(&mut self, pin: &str) -> Result<(), OtpTransportError> {
-        t2::validate_otp_pin(pin).map_err(OtpTransportError::InvalidPin)?;
         self.ensure_session()?;
-        let keys = self.pin_session.as_ref().expect("session ensured above");
-        let data = t2::crypto::build_set_pin_data(keys, pin.as_bytes(), t2::cmd::PIN_DEFAULT_MAX_RETRY);
+        let keys = self
+            .pin_session
+            .as_ref()
+            .ok_or(OtpTransportError::PinSessionMissing)?;
+        let data =
+            t2::crypto::build_set_pin_data(keys, pin.as_bytes(), t2::cmd::PIN_DEFAULT_MAX_RETRY)?;
         let apdu = t2::build_apdu(t2::cmd::SET_OTP_PIN, &data);
         let (_, sw) = self.transport.transmit(&apdu, false)?;
-        OtpError::check(sw)?;
+        OtpError::check_pin(sw)?;
         Ok(())
     }
 
@@ -1149,7 +1200,7 @@ impl Token2OtpSession {
         // Fetch the verify challenge: IV || EncRand (Lc = 0x29).
         let flag_apdu = t2::read_otp_pin_flag(t2::cmd::PIN_FLAG_LC_CHALLENGE);
         let (data, sw) = self.transport.transmit(&flag_apdu, false)?;
-        OtpError::check(sw)?;
+        OtpError::check_pin(sw)?;
         let flag = t2::PinFlag::parse(&data)?;
         if !flag.is_set() {
             return Err(OtpTransportError::PinRequired);
@@ -1158,24 +1209,27 @@ impl Token2OtpSession {
             .challenge
             .ok_or(OtpTransportError::Parse(ParseError::Truncated))?;
 
-        let keys = self.pin_session.as_ref().expect("session ensured above");
+        let keys = self
+            .pin_session
+            .as_ref()
+            .ok_or(OtpTransportError::PinSessionMissing)?;
         // Rand is a raw 16-byte block with NO PKCS#7 padding.
         let rand = t2::crypto::session_decrypt_raw(&keys.enc, &iv, &enc_rand);
         if rand.len() != 16 {
             return Err(OtpTransportError::Encrypt(EncryptError::BadCiphertext));
         }
 
-        let data_field = t2::crypto::build_verify_pin_data(keys, pin.as_bytes(), &rand);
+        let data_field = t2::crypto::build_verify_pin_data(keys, pin.as_bytes(), &rand)?;
         let apdu = t2::build_apdu(t2::cmd::VERIFY_OTP_PIN, &data_field);
         let (_, sw) = self.transport.transmit(&apdu, false)?;
-        OtpError::check(sw)?;
+        OtpError::check_pin(sw)?;
         self.pin_verified = true;
         Ok(())
     }
 
-    /// Change the OTP PIN (requires the current PIN).
+    /// Change the OTP PIN (requires the current PIN). The new PIN is not
+    /// screened here — see [`set_pin`](Self::set_pin).
     pub fn change_pin(&mut self, current: &str, new: &str) -> Result<(), OtpTransportError> {
-        t2::validate_otp_pin(new).map_err(OtpTransportError::InvalidPin)?;
         self.change_pin_inner(current, Some(new))
     }
 
@@ -1190,25 +1244,32 @@ impl Token2OtpSession {
         new: Option<&str>,
     ) -> Result<(), OtpTransportError> {
         self.ensure_session()?;
-        // The change proof binds the current PIN to the fresh Rand, like verify.
+        // The reference sequence reads the challenge before a change, and the
+        // Rand it yields is passed on to the builder — but nothing in the change
+        // block binds it (see the TODO on `build_change_pin_data`). The read is
+        // kept because it is what the applet has been observed to expect; it is
+        // deliberately NOT described here as a binding the bytes don't perform.
         let flag_apdu = t2::read_otp_pin_flag(t2::cmd::PIN_FLAG_LC_CHALLENGE);
         let (data, sw) = self.transport.transmit(&flag_apdu, false)?;
-        OtpError::check(sw)?;
+        OtpError::check_pin(sw)?;
         let flag = t2::PinFlag::parse(&data)?;
         let (iv, enc_rand) = flag
             .challenge
             .ok_or(OtpTransportError::Parse(ParseError::Truncated))?;
-        let keys = self.pin_session.as_ref().expect("session ensured above");
+        let keys = self
+            .pin_session
+            .as_ref()
+            .ok_or(OtpTransportError::PinSessionMissing)?;
         let rand = t2::crypto::session_decrypt_raw(&keys.enc, &iv, &enc_rand);
         if rand.len() != 16 {
             return Err(OtpTransportError::Encrypt(EncryptError::BadCiphertext));
         }
         let new_bytes = new.map(|s| s.as_bytes()).unwrap_or(&[]);
         let data_field =
-            t2::crypto::build_change_pin_data(keys, new_bytes, current.as_bytes(), &rand);
+            t2::crypto::build_change_pin_data(keys, new_bytes, current.as_bytes(), &rand)?;
         let apdu = t2::build_apdu(t2::cmd::CHANGE_OTP_PIN, &data_field);
         let (_, sw) = self.transport.transmit(&apdu, false)?;
-        OtpError::check(sw)?;
+        OtpError::check_pin(sw)?;
         self.pin_verified = false;
         Ok(())
     }
@@ -1719,6 +1780,7 @@ mod enumerate_bounds_tests {
             is_pcsc: false,
             pin_session: None,
             pin_verified: false,
+            pin_present: None,
         };
         let res = session.enumerate(0);
         assert!(
@@ -1759,6 +1821,7 @@ mod enumerate_bounds_tests {
             is_pcsc: false,
             pin_session: None,
             pin_verified: false,
+            pin_present: None,
         };
         let entries = session.enumerate(0).expect("two pages must enumerate");
         assert_eq!(entries.len(), 2);

--- a/crates/keyroost-transport/src/token2otp.rs
+++ b/crates/keyroost-transport/src/token2otp.rs
@@ -1177,8 +1177,7 @@ impl Token2OtpSession {
     /// Set an OTP PIN on a currently-unprotected key.
     ///
     /// The PIN is not screened here: the applet owns that policy and reports
-    /// what it will not take (`keyroost_token2otp::otp_pin_hint` exists to
-    /// *advise* a user before they commit, not to gate the attempt).
+    /// what it will not take.
     pub fn set_pin(&mut self, pin: &str) -> Result<(), OtpTransportError> {
         self.ensure_session()?;
         let keys = self

--- a/crates/keyroost-transport/src/token2otp.rs
+++ b/crates/keyroost-transport/src/token2otp.rs
@@ -1972,3 +1972,251 @@ mod declined_probe_is_not_an_unusable_interface {
         }
     }
 }
+
+/// A key that has never heard of the OTP-PIN command must behave exactly as it
+/// did before the feature existed.
+///
+/// The PIN-flag read now runs ahead of every list, add and delete, so the way
+/// an older applet answers it decides whether those still work. Firmware before
+/// R3.4 answers `80 C5 05 04` with whatever its dispatcher says for an unknown
+/// instruction — the exact status word varies by model and channel — and none
+/// of those may become a failure the user sees.
+#[cfg(test)]
+mod pre_r34_keys_are_unaffected {
+    use super::*;
+    use std::cell::RefCell;
+    use std::rc::Rc;
+
+    /// The `ENUM_CODES` READ_ALL APDU as `main` builds it, byte for byte: the
+    /// short-Lc 9-byte body carrying the subcommand and a big-endian timestamp.
+    /// Pinned here rather than rebuilt, so a change to the builder shows up as a
+    /// diff in *this* test too.
+    const ENUM_READ_ALL_AT_T0: [u8; 14] = [
+        0x80, 0xC5, 0x05, 0x00, // ENUM_CODES
+        0x09, // short Lc
+        0x03, // SUB_READ_ALL
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // timestamp 0
+    ];
+
+    /// One valid single-entry page (spec §10.1), never encrypted.
+    fn cleartext_page() -> Vec<u8> {
+        let mut payload = vec![0x01, 0xC1, 0x00, 0x1E, 0x06, 0x00, 0x04];
+        payload.extend_from_slice(b"Test");
+        payload.push(0x05);
+        payload.extend_from_slice(b"alice");
+        payload.push(0x06);
+        payload.extend_from_slice(b"123456");
+        payload
+    }
+
+    /// The P-256 generator, as the raw `X || Y` a `GET_ECDH_PUBKEY` answers
+    /// with. Any valid point does; this one needs no key generation in a test.
+    const DEVICE_PUB_XY: [u8; 64] = [
+        0x6B, 0x17, 0xD1, 0xF2, 0xE1, 0x2C, 0x42, 0x47, 0xF8, 0xBC, 0xE6, 0xE5, 0x63, 0xA4, 0x40,
+        0xF2, 0x77, 0x03, 0x7D, 0x81, 0x2D, 0xEB, 0x33, 0xA0, 0xF4, 0xA1, 0x39, 0x45, 0xD8, 0x98,
+        0xC2, 0x96, 0x4F, 0xE3, 0x42, 0xE2, 0xFE, 0x1A, 0x7F, 0x9B, 0x8E, 0xE7, 0xEB, 0x4A, 0x7C,
+        0x0F, 0x9E, 0x16, 0x2B, 0xCE, 0x33, 0x57, 0x6B, 0x31, 0x5E, 0xCE, 0xCB, 0xB6, 0x40, 0x68,
+        0x37, 0xBF, 0x51, 0xF5,
+    ];
+
+    /// Stands in for pre-R3.4 firmware: the PIN-flag instruction gets `sw`, and
+    /// everything else answers the way it always has. Records every APDU.
+    struct OldFirmware {
+        flag_sw: u16,
+        sent: Rc<RefCell<Vec<Vec<u8>>>>,
+    }
+
+    impl OtpTransport for OldFirmware {
+        fn transmit(
+            &mut self,
+            apdu: &[u8],
+            _detect_button_wait: bool,
+        ) -> Result<(Vec<u8>, u16), OtpTransportError> {
+            self.sent.borrow_mut().push(apdu.to_vec());
+            match apdu.get(..4) {
+                Some(h) if h == t2::cmd::READ_OTP_PIN_FLAG => Ok((Vec::new(), self.flag_sw)),
+                Some(h) if h == t2::cmd::GET_ECDH_PUBKEY => Ok((DEVICE_PUB_XY.to_vec(), 0x9000)),
+                Some(h) if h == t2::cmd::ENUM_CODES => Ok((cleartext_page(), 0x9000)),
+                _ => Ok((Vec::new(), 0x9000)),
+            }
+        }
+    }
+
+    fn old_key(flag_sw: u16) -> (Token2OtpSession, Rc<RefCell<Vec<Vec<u8>>>>) {
+        let sent = Rc::new(RefCell::new(Vec::new()));
+        let session = Token2OtpSession {
+            transport: Box::new(OldFirmware {
+                flag_sw,
+                sent: sent.clone(),
+            }),
+            is_pcsc: false,
+            pin_session: None,
+            pin_verified: false,
+            pin_present: None,
+        };
+        (session, sent)
+    }
+
+    /// Every status word an applet has been seen to use for "I don't know that
+    /// instruction", plus the generic wrong-length and wrong-P1P2 answers.
+    const UNKNOWN_INSTRUCTION_ANSWERS: [u16; 6] = [
+        0x6A81, // function not supported in the current state
+        0x6D00, // instruction not supported
+        0x6A86, // incorrect P1/P2
+        0x6AF8, // what R3.4 itself answers a bodyless flag read
+        0x6700, // wrong length
+        0x6E00, // class not supported
+    ];
+
+    #[test]
+    fn listing_still_works_and_sends_the_same_bytes_as_before() {
+        for sw in UNKNOWN_INSTRUCTION_ANSWERS {
+            let (mut session, sent) = old_key(sw);
+            let entries = session
+                .enumerate_pinned(0, None)
+                .unwrap_or_else(|e| panic!("a key answering {sw:#06X} must still list: {e}"));
+            assert_eq!(entries.len(), 1);
+            assert_eq!(entries[0].account_name, "alice");
+            assert_eq!(entries[0].code.as_deref(), Some("123456"));
+
+            // The only new traffic is the capability probe itself; the
+            // enumeration is byte-identical to what shipped before the PIN work.
+            let sent = sent.borrow();
+            assert_eq!(sent.len(), 2, "one flag read, then the enumeration");
+            assert_eq!(&sent[0][..4], &t2::cmd::READ_OTP_PIN_FLAG);
+            assert_eq!(sent[1], ENUM_READ_ALL_AT_T0);
+        }
+    }
+
+    #[test]
+    fn writing_and_deleting_still_work() {
+        for sw in UNKNOWN_INSTRUCTION_ANSWERS {
+            let (mut session, sent) = old_key(sw);
+            let entry = WriteEntry {
+                otp_type: t2::OtpType::Totp,
+                algorithm: t2::Algorithm::Sha1,
+                timestep: 30,
+                code_length: 6,
+                button_required: false,
+                app_name: "Test",
+                account_name: "alice",
+                seed: &[0u8; 20],
+            };
+            session
+                .write_entry_pinned(&entry, None)
+                .unwrap_or_else(|e| panic!("a key answering {sw:#06X} must still write: {e}"));
+            // The unprotected write still goes out as an ECDH-sealed blob —
+            // the session-key path is only for a verified PIN window.
+            let seen = sent.borrow().clone();
+            assert!(seen.iter().any(|a| a[..4] == t2::cmd::GET_ECDH_PUBKEY));
+            assert!(seen.iter().any(|a| a[..4] == t2::cmd::WRITE_SEED));
+
+            let (mut session, _) = old_key(sw);
+            session
+                .delete_entry_pinned("Test", "alice", None)
+                .unwrap_or_else(|e| panic!("a key answering {sw:#06X} must still delete: {e}"));
+        }
+    }
+
+    #[test]
+    fn the_pin_state_reads_as_absent_rather_than_as_an_error() {
+        for sw in UNKNOWN_INSTRUCTION_ANSWERS {
+            let (mut session, _) = old_key(sw);
+            assert!(
+                session.pin_status().expect("not an error").is_none(),
+                "{sw:#06X} means the feature is not there"
+            );
+            assert!(!session.pin_is_set().unwrap());
+            assert_eq!(session.pin_set_cached(), None);
+        }
+    }
+
+    #[test]
+    fn a_body_too_short_to_parse_is_also_just_absent() {
+        // A key that answers 9000 with nothing useful has told us as little as
+        // one that declined outright.
+        struct EmptyOk;
+        impl OtpTransport for EmptyOk {
+            fn transmit(
+                &mut self,
+                apdu: &[u8],
+                _b: bool,
+            ) -> Result<(Vec<u8>, u16), OtpTransportError> {
+                if apdu[..4] == t2::cmd::READ_OTP_PIN_FLAG {
+                    Ok((vec![0x07, 0x64], 0x9000)) // under the 4-byte head
+                } else {
+                    Ok((cleartext_page(), 0x9000))
+                }
+            }
+        }
+        let mut session = Token2OtpSession {
+            transport: Box::new(EmptyOk),
+            is_pcsc: false,
+            pin_session: None,
+            pin_verified: false,
+            pin_present: None,
+        };
+        assert!(session.pin_status().unwrap().is_none());
+        assert_eq!(session.enumerate_pinned(0, None).unwrap().len(), 1);
+    }
+
+    #[test]
+    fn a_transport_failure_is_still_a_failure() {
+        // Degrading on a status word must not swallow a broken cable: the
+        // applet declining and the interface not working are different facts.
+        struct Dead;
+        impl OtpTransport for Dead {
+            fn transmit(
+                &mut self,
+                _a: &[u8],
+                _b: bool,
+            ) -> Result<(Vec<u8>, u16), OtpTransportError> {
+                Err(OtpTransportError::EmptyResponse)
+            }
+        }
+        let mut session = Token2OtpSession {
+            transport: Box::new(Dead),
+            is_pcsc: false,
+            pin_session: None,
+            pin_verified: false,
+            pin_present: None,
+        };
+        assert!(matches!(
+            session.pin_status(),
+            Err(OtpTransportError::EmptyResponse)
+        ));
+    }
+
+    #[test]
+    fn a_protected_key_with_no_pin_supplied_asks_for_one() {
+        // The other side of the same branch: a key that DOES answer the flag
+        // read, and reports a PIN, must not silently list nothing.
+        struct Protected;
+        impl OtpTransport for Protected {
+            fn transmit(
+                &mut self,
+                apdu: &[u8],
+                _b: bool,
+            ) -> Result<(Vec<u8>, u16), OtpTransportError> {
+                if apdu[..4] == t2::cmd::READ_OTP_PIN_FLAG {
+                    // AlgId, retries left, PIN length 6, max retries.
+                    Ok((vec![0x07, 0x64, 0x06, 0x64], 0x9000))
+                } else {
+                    Ok((cleartext_page(), 0x9000))
+                }
+            }
+        }
+        let mut session = Token2OtpSession {
+            transport: Box::new(Protected),
+            is_pcsc: false,
+            pin_session: None,
+            pin_verified: false,
+            pin_present: None,
+        };
+        assert!(matches!(
+            session.enumerate_pinned(0, None),
+            Err(OtpTransportError::PinRequired)
+        ));
+        assert_eq!(session.pin_set_cached(), Some(true));
+    }
+}

--- a/crates/keyroost-transport/src/token2otp.rs
+++ b/crates/keyroost-transport/src/token2otp.rs
@@ -87,6 +87,12 @@ pub enum OtpTransportError {
     /// fault is whatever stopped CCID — for the reporter, a smart-card service
     /// that was not running.
     HidDeclinedAndNoCcid { sw: u16, ccid: String },
+    /// The key has an OTP PIN set, but no PIN was supplied for an operation that
+    /// needs one (the caller — CLI or GUI — should prompt for it and retry).
+    PinRequired,
+    /// A supplied PIN failed the client-side policy check (before it was sent to
+    /// the device); the message describes which rule.
+    InvalidPin(&'static str),
 }
 
 impl std::fmt::Display for OtpTransportError {
@@ -135,6 +141,11 @@ impl std::fmt::Display for OtpTransportError {
                 sw,
                 ccid
             ),
+            OtpTransportError::PinRequired => write!(
+                f,
+                "this key's OTP codes are PIN-protected; supply the OTP PIN to unlock them"
+            ),
+            OtpTransportError::InvalidPin(m) => write!(f, "invalid OTP PIN: {}", m),
         }
     }
 }
@@ -729,6 +740,12 @@ impl OtpTransport for PcScOtpTransport {
 pub struct Token2OtpSession {
     transport: Box<dyn OtpTransport>,
     is_pcsc: bool,
+    /// ECDH session keys, established lazily on the first PIN operation. `None`
+    /// until then.
+    pin_session: Option<t2::crypto::SessionKeys>,
+    /// Whether a successful `VERIFY_OTP_PIN` has opened the device read window on
+    /// this connection.
+    pin_verified: bool,
 }
 
 /// Host-owned caps on the `ENUM_CODES` pagination loop (audit KEY-009). Both
@@ -867,6 +884,8 @@ impl Token2OtpSession {
                     Ok(t) => Ok(Self {
                         transport: Box::new(t),
                         is_pcsc: false,
+                        pin_session: None,
+                        pin_verified: false,
                     }),
                     Err((probe_err, _)) => {
                         // HID present but the applet didn't accept the probe
@@ -876,6 +895,8 @@ impl Token2OtpSession {
                             Ok(p) => Ok(Self {
                                 transport: Box::new(p),
                                 is_pcsc: true,
+                                pin_session: None,
+                                pin_verified: false,
                             }),
                             // No CCID either. Both outcomes matter now: which
                             // kind of HID failure it was, and why CCID could
@@ -890,6 +911,8 @@ impl Token2OtpSession {
                 Ok(Self {
                     transport: Box::new(t),
                     is_pcsc: true,
+                    pin_session: None,
+                    pin_verified: false,
                 })
             }
             Err(e) => Err(e),
@@ -905,6 +928,8 @@ impl Token2OtpSession {
         Ok(Self {
             transport: Box::new(t),
             is_pcsc: false,
+            pin_session: None,
+            pin_verified: false,
         })
     }
 
@@ -914,6 +939,8 @@ impl Token2OtpSession {
         Ok(Self {
             transport: Box::new(t),
             is_pcsc: true,
+            pin_session: None,
+            pin_verified: false,
         })
     }
 
@@ -926,6 +953,8 @@ impl Token2OtpSession {
         Ok(Self {
             transport: Box::new(t),
             is_pcsc: false,
+            pin_session: None,
+            pin_verified: false,
         })
     }
 
@@ -936,6 +965,8 @@ impl Token2OtpSession {
         Ok(Self {
             transport: Box::new(t),
             is_pcsc: true,
+            pin_session: None,
+            pin_verified: false,
         })
     }
 
@@ -944,6 +975,8 @@ impl Token2OtpSession {
         Self {
             transport: Box::new(t),
             is_pcsc: false,
+            pin_session: None,
+            pin_verified: false,
         }
     }
 
@@ -952,6 +985,8 @@ impl Token2OtpSession {
         Self {
             transport: Box::new(t),
             is_pcsc: true,
+            pin_session: None,
+            pin_verified: false,
         }
     }
 
@@ -980,6 +1015,7 @@ impl Token2OtpSession {
             }
             return Err(e.into());
         }
+        let data = self.maybe_decrypt_page(&data)?;
         let mut page = t2::parse_enum_page(&data)?;
         let mut entries = page.entries;
         let mut pages = 1usize;
@@ -993,6 +1029,7 @@ impl Token2OtpSession {
             let cont = t2::build_apdu(cmd::ENUM_CODES_CONTINUE, &timestamp.to_be_bytes());
             let (data, sw) = self.transport.transmit(&cont, false)?;
             OtpError::check(sw)?;
+            let data = self.maybe_decrypt_page(&data)?;
             page = t2::parse_enum_page(&data)?;
             entries.extend(page.entries);
         }
@@ -1002,6 +1039,250 @@ impl Token2OtpSession {
             return Err(OtpTransportError::EnumerationCapExceeded);
         }
         Ok(entries)
+    }
+
+    /// On a PIN-protected key with the read window open (after `verify_pin`), the
+    /// applet returns enumeration/read pages ENCRYPTED under the session key:
+    /// `IV(16) || AES-CBC(SessionEncKey, IV, page) || HMAC(SessionMacKey, enc)[:16]`.
+    /// Decrypt and authenticate before parsing. When the window isn't open (no
+    /// PIN, or not verified) the page is already cleartext and returned as-is.
+    fn maybe_decrypt_page(&self, data: &[u8]) -> Result<Vec<u8>, OtpTransportError> {
+        if !self.pin_verified {
+            return Ok(data.to_vec());
+        }
+        let keys = self
+            .pin_session
+            .as_ref()
+            .ok_or(OtpTransportError::Parse(ParseError::Truncated))?;
+        if data.len() < 16 + 16 + 16 {
+            return Err(OtpTransportError::Parse(ParseError::Truncated));
+        }
+        let iv: [u8; 16] = data[..16].try_into().expect("checked length");
+        let enc = &data[16..data.len() - 16];
+        let auth = &data[data.len() - 16..];
+        t2::crypto::verify_auth_tag(&keys.mac, enc, auth)?;
+        let plain = t2::crypto::session_decrypt(&keys.enc, &iv, enc)?;
+        Ok(plain.to_vec())
+    }
+
+    // --- OTP PIN (R3.4 privacy protection) -----------------------------------
+
+    /// Read the PIN flag (base form): reports whether a PIN is set, retry counts.
+    /// Needs no session.
+    pub fn pin_status(&mut self) -> Result<t2::PinFlag, OtpTransportError> {
+        let apdu = t2::read_otp_pin_flag(t2::cmd::PIN_FLAG_LC_BASE);
+        let (data, sw) = self.transport.transmit(&apdu, false)?;
+        OtpError::check(sw)?;
+        Ok(t2::PinFlag::parse(&data)?)
+    }
+
+    /// True if the key currently has an OTP PIN set.
+    pub fn pin_is_set(&mut self) -> Result<bool, OtpTransportError> {
+        Ok(self.pin_status()?.is_set())
+    }
+
+    /// Establish an authenticated ECDH session and cache the derived keys.
+    /// Required before any PIN command and before reading PIN-protected entries.
+    ///
+    /// NOTE: the protocol also returns an ECC-P521 signature over
+    /// `hostPub || devPub` that the host *should* verify against the device's
+    /// P-521 key. This is NOT verified here: the P-256 crate can't check a P-521
+    /// signature. The ECDH still provides session confidentiality, but device
+    /// *authenticity* is not cryptographically checked — see the reference
+    /// client's identical caveat.
+    pub fn open_session(&mut self) -> Result<(), OtpTransportError> {
+        use p256::elliptic_curve::sec1::ToEncodedPoint;
+        use p256::SecretKey;
+        use rand_core::OsRng;
+
+        // The reference sequence reads the PIN flag FIRST (Lc=09) before the
+        // handshake — this primes the device PIN state. Skipping it makes a
+        // subsequent SET fail with 6985.
+        let prime = t2::read_otp_pin_flag(t2::cmd::PIN_FLAG_LC_PRIME);
+        let (_pdata, psw) = self.transport.transmit(&prime, false)?;
+        OtpError::check(psw)?;
+
+        let host_secret = SecretKey::random(&mut OsRng);
+        let host_point = host_secret.public_key().to_encoded_point(false);
+        let mut host_xy = [0u8; 64];
+        host_xy.copy_from_slice(&host_point.as_bytes()[1..]);
+
+        let apdu = t2::read_agreement_pubkey(&host_xy);
+        let (data, sw) = self.transport.transmit(&apdu, false)?;
+        OtpError::check(sw)?;
+        // Response: devPub(64) || sig(132). We consume devPub; sig is unverified.
+        if data.len() < 64 {
+            return Err(OtpTransportError::Parse(ParseError::Truncated));
+        }
+        let dev_xy = &data[..64];
+
+        let keys = t2::crypto::derive_session_keys(&host_secret, dev_xy)?;
+        self.pin_session = Some(keys);
+        self.pin_verified = false;
+        Ok(())
+    }
+
+    /// Open a session if one isn't already cached.
+    fn ensure_session(&mut self) -> Result<(), OtpTransportError> {
+        if self.pin_session.is_none() {
+            self.open_session()?;
+        }
+        Ok(())
+    }
+
+    /// Set an OTP PIN on a currently-unprotected key.
+    pub fn set_pin(&mut self, pin: &str) -> Result<(), OtpTransportError> {
+        t2::validate_otp_pin(pin).map_err(OtpTransportError::InvalidPin)?;
+        self.ensure_session()?;
+        let keys = self.pin_session.as_ref().expect("session ensured above");
+        let data = t2::crypto::build_set_pin_data(keys, pin.as_bytes(), t2::cmd::PIN_DEFAULT_MAX_RETRY);
+        let apdu = t2::build_apdu(t2::cmd::SET_OTP_PIN, &data);
+        let (_, sw) = self.transport.transmit(&apdu, false)?;
+        OtpError::check(sw)?;
+        Ok(())
+    }
+
+    /// Verify the OTP PIN, opening the device read window for this connection so
+    /// subsequent `enumerate`/`read_entry` calls return usable codes.
+    pub fn verify_pin(&mut self, pin: &str) -> Result<(), OtpTransportError> {
+        self.ensure_session()?;
+        // Fetch the verify challenge: IV || EncRand (Lc = 0x29).
+        let flag_apdu = t2::read_otp_pin_flag(t2::cmd::PIN_FLAG_LC_CHALLENGE);
+        let (data, sw) = self.transport.transmit(&flag_apdu, false)?;
+        OtpError::check(sw)?;
+        let flag = t2::PinFlag::parse(&data)?;
+        if !flag.is_set() {
+            return Err(OtpTransportError::PinRequired);
+        }
+        let (iv, enc_rand) = flag
+            .challenge
+            .ok_or(OtpTransportError::Parse(ParseError::Truncated))?;
+
+        let keys = self.pin_session.as_ref().expect("session ensured above");
+        // Rand is a raw 16-byte block with NO PKCS#7 padding.
+        let rand = t2::crypto::session_decrypt_raw(&keys.enc, &iv, &enc_rand);
+        if rand.len() != 16 {
+            return Err(OtpTransportError::Encrypt(EncryptError::BadCiphertext));
+        }
+
+        let data_field = t2::crypto::build_verify_pin_data(keys, pin.as_bytes(), &rand);
+        let apdu = t2::build_apdu(t2::cmd::VERIFY_OTP_PIN, &data_field);
+        let (_, sw) = self.transport.transmit(&apdu, false)?;
+        OtpError::check(sw)?;
+        self.pin_verified = true;
+        Ok(())
+    }
+
+    /// Change the OTP PIN (requires the current PIN).
+    pub fn change_pin(&mut self, current: &str, new: &str) -> Result<(), OtpTransportError> {
+        t2::validate_otp_pin(new).map_err(OtpTransportError::InvalidPin)?;
+        self.change_pin_inner(current, Some(new))
+    }
+
+    /// Remove the OTP PIN (a change to length 0; requires the current PIN).
+    pub fn remove_pin(&mut self, current: &str) -> Result<(), OtpTransportError> {
+        self.change_pin_inner(current, None)
+    }
+
+    fn change_pin_inner(
+        &mut self,
+        current: &str,
+        new: Option<&str>,
+    ) -> Result<(), OtpTransportError> {
+        self.ensure_session()?;
+        // The change proof binds the current PIN to the fresh Rand, like verify.
+        let flag_apdu = t2::read_otp_pin_flag(t2::cmd::PIN_FLAG_LC_CHALLENGE);
+        let (data, sw) = self.transport.transmit(&flag_apdu, false)?;
+        OtpError::check(sw)?;
+        let flag = t2::PinFlag::parse(&data)?;
+        let (iv, enc_rand) = flag
+            .challenge
+            .ok_or(OtpTransportError::Parse(ParseError::Truncated))?;
+        let keys = self.pin_session.as_ref().expect("session ensured above");
+        let rand = t2::crypto::session_decrypt_raw(&keys.enc, &iv, &enc_rand);
+        if rand.len() != 16 {
+            return Err(OtpTransportError::Encrypt(EncryptError::BadCiphertext));
+        }
+        let new_bytes = new.map(|s| s.as_bytes()).unwrap_or(&[]);
+        let data_field =
+            t2::crypto::build_change_pin_data(keys, new_bytes, current.as_bytes(), &rand);
+        let apdu = t2::build_apdu(t2::cmd::CHANGE_OTP_PIN, &data_field);
+        let (_, sw) = self.transport.transmit(&apdu, false)?;
+        OtpError::check(sw)?;
+        self.pin_verified = false;
+        Ok(())
+    }
+
+    /// Close the PIN read/write window immediately (the window a verify opens for
+    /// ~5 minutes). After this, protected reads/writes need a fresh verify.
+    pub fn lock_pin(&mut self) -> Result<(), OtpTransportError> {
+        let apdu = t2::lock_otp_pin();
+        let (_, sw) = self.transport.transmit(&apdu, false)?;
+        OtpError::check(sw)?;
+        self.pin_verified = false;
+        Ok(())
+    }
+
+    /// If the key has an OTP PIN set, verify `pin` to open the read/write window;
+    /// if no PIN is set, this is a no-op. Returns [`OtpTransportError::PinRequired`]
+    /// when a PIN is set but `pin` is `None`.
+    pub fn unlock_if_pinned(&mut self, pin: Option<&str>) -> Result<(), OtpTransportError> {
+        if self.pin_is_set()? {
+            match pin {
+                Some(p) => self.verify_pin(p)?,
+                None => return Err(OtpTransportError::PinRequired),
+            }
+        }
+        Ok(())
+    }
+
+    /// List entries, transparently handling a PIN-protected key: if a PIN is set,
+    /// `pin` must be supplied (it is verified to open the read window). When a PIN
+    /// is set but `pin` is `None`, returns [`OtpTransportError::PinRequired`] so a
+    /// caller (CLI/GUI) can prompt for it.
+    pub fn enumerate_pinned(
+        &mut self,
+        timestamp: u64,
+        pin: Option<&str>,
+    ) -> Result<Vec<Entry>, OtpTransportError> {
+        self.unlock_if_pinned(pin)?;
+        self.enumerate(timestamp)
+    }
+
+    /// Add/overwrite an entry, transparently handling a PIN-protected key: if a
+    /// PIN is set it must be supplied (verified to open the write window) unless
+    /// the window is already open on this session. Returns
+    /// [`OtpTransportError::PinRequired`] when a PIN is set but none was given.
+    pub fn write_entry_pinned(
+        &mut self,
+        entry: &WriteEntry<'_>,
+        pin: Option<&str>,
+    ) -> Result<(), OtpTransportError> {
+        if !self.pin_verified && self.pin_is_set()? {
+            match pin {
+                Some(p) => self.verify_pin(p)?,
+                None => return Err(OtpTransportError::PinRequired),
+            }
+        }
+        self.write_entry(entry)
+    }
+
+    /// Delete an entry, transparently handling a PIN-protected key (see
+    /// [`write_entry_pinned`](Self::write_entry_pinned)). Delete is a seed-write
+    /// with an empty seed, so it takes the same protected path.
+    pub fn delete_entry_pinned(
+        &mut self,
+        app_name: &str,
+        account_name: &str,
+        pin: Option<&str>,
+    ) -> Result<(), OtpTransportError> {
+        if !self.pin_verified && self.pin_is_set()? {
+            match pin {
+                Some(p) => self.verify_pin(p)?,
+                None => return Err(OtpTransportError::PinRequired),
+            }
+        }
+        self.delete_entry(app_name, account_name)
     }
 
     /// Read a single entry by `(app, account)`, returning its live code (spec
@@ -1220,9 +1501,24 @@ impl Token2OtpSession {
         }
     }
 
-    /// Run the ECDH handshake: fetch the device pubkey, then seal `cleartext`
-    /// with `iv` (spec §6.3 step 1, §7).
+    /// Seal `cleartext` for a `WRITE_SEED`, choosing the encryption by PIN state:
+    ///
+    ///  * PIN window open (`pin_verified`): the device rejects `GET_ECDH_PUBKEY`
+    ///    with `6A81`, so there is no ECDH blob. The write instead reuses the
+    ///    verified PIN session keys, in the authenticated format that mirrors a
+    ///    PIN-mode read: `IV || AES-CBC(SessionEncKey, IV, pt) ||
+    ///    HMAC(SessionMacKey, EncData)[:16]` (confirmed against a device capture
+    ///    in the reference client).
+    ///  * Otherwise (unprotected key): fetch a fresh ephemeral device pubkey via
+    ///    `GET_ECDH_PUBKEY` and build the standard ECDH seed blob with `iv`.
     fn seal(&mut self, cleartext: &[u8], iv: &[u8; 16]) -> Result<Vec<u8>, OtpTransportError> {
+        if self.pin_verified {
+            let keys = self
+                .pin_session
+                .as_ref()
+                .ok_or(OtpTransportError::Parse(ParseError::Truncated))?;
+            return Ok(t2::crypto::build_protected_write_data(keys, cleartext));
+        }
         let (device_pub, sw) = self.transport.transmit(&t2::get_ecdh_pubkey(), false)?;
         OtpError::check(sw)?;
         Ok(t2::encrypt_seed_payload(&device_pub, cleartext, iv)?)
@@ -1421,6 +1717,8 @@ mod enumerate_bounds_tests {
                 transmits: transmits.clone(),
             }),
             is_pcsc: false,
+            pin_session: None,
+            pin_verified: false,
         };
         let res = session.enumerate(0);
         assert!(
@@ -1459,6 +1757,8 @@ mod enumerate_bounds_tests {
         let mut session = Token2OtpSession {
             transport: Box::new(TwoPages { sent: 0 }),
             is_pcsc: false,
+            pin_session: None,
+            pin_verified: false,
         };
         let entries = session.enumerate(0).expect("two pages must enumerate");
         assert_eq!(entries.len(), 2);

--- a/crates/keyroost/src/otp_pane.rs
+++ b/crates/keyroost/src/otp_pane.rs
@@ -1460,7 +1460,7 @@ impl App {
                             }
                             None => {
                                 ui.add_enabled_ui(false, |ui| {
-                                    let _ = ui.selectable_label(false, "PIN state unknown");
+                                    let _ = ui.selectable_label(false, "No PIN feature reported");
                                 });
                             }
                         }

--- a/crates/keyroost/src/otp_pane.rs
+++ b/crates/keyroost/src/otp_pane.rs
@@ -969,15 +969,14 @@ impl App {
         let newpin = dlg.new.clone();
         let confirm = dlg.confirm.clone();
 
-        // Client-side checks before any device I/O.
+        // The only host-side gate is the one the host owns: the two typed
+        // fields must agree, because only this dialog knows they were meant to.
+        // Whether the key accepts the PIN is the key's call — it answers with a
+        // status word, and that answer is what the user is shown.
         match kind {
             PinDialogKind::Set | PinDialogKind::Change => {
                 if newpin != confirm {
                     self.otp.error = Some("New PIN and confirmation do not match.".into());
-                    return;
-                }
-                if let Err(m) = keyroost_token2otp::validate_otp_pin(&newpin) {
-                    self.otp.error = Some(format!("PIN policy: {m}"));
                     return;
                 }
             }
@@ -1549,8 +1548,7 @@ impl App {
                         .hint_text("OTP PIN")
                         .desired_width(220.0),
                 );
-                let entered =
-                    resp.lost_focus() && ui.input(|i| i.key_pressed(egui::Key::Enter));
+                let entered = resp.lost_focus() && ui.input(|i| i.key_pressed(egui::Key::Enter));
                 ui.add_space(8.0);
                 ui.horizontal(|ui| {
                     if theme::button(ui, p, BtnKind::Primary, "Unlock").clicked() || entered {
@@ -1567,8 +1565,9 @@ impl App {
                 }
             });
             if do_unlock && !self.otp.pin_input.trim().is_empty() {
-                self.otp.pin =
-                    Some(zeroize::Zeroizing::new(self.otp.pin_input.trim().to_owned()));
+                self.otp.pin = Some(zeroize::Zeroizing::new(
+                    self.otp.pin_input.trim().to_owned(),
+                ));
                 self.otp.pin_input.clear();
                 self.otp.pin_required = false;
                 self.otp.error = None;

--- a/crates/keyroost/src/otp_pane.rs
+++ b/crates/keyroost/src/otp_pane.rs
@@ -257,6 +257,58 @@ pub struct KbdToggle {
     pub typed: String,
 }
 
+/// Which OTP-PIN management action a [`PinDialog`] performs.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum PinDialogKind {
+    /// Set a PIN on a currently-unprotected key.
+    Set,
+    /// Change the PIN (needs the current PIN + a new one).
+    Change,
+    /// Remove the PIN (needs the current PIN).
+    Remove,
+}
+
+/// A modal for setting / changing / removing the OTP PIN. `current`/`new` are
+/// masked inputs; which are shown depends on `kind`. Wiped on drop.
+#[derive(Default)]
+pub struct PinDialog {
+    pub kind_set: bool,
+    pub kind_remove: bool,
+    pub current: String,
+    pub new: String,
+    pub confirm: String,
+}
+
+impl Drop for PinDialog {
+    fn drop(&mut self) {
+        use zeroize::Zeroize;
+        self.current.zeroize();
+        self.new.zeroize();
+        self.confirm.zeroize();
+    }
+}
+
+impl PinDialog {
+    fn for_kind(kind: PinDialogKind) -> Self {
+        PinDialog {
+            kind_set: kind == PinDialogKind::Set,
+            kind_remove: kind == PinDialogKind::Remove,
+            current: String::new(),
+            new: String::new(),
+            confirm: String::new(),
+        }
+    }
+    fn kind(&self) -> PinDialogKind {
+        if self.kind_set {
+            PinDialogKind::Set
+        } else if self.kind_remove {
+            PinDialogKind::Remove
+        } else {
+            PinDialogKind::Change
+        }
+    }
+}
+
 /// Result of a successful OTP-pane load: the entry rows plus the device facts the
 /// pane shows (transport label, serial, touch-HOTP availability, interface state).
 struct OtpLoad {
@@ -287,6 +339,19 @@ pub struct OtpState {
     /// Dialog for the HOTP-on-touch keystroke slot.
     pub button_hotp: ButtonHotpDialog,
     pub confirm_delete: Option<(String, String)>,
+    /// PIN entry buffer for a protected (R3.4+) key. Held only while unlocking.
+    pub pin_input: String,
+    /// Set when the last read reported the key is PIN-protected and no valid PIN
+    /// has been entered yet — drives the unlock prompt instead of the list.
+    pub pin_required: bool,
+    /// The verified PIN for the current selection, reused across refreshes so the
+    /// user isn't re-prompted every reload. Cleared when the device changes.
+    pub pin: Option<zeroize::Zeroizing<String>>,
+    /// Open PIN-management dialog (set / change / remove), if any.
+    pub pin_dialog: Option<PinDialog>,
+    /// Whether the key currently has an OTP PIN set (R3.4+). `None` until known.
+    /// Drives which PIN menu items appear (Set vs Change/Remove/Lock).
+    pub pin_set: Option<bool>,
     /// Active transport label after a successful open (for the status line).
     pub active: Option<&'static str>,
     /// Device serial number (hex), read alongside the entry list when available.
@@ -395,6 +460,11 @@ impl App {
             );
         }
         let for_device = self.selected_device.clone();
+        // Move the (already-verified) PIN, if any, into the read job so a
+        // protected key's codes decrypt. `None` means "unprotected, or not yet
+        // unlocked" — enumerate_pinned then reports PinRequired for a protected
+        // key, which the completion handler turns into the unlock prompt.
+        let pin: Option<String> = self.otp.pin.as_ref().map(|p| p.to_string());
         self.spawn_job("Reading OTP entries\u{2026}", move || {
             let result =
                 (|| -> Result<OtpLoad, OtpTransportError> {
@@ -430,7 +500,7 @@ impl App {
                     // Carries the config read across both arms below so a failed
                     // enumerate doesn't cost a second READ_CONFIG.
                     let mut dev_info: Option<keyroost_token2otp::DeviceInfo> = None;
-                    let rows: Vec<OtpRow> = match session.enumerate(now) {
+                    let rows: Vec<OtpRow> = match session.enumerate_pinned(now, pin.as_deref()) {
                         Ok(entries) => entries
                             .into_iter()
                             .map(|e| OtpRow {
@@ -547,10 +617,42 @@ impl App {
                         // drop them so the freshly-loaded list governs display.
                         app.otp.touch_codes.clear();
                         app.otp.error = None;
+                        // A successful read means either the key isn't protected
+                        // or the stored PIN worked — leave the prompt state off.
+                        app.otp.pin_required = false;
+                        // If the read succeeded using a stored PIN, the key is
+                        // protected; if it succeeded with no PIN, it isn't.
+                        app.otp.pin_set = Some(app.otp.pin.is_some());
                     }
                     Err(e) => {
-                        app.otp.error = Some(e.to_string());
-                        app.otp.loaded = true;
+                        if std::env::var_os("KEYROOST_OTP_DEBUG").is_some() {
+                            eprintln!("[otp gui] load error variant: {e:?}");
+                        }
+                        // A protected key with no (or a wrong) PIN: flip the pane
+                        // into its unlock prompt rather than showing a raw error.
+                        if matches!(e, keyroost_transport::OtpTransportError::PinRequired) {
+                            app.otp.pin_required = true;
+                            app.otp.pin_set = Some(true);
+                            app.otp.rows.clear();
+                            app.otp.loaded = true;
+                            app.otp.error = None;
+                        } else {
+                            // A wrong PIN invalidates the stored one so the prompt
+                            // reappears instead of silently failing every refresh.
+                            if matches!(
+                                e,
+                                keyroost_transport::OtpTransportError::Applet(
+                                    keyroost_token2otp::OtpError::PinInvalid
+                                ) | keyroost_transport::OtpTransportError::Applet(
+                                    keyroost_token2otp::OtpError::PinInvalidRetries(_)
+                                )
+                            ) {
+                                app.otp.pin = None;
+                                app.otp.pin_required = true;
+                            }
+                            app.otp.error = Some(e.to_string());
+                            app.otp.loaded = true;
+                        }
                     }
                 }
             })
@@ -584,6 +686,9 @@ impl App {
             }
         };
         let for_device = self.selected_device.clone();
+        // Carry the verified PIN (if the key is protected and already unlocked)
+        // so the write takes the session-key path the device requires.
+        let pin: Option<String> = self.otp.pin.as_ref().map(|p| p.to_string());
 
         self.spawn_job("Adding OTP entry\u{2026}", move || {
             let result = (|| -> Result<(), String> {
@@ -608,7 +713,9 @@ impl App {
                     account_name: &account_name,
                     seed: &seed,
                 };
-                session.write_entry(&entry).map_err(|e| e.to_string())
+                session
+                    .write_entry_pinned(&entry, pin.as_deref())
+                    .map_err(|e| e.to_string())
             })();
             Box::new(move |app: &mut App| {
                 if app.selected_device != for_device {
@@ -793,10 +900,11 @@ impl App {
             }
         };
         let for_device = self.selected_device.clone();
+        let pin: Option<String> = self.otp.pin.as_ref().map(|p| p.to_string());
         self.spawn_job("Deleting OTP entry\u{2026}", move || {
             let result = (|| -> Result<(), OtpTransportError> {
                 let mut session = target.open()?;
-                session.delete_entry(&app_name, &account_name)
+                session.delete_entry_pinned(&app_name, &account_name, pin.as_deref())
             })();
             Box::new(move |app: &mut App| {
                 if app.selected_device != for_device {
@@ -813,8 +921,217 @@ impl App {
         });
     }
 
-    /// Read a touch-required TOTP entry's current code: the device requires a
-    /// button press, so `read_entry` waits for the touch (the transport fires
+    /// Lock the OTP PIN window now, clearing the cached PIN so the next read
+    /// re-prompts.
+    pub(crate) fn lock_otp_pin(&mut self) {
+        self.otp.error = None;
+        let target = match self.otp_target() {
+            Ok(t) => t,
+            Err(e) => {
+                self.otp.error = Some(e);
+                return;
+            }
+        };
+        let for_device = self.selected_device.clone();
+        let pin: Option<String> = self.otp.pin.as_ref().map(|p| p.to_string());
+        self.spawn_job("Locking OTP PIN\u{2026}", move || {
+            let result = (|| -> Result<(), OtpTransportError> {
+                let mut session = target.open()?;
+                // Re-verify to hold the window, then close it explicitly.
+                if let Some(p) = pin.as_deref() {
+                    session.verify_pin(p)?;
+                }
+                session.lock_pin()
+            })();
+            Box::new(move |app: &mut App| {
+                if app.selected_device != for_device {
+                    return;
+                }
+                app.otp.pin = None;
+                app.otp.pin_required = true;
+                app.otp.rows.clear();
+                match result {
+                    Ok(()) => app.otp.info = Some("OTP PIN locked.".into()),
+                    Err(e) => app.otp.error = Some(e.to_string()),
+                }
+            })
+        });
+    }
+
+    /// Apply a set / change / remove PIN action from the [`PinDialog`].
+    pub(crate) fn apply_pin_dialog(&mut self, kind: PinDialogKind) {
+        self.otp.error = None;
+        let dlg = match &self.otp.pin_dialog {
+            Some(d) => d,
+            None => return,
+        };
+        let current = dlg.current.clone();
+        let newpin = dlg.new.clone();
+        let confirm = dlg.confirm.clone();
+
+        // Client-side checks before any device I/O.
+        match kind {
+            PinDialogKind::Set | PinDialogKind::Change => {
+                if newpin != confirm {
+                    self.otp.error = Some("New PIN and confirmation do not match.".into());
+                    return;
+                }
+                if let Err(m) = keyroost_token2otp::validate_otp_pin(&newpin) {
+                    self.otp.error = Some(format!("PIN policy: {m}"));
+                    return;
+                }
+            }
+            PinDialogKind::Remove => {}
+        }
+
+        let target = match self.otp_target() {
+            Ok(t) => t,
+            Err(e) => {
+                self.otp.error = Some(e);
+                return;
+            }
+        };
+        let for_device = self.selected_device.clone();
+        self.spawn_job("Updating OTP PIN\u{2026}", move || {
+            let result = (|| -> Result<Option<String>, OtpTransportError> {
+                let mut session = target.open()?;
+                match kind {
+                    PinDialogKind::Set => {
+                        session.set_pin(&newpin)?;
+                        Ok(Some(newpin.clone()))
+                    }
+                    PinDialogKind::Change => {
+                        session.change_pin(&current, &newpin)?;
+                        Ok(Some(newpin.clone()))
+                    }
+                    PinDialogKind::Remove => {
+                        session.remove_pin(&current)?;
+                        Ok(None)
+                    }
+                }
+            })();
+            Box::new(move |app: &mut App| {
+                if app.selected_device != for_device {
+                    return;
+                }
+                match result {
+                    Ok(new_pin) => {
+                        app.otp.pin_dialog = None;
+                        match kind {
+                            PinDialogKind::Set => {
+                                app.otp.pin = new_pin.map(zeroize::Zeroizing::new);
+                                app.otp.pin_set = Some(true);
+                                app.otp.info = Some("OTP PIN set.".into());
+                            }
+                            PinDialogKind::Change => {
+                                app.otp.pin = new_pin.map(zeroize::Zeroizing::new);
+                                app.otp.pin_set = Some(true);
+                                app.otp.info = Some("OTP PIN changed.".into());
+                            }
+                            PinDialogKind::Remove => {
+                                app.otp.pin = None;
+                                app.otp.pin_set = Some(false);
+                                app.otp.pin_required = false;
+                                app.otp.info = Some("OTP PIN removed.".into());
+                            }
+                        }
+                        app.load_otp_entries();
+                    }
+                    Err(e) => app.otp.error = Some(e.to_string()),
+                }
+            })
+        });
+    }
+
+    /// Render the set / change / remove PIN modal when open.
+    fn render_pin_dialog(&mut self, ui: &mut egui::Ui, p: &Palette) {
+        let kind = match &self.otp.pin_dialog {
+            Some(d) => d.kind(),
+            None => return,
+        };
+        let mut submit = false;
+        let mut cancel = false;
+        theme::card_frame(p).show(ui, |ui| {
+            let title = match kind {
+                PinDialogKind::Set => "Set OTP PIN",
+                PinDialogKind::Change => "Change OTP PIN",
+                PinDialogKind::Remove => "Remove OTP PIN",
+            };
+            ui.label(
+                egui::RichText::new(title)
+                    .font(theme::f_sb(14.0))
+                    .color(p.txt),
+            );
+            ui.add_space(8.0);
+            if let Some(dlg) = &mut self.otp.pin_dialog {
+                if matches!(kind, PinDialogKind::Change | PinDialogKind::Remove) {
+                    ui.label(
+                        egui::RichText::new("Current PIN")
+                            .font(theme::f_reg(12.0))
+                            .color(p.txt2),
+                    );
+                    ui.add(
+                        egui::TextEdit::singleline(&mut dlg.current)
+                            .password(true)
+                            .desired_width(220.0),
+                    );
+                    ui.add_space(6.0);
+                }
+                if matches!(kind, PinDialogKind::Set | PinDialogKind::Change) {
+                    ui.label(
+                        egui::RichText::new("New PIN")
+                            .font(theme::f_reg(12.0))
+                            .color(p.txt2),
+                    );
+                    ui.add(
+                        egui::TextEdit::singleline(&mut dlg.new)
+                            .password(true)
+                            .desired_width(220.0),
+                    );
+                    ui.add_space(6.0);
+                    ui.label(
+                        egui::RichText::new("Confirm new PIN")
+                            .font(theme::f_reg(12.0))
+                            .color(p.txt2),
+                    );
+                    ui.add(
+                        egui::TextEdit::singleline(&mut dlg.confirm)
+                            .password(true)
+                            .desired_width(220.0),
+                    );
+                }
+            }
+            ui.add_space(6.0);
+            ui.label(
+                egui::RichText::new(
+                    "Numeric PINs need 6+ digits (no trivial sequences); \
+                     alphanumeric PINs need 10+ characters.",
+                )
+                .font(theme::f_reg(11.0))
+                .color(p.txt3),
+            );
+            ui.add_space(10.0);
+            ui.horizontal(|ui| {
+                let action = match kind {
+                    PinDialogKind::Set => "Set PIN",
+                    PinDialogKind::Change => "Change PIN",
+                    PinDialogKind::Remove => "Remove PIN",
+                };
+                if theme::button(ui, p, BtnKind::Primary, action).clicked() {
+                    submit = true;
+                }
+                if theme::button(ui, p, BtnKind::Default, "Cancel").clicked() {
+                    cancel = true;
+                }
+            });
+        });
+        if cancel {
+            self.otp.pin_dialog = None;
+        } else if submit {
+            self.apply_pin_dialog(kind);
+        }
+    }
+
     /// the button-prompt). The returned code is stashed in `touch_codes` and
     /// shown in place of "touch to view" until the next list reload.
     pub(crate) fn read_touch_otp_entry(&mut self, app_name: String, account_name: String) {
@@ -957,6 +1274,8 @@ impl App {
                 let mut open_touch = false;
                 let mut kbd_target: Option<bool> = None;
                 let mut new_transport: Option<OtpTransportSel> = None;
+                let mut pin_dialog_open: Option<PinDialogKind> = None;
+                let mut pin_lock = false;
 
                 let menu_btn =
                     theme::button(ui, p, BtnKind::Default, "...").on_hover_text("More actions");
@@ -1041,6 +1360,40 @@ impl App {
                                 }
                             });
                         }
+
+                        // --- OTP PIN (R3.4+ privacy protection) ---
+                        ui.separator();
+                        ui.label(
+                            egui::RichText::new("OTP PIN")
+                                .font(theme::f_reg(11.0))
+                                .color(p.txt3),
+                        );
+                        match self.otp.pin_set {
+                            Some(false) => {
+                                if ui.selectable_label(false, "Set PIN\u{2026}").clicked() {
+                                    pin_dialog_open = Some(PinDialogKind::Set);
+                                }
+                            }
+                            Some(true) => {
+                                if ui.selectable_label(false, "Change PIN\u{2026}").clicked() {
+                                    pin_dialog_open = Some(PinDialogKind::Change);
+                                }
+                                if ui.selectable_label(false, "Remove PIN\u{2026}").clicked() {
+                                    pin_dialog_open = Some(PinDialogKind::Remove);
+                                }
+                                // Lock is only meaningful once unlocked this session.
+                                ui.add_enabled_ui(self.otp.pin.is_some(), |ui| {
+                                    if ui.selectable_label(false, "Lock now").clicked() {
+                                        pin_lock = true;
+                                    }
+                                });
+                            }
+                            None => {
+                                ui.add_enabled_ui(false, |ui| {
+                                    let _ = ui.selectable_label(false, "PIN state unknown");
+                                });
+                            }
+                        }
                     });
 
                 // Apply menu selections after the closure.
@@ -1068,6 +1421,12 @@ impl App {
                         enable: target,
                         typed: String::new(),
                     });
+                }
+                if let Some(kind) = pin_dialog_open {
+                    self.otp.pin_dialog = Some(PinDialog::for_kind(kind));
+                }
+                if pin_lock {
+                    self.lock_otp_pin();
                 }
 
                 // Primary actions, to the left of the overflow menu (added after
@@ -1125,6 +1484,7 @@ impl App {
         }
 
         self.render_otp_add_form(ui, p);
+        self.render_pin_dialog(ui, p);
         self.render_button_hotp_form(ui, p);
         self.render_keyboard_confirm(ui, p);
         self.render_otp_delete_confirm(ui, p);
@@ -1165,6 +1525,58 @@ impl App {
             });
             return;
         }
+        // Protected (R3.4+) key with no valid PIN yet: show the unlock prompt
+        // instead of the (empty) list. Entering the PIN and unlocking reloads
+        // the entries via the stored PIN.
+        if self.otp.pin_required {
+            let mut do_unlock = false;
+            theme::card_frame(p).show(ui, |ui| {
+                ui.label(
+                    egui::RichText::new("This key's OTP codes are PIN-protected")
+                        .font(theme::f_sb(13.5))
+                        .color(p.txt),
+                );
+                ui.add_space(6.0);
+                ui.label(
+                    egui::RichText::new("Enter the OTP PIN to view and manage codes.")
+                        .font(theme::f_reg(12.5))
+                        .color(p.txt2),
+                );
+                ui.add_space(8.0);
+                let resp = ui.add(
+                    egui::TextEdit::singleline(&mut self.otp.pin_input)
+                        .password(true)
+                        .hint_text("OTP PIN")
+                        .desired_width(220.0),
+                );
+                let entered =
+                    resp.lost_focus() && ui.input(|i| i.key_pressed(egui::Key::Enter));
+                ui.add_space(8.0);
+                ui.horizontal(|ui| {
+                    if theme::button(ui, p, BtnKind::Primary, "Unlock").clicked() || entered {
+                        do_unlock = true;
+                    }
+                });
+                if let Some(err) = &self.otp.error {
+                    ui.add_space(6.0);
+                    ui.label(
+                        egui::RichText::new(err)
+                            .font(theme::f_reg(12.0))
+                            .color(p.err),
+                    );
+                }
+            });
+            if do_unlock && !self.otp.pin_input.trim().is_empty() {
+                self.otp.pin =
+                    Some(zeroize::Zeroizing::new(self.otp.pin_input.trim().to_owned()));
+                self.otp.pin_input.clear();
+                self.otp.pin_required = false;
+                self.otp.error = None;
+                self.load_otp_entries();
+            }
+            return;
+        }
+
         if self.otp.rows.is_empty() && self.otp.error.is_none() {
             ui.label(
                 egui::RichText::new("No OTP entries on this key.")

--- a/crates/keyroost/src/otp_pane.rs
+++ b/crates/keyroost/src/otp_pane.rs
@@ -325,6 +325,10 @@ struct OtpLoad {
     totp_supported: Option<bool>,
     iface: Option<IfaceState>,
     button_hotp_status: Option<ButtonHotpStatus>,
+    /// What the key itself said about its OTP PIN during this read: `Some(true)`
+    /// a PIN is set, `Some(false)` the feature is present and unset, `None` the
+    /// key does not offer the feature at all.
+    pin_set: Option<bool>,
 }
 
 /// Per-selection state for the OTP pane.
@@ -384,6 +388,17 @@ pub struct OtpState {
     /// `None` until read. Drives the "seed configured" indicator and the
     /// settings-only editor.
     pub button_hotp_status: Option<ButtonHotpStatus>,
+}
+
+impl Drop for OtpState {
+    /// Scrub the PIN entry buffer when the pane state is torn down — which is
+    /// what a device switch does (`self.otp = OtpState::default()`), so a PIN
+    /// typed for one key must not survive into the next selection's memory.
+    /// The `pin` field is `Zeroizing` and wipes itself; `pin_input` is a plain
+    /// `String` because egui edits it in place, so it needs this.
+    fn drop(&mut self) {
+        wipe(&mut self.pin_input);
+    }
 }
 
 fn unix_now() -> u64 {
@@ -464,7 +479,10 @@ impl App {
         // protected key's codes decrypt. `None` means "unprotected, or not yet
         // unlocked" — enumerate_pinned then reports PinRequired for a protected
         // key, which the completion handler turns into the unlock prompt.
-        let pin: Option<String> = self.otp.pin.as_ref().map(|p| p.to_string());
+        // Clone as `Zeroizing`, not `String`: this copy travels into a worker
+        // thread and is dropped there, so a plain clone would leave the PIN in
+        // that thread's heap with nothing left to wipe it.
+        let pin: Option<zeroize::Zeroizing<String>> = self.otp.pin.clone();
         self.spawn_job("Reading OTP entries\u{2026}", move || {
             let result =
                 (|| -> Result<OtpLoad, OtpTransportError> {
@@ -500,7 +518,7 @@ impl App {
                     // Carries the config read across both arms below so a failed
                     // enumerate doesn't cost a second READ_CONFIG.
                     let mut dev_info: Option<keyroost_token2otp::DeviceInfo> = None;
-                    let rows: Vec<OtpRow> = match session.enumerate_pinned(now, pin.as_deref()) {
+                    let rows: Vec<OtpRow> = match session.enumerate_pinned(now, pin.as_ref().map(|p| p.as_str())) {
                         Ok(entries) => entries
                             .into_iter()
                             .map(|e| OtpRow {
@@ -585,9 +603,15 @@ impl App {
                             numpad: info.hotp_uses_numpad(),
                         })
                     });
+                    // The flag read that `enumerate_pinned` already performed,
+                    // read back off the same connection — no extra round trip,
+                    // and it is the key's answer rather than an inference from
+                    // whether we happened to hold a PIN.
+                    let pin_set = session.pin_set_cached();
                     Ok(OtpLoad {
                         rows,
                         active,
+                        pin_set,
                         serial,
                         touch_ok,
                         touch_why,
@@ -620,9 +644,12 @@ impl App {
                         // A successful read means either the key isn't protected
                         // or the stored PIN worked — leave the prompt state off.
                         app.otp.pin_required = false;
-                        // If the read succeeded using a stored PIN, the key is
-                        // protected; if it succeeded with no PIN, it isn't.
-                        app.otp.pin_set = Some(app.otp.pin.is_some());
+                        // Straight from the device's flag read. Inferring it
+                        // from `app.otp.pin.is_some()` got this wrong whenever
+                        // the key's own window was already open: the read
+                        // succeeded without a PIN, so the pane reported "no PIN"
+                        // and hid Change / Remove / Lock on a protected key.
+                        app.otp.pin_set = load.pin_set;
                     }
                     Err(e) => {
                         if std::env::var_os("KEYROOST_OTP_DEBUG").is_some() {
@@ -688,7 +715,10 @@ impl App {
         let for_device = self.selected_device.clone();
         // Carry the verified PIN (if the key is protected and already unlocked)
         // so the write takes the session-key path the device requires.
-        let pin: Option<String> = self.otp.pin.as_ref().map(|p| p.to_string());
+        // Clone as `Zeroizing`, not `String`: this copy travels into a worker
+        // thread and is dropped there, so a plain clone would leave the PIN in
+        // that thread's heap with nothing left to wipe it.
+        let pin: Option<zeroize::Zeroizing<String>> = self.otp.pin.clone();
 
         self.spawn_job("Adding OTP entry\u{2026}", move || {
             let result = (|| -> Result<(), String> {
@@ -714,7 +744,7 @@ impl App {
                     seed: &seed,
                 };
                 session
-                    .write_entry_pinned(&entry, pin.as_deref())
+                    .write_entry_pinned(&entry, pin.as_ref().map(|p| p.as_str()))
                     .map_err(|e| e.to_string())
             })();
             Box::new(move |app: &mut App| {
@@ -900,11 +930,18 @@ impl App {
             }
         };
         let for_device = self.selected_device.clone();
-        let pin: Option<String> = self.otp.pin.as_ref().map(|p| p.to_string());
+        // Clone as `Zeroizing`, not `String`: this copy travels into a worker
+        // thread and is dropped there, so a plain clone would leave the PIN in
+        // that thread's heap with nothing left to wipe it.
+        let pin: Option<zeroize::Zeroizing<String>> = self.otp.pin.clone();
         self.spawn_job("Deleting OTP entry\u{2026}", move || {
             let result = (|| -> Result<(), OtpTransportError> {
                 let mut session = target.open()?;
-                session.delete_entry_pinned(&app_name, &account_name, pin.as_deref())
+                session.delete_entry_pinned(
+                    &app_name,
+                    &account_name,
+                    pin.as_ref().map(|p| p.as_str()),
+                )
             })();
             Box::new(move |app: &mut App| {
                 if app.selected_device != for_device {
@@ -933,15 +970,34 @@ impl App {
             }
         };
         let for_device = self.selected_device.clone();
-        let pin: Option<String> = self.otp.pin.as_ref().map(|p| p.to_string());
+        // Clone as `Zeroizing`, not `String`: this copy travels into a worker
+        // thread and is dropped there, so a plain clone would leave the PIN in
+        // that thread's heap with nothing left to wipe it.
+        let pin: Option<zeroize::Zeroizing<String>> = self.otp.pin.clone();
         self.spawn_job("Locking OTP PIN\u{2026}", move || {
             let result = (|| -> Result<(), OtpTransportError> {
                 let mut session = target.open()?;
-                // Re-verify to hold the window, then close it explicitly.
-                if let Some(p) = pin.as_deref() {
-                    session.verify_pin(p)?;
+                // Ask to close the window first. The window is device-side
+                // state, and the lock form of VERIFY carries no PIN, so on a
+                // key that accepts it bare this costs nothing. Verifying first
+                // — as this did — spends one of a finite number of retries
+                // every time the user presses Lock, and spends it on a cached
+                // PIN that may since have been changed on another host.
+                match session.lock_pin() {
+                    // The one answer that means "there was no session to close
+                    // this way": open one with the PIN we hold and lock again.
+                    Err(OtpTransportError::Applet(
+                        keyroost_token2otp::OtpError::PinConditionsNotSatisfied,
+                    )) => {
+                        if let Some(p) = pin.as_deref() {
+                            session.verify_pin(p)?;
+                            session.lock_pin()
+                        } else {
+                            Ok(())
+                        }
+                    }
+                    other => other,
                 }
-                session.lock_pin()
             })();
             Box::new(move |app: &mut App| {
                 if app.selected_device != for_device {
@@ -965,9 +1021,11 @@ impl App {
             Some(d) => d,
             None => return,
         };
-        let current = dlg.current.clone();
-        let newpin = dlg.new.clone();
-        let confirm = dlg.confirm.clone();
+        // The dialog wipes its own fields on drop; these copies must too, or
+        // the PIN outlives the modal in the worker thread's heap.
+        let current = zeroize::Zeroizing::new(dlg.current.clone());
+        let newpin = zeroize::Zeroizing::new(dlg.new.clone());
+        let confirm = zeroize::Zeroizing::new(dlg.confirm.clone());
 
         // The only host-side gate is the one the host owns: the two typed
         // fields must agree, because only this dialog knows they were meant to.
@@ -992,7 +1050,7 @@ impl App {
         };
         let for_device = self.selected_device.clone();
         self.spawn_job("Updating OTP PIN\u{2026}", move || {
-            let result = (|| -> Result<Option<String>, OtpTransportError> {
+            let result = (|| -> Result<Option<zeroize::Zeroizing<String>>, OtpTransportError> {
                 let mut session = target.open()?;
                 match kind {
                     PinDialogKind::Set => {
@@ -1018,12 +1076,12 @@ impl App {
                         app.otp.pin_dialog = None;
                         match kind {
                             PinDialogKind::Set => {
-                                app.otp.pin = new_pin.map(zeroize::Zeroizing::new);
+                                app.otp.pin = new_pin.clone();
                                 app.otp.pin_set = Some(true);
                                 app.otp.info = Some("OTP PIN set.".into());
                             }
                             PinDialogKind::Change => {
-                                app.otp.pin = new_pin.map(zeroize::Zeroizing::new);
+                                app.otp.pin = new_pin.clone();
                                 app.otp.pin_set = Some(true);
                                 app.otp.info = Some("OTP PIN changed.".into());
                             }
@@ -1101,14 +1159,27 @@ impl App {
                 }
             }
             ui.add_space(6.0);
+            // Advice, not a rule: the key decides what it accepts and says so.
             ui.label(
                 egui::RichText::new(
-                    "Numeric PINs need 6+ digits (no trivial sequences); \
-                     alphanumeric PINs need 10+ characters.",
+                    "Keys typically want 6+ digits (no trivial sequences), or \
+                     10+ characters if the PIN isn't all digits.",
                 )
                 .font(theme::f_reg(11.0))
                 .color(p.txt3),
             );
+            if matches!(kind, PinDialogKind::Set | PinDialogKind::Change) {
+                ui.add_space(4.0);
+                ui.label(
+                    egui::RichText::new(
+                        "There is no PIN reset. Wrong attempts count down a retry \
+                         counter, and once it reaches zero the only way back is to \
+                         erase every OTP entry on this key.",
+                    )
+                    .font(theme::f_reg(11.0))
+                    .color(p.warn),
+                );
+            }
             ui.add_space(10.0);
             ui.horizontal(|ui| {
                 let action = match kind {
@@ -1568,7 +1639,10 @@ impl App {
                 self.otp.pin = Some(zeroize::Zeroizing::new(
                     self.otp.pin_input.trim().to_owned(),
                 ));
-                self.otp.pin_input.clear();
+                // `.clear()` only sets the length to zero — the PIN would stay
+                // in the buffer verbatim. `wipe` is the helper the rest of the
+                // GUI's secret fields use.
+                wipe(&mut self.otp.pin_input);
                 self.otp.pin_required = false;
                 self.otp.error = None;
                 self.load_otp_entries();

--- a/crates/keyroostctl/src/main.rs
+++ b/crates/keyroostctl/src/main.rs
@@ -2062,8 +2062,16 @@ enum LargeBlobCmd {
 #[derive(Subcommand)]
 enum OtpCmd {
     /// List the OTP entries stored on the key, with their live codes where the
-    /// device returns them (TOTP without button-press).
-    List,
+    /// device returns them (TOTP without button-press). On a PIN-protected
+    /// (R3.4+) key, supply the PIN via `--pin-stdin` or `--pin-env` to unlock.
+    List {
+        /// Read the OTP PIN from the named environment variable (protected keys).
+        #[arg(long, value_name = "VAR", conflicts_with = "pin_stdin")]
+        pin_env: Option<String>,
+        /// Read the OTP PIN from stdin (one line) to unlock a protected key.
+        #[arg(long)]
+        pin_stdin: bool,
+    },
     /// Print the current code for one entry, identified by app and account.
     /// A button-required entry will prompt for a touch.
     Get {
@@ -2104,6 +2112,13 @@ enum OtpCmd {
         /// Read the base32 seed from stdin (one line).
         #[arg(long)]
         seed_stdin: bool,
+        /// OTP PIN for a protected (R3.4+) key, from this env var.
+        #[arg(long, value_name = "VAR")]
+        pin_env: Option<String>,
+        /// Read the OTP PIN from stdin (SECOND line, after the seed) to unlock a
+        /// protected key.
+        #[arg(long)]
+        pin_stdin: bool,
     },
     /// Delete one OTP entry by app and account.
     Delete {
@@ -2113,6 +2128,12 @@ enum OtpCmd {
         /// Account name as stored.
         #[arg(long)]
         account: String,
+        /// OTP PIN for a protected (R3.4+) key, from this env var.
+        #[arg(long, value_name = "VAR", conflicts_with = "pin_stdin")]
+        pin_env: Option<String>,
+        /// Read the OTP PIN from stdin (one line) to unlock a protected key.
+        #[arg(long)]
+        pin_stdin: bool,
     },
     /// Erase every OTP entry on the key. Requires a confirming button press and
     /// the `--yes` acknowledgement.
@@ -2172,6 +2193,47 @@ enum OtpCmd {
         /// Skip the interactive confirmation (still refuses to disable all).
         #[arg(long)]
         yes: bool,
+    },
+    /// Report OTP-PIN status (R3.4+ keys): whether a PIN is set and retries left.
+    PinStatus,
+    /// Set an OTP PIN on a currently-unprotected key. After this, codes are
+    /// readable only after `verify`. The PIN is read from stdin or an env var —
+    /// never argv.
+    SetPin {
+        /// Read the PIN from the named environment variable.
+        #[arg(long, value_name = "VAR", conflicts_with = "pin_stdin")]
+        pin_env: Option<String>,
+        /// Read the PIN from stdin (one line).
+        #[arg(long)]
+        pin_stdin: bool,
+    },
+    /// Verify the OTP PIN, opening the read window for this connection (mostly
+    /// for testing; `list`/`get` take `--pin-*` directly). PIN via stdin or env.
+    Verify {
+        #[arg(long, value_name = "VAR", conflicts_with = "pin_stdin")]
+        pin_env: Option<String>,
+        #[arg(long)]
+        pin_stdin: bool,
+    },
+    /// Change the OTP PIN. Reads the current PIN from stdin (first line) and the
+    /// new PIN from stdin (second line), or from two env vars.
+    ChangePin {
+        /// Env var holding the current PIN.
+        #[arg(long, value_name = "VAR", conflicts_with = "pin_stdin")]
+        current_env: Option<String>,
+        /// Env var holding the new PIN.
+        #[arg(long, value_name = "VAR", conflicts_with = "pin_stdin")]
+        new_env: Option<String>,
+        /// Read current PIN (line 1) and new PIN (line 2) from stdin.
+        #[arg(long)]
+        pin_stdin: bool,
+    },
+    /// Remove the OTP PIN (requires the current PIN). PIN via stdin or env.
+    RemovePin {
+        #[arg(long, value_name = "VAR", conflicts_with = "pin_stdin")]
+        pin_env: Option<String>,
+        #[arg(long)]
+        pin_stdin: bool,
     },
 }
 
@@ -4962,11 +5024,19 @@ fn run_otp(
     debug: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     match cmd {
-        OtpCmd::List => {
+        OtpCmd::List { pin_env, pin_stdin } => {
             let mut session = open_otp(transport, debug)?;
             ensure_otp_feature(&mut session, OtpFeature::OnDevice)?;
             let now = unix_now() as u64;
-            let entries = session.enumerate(now)?;
+            // If a PIN was supplied, unlock the protected read window first; if
+            // the key is protected and none was given, enumerate_pinned surfaces
+            // a clear "PIN required" error the user can act on.
+            let pin = if pin_env.is_some() || *pin_stdin {
+                Some(read_secret("OTP PIN", pin_env.as_deref(), *pin_stdin)?)
+            } else {
+                None
+            };
+            let entries = session.enumerate_pinned(now, pin.as_deref().map(|p| p.as_str()))?;
             if json_output() {
                 let out: Vec<json_out::OtpEntryJson> = entries
                     .iter()
@@ -5034,11 +5104,39 @@ fn run_otp(
             touch,
             seed_env,
             seed_stdin,
+            pin_env,
+            pin_stdin,
         } => {
             if !(4..=10).contains(digits) {
                 return Err("--digits must be between 4 and 10".into());
             }
-            let seed_b32 = read_secret("seed", seed_env.as_deref(), *seed_stdin)?;
+            // On stdin the seed is line 1 and (if --pin-stdin) the PIN is line 2.
+            let (seed_b32, pin): (zeroize::Zeroizing<String>, Option<zeroize::Zeroizing<String>>) =
+                if *seed_stdin && *pin_stdin {
+                    use std::io::BufRead;
+                    let stdin = std::io::stdin();
+                    let mut lines = stdin.lock().lines();
+                    let seed = lines
+                        .next()
+                        .transpose()?
+                        .ok_or("expected base32 seed on stdin line 1")?;
+                    let pin = lines
+                        .next()
+                        .transpose()?
+                        .ok_or("expected OTP PIN on stdin line 2")?;
+                    (
+                        zeroize::Zeroizing::new(seed),
+                        Some(zeroize::Zeroizing::new(pin)),
+                    )
+                } else {
+                    let seed = read_secret("seed", seed_env.as_deref(), *seed_stdin)?;
+                    let pin = if pin_env.is_some() || *pin_stdin {
+                        Some(read_secret("OTP PIN", pin_env.as_deref(), *pin_stdin)?)
+                    } else {
+                        None
+                    };
+                    (seed, pin)
+                };
             let seed = keyroost_token2otp::decode_base32_seed(seed_b32.trim())
                 .map_err(|e| format!("invalid base32 seed: {e}"))?;
             let mut session = open_otp(transport, debug)?;
@@ -5053,7 +5151,7 @@ fn run_otp(
                 account_name: account,
                 seed: &seed,
             };
-            session.write_entry(&entry)?;
+            session.write_entry_pinned(&entry, pin.as_deref().map(|p| p.as_str()))?;
             let label = if app.is_empty() {
                 account.clone()
             } else {
@@ -5061,10 +5159,20 @@ fn run_otp(
             };
             println!("Added OTP entry {label:?}.");
         }
-        OtpCmd::Delete { app, account } => {
+        OtpCmd::Delete {
+            app,
+            account,
+            pin_env,
+            pin_stdin,
+        } => {
+            let pin = if pin_env.is_some() || *pin_stdin {
+                Some(read_secret("OTP PIN", pin_env.as_deref(), *pin_stdin)?)
+            } else {
+                None
+            };
             let mut session = open_otp(transport, debug)?;
             ensure_otp_feature(&mut session, OtpFeature::OnDevice)?;
-            session.delete_entry(app, account)?;
+            session.delete_entry_pinned(app, account, pin.as_deref().map(|p| p.as_str()))?;
             let label = if app.is_empty() {
                 account.clone()
             } else {
@@ -5258,6 +5366,72 @@ fn run_otp(
             let mut session = open_otp(transport, debug)?;
             session.set_device_type(disable)?;
             println!("Interface configuration updated. Re-plug the key for it to take effect.");
+        }
+        OtpCmd::PinStatus => {
+            let mut session = open_otp(transport, debug)?;
+            ensure_otp_feature(&mut session, OtpFeature::OnDevice)?;
+            let flag = session.pin_status()?;
+            if flag.is_set() {
+                println!(
+                    "OTP PIN: set  (retries left: {}, max: {})",
+                    flag.retries_left, flag.max_retries
+                );
+            } else {
+                println!("OTP PIN: not set");
+            }
+        }
+        OtpCmd::SetPin { pin_env, pin_stdin } => {
+            let pin = read_secret("new OTP PIN", pin_env.as_deref(), *pin_stdin)?;
+            let mut session = open_otp(transport, debug)?;
+            ensure_otp_feature(&mut session, OtpFeature::OnDevice)?;
+            session.set_pin(pin.as_str())?;
+            println!("OTP PIN set. Codes now require the PIN to read.");
+        }
+        OtpCmd::Verify { pin_env, pin_stdin } => {
+            let pin = read_secret("OTP PIN", pin_env.as_deref(), *pin_stdin)?;
+            let mut session = open_otp(transport, debug)?;
+            ensure_otp_feature(&mut session, OtpFeature::OnDevice)?;
+            session.verify_pin(pin.as_str())?;
+            println!("OTP PIN verified; read window open for this connection.");
+        }
+        OtpCmd::ChangePin {
+            current_env,
+            new_env,
+            pin_stdin,
+        } => {
+            let (current, new) = if *pin_stdin {
+                // Two lines from stdin: current, then new.
+                use std::io::BufRead;
+                let stdin = std::io::stdin();
+                let mut lines = stdin.lock().lines();
+                let current = lines
+                    .next()
+                    .transpose()?
+                    .ok_or("expected current PIN on stdin line 1")?;
+                let new = lines
+                    .next()
+                    .transpose()?
+                    .ok_or("expected new PIN on stdin line 2")?;
+                (
+                    zeroize::Zeroizing::new(current),
+                    zeroize::Zeroizing::new(new),
+                )
+            } else {
+                let current = read_secret("current OTP PIN", current_env.as_deref(), false)?;
+                let new = read_secret("new OTP PIN", new_env.as_deref(), false)?;
+                (current, new)
+            };
+            let mut session = open_otp(transport, debug)?;
+            ensure_otp_feature(&mut session, OtpFeature::OnDevice)?;
+            session.change_pin(current.as_str(), new.as_str())?;
+            println!("OTP PIN changed.");
+        }
+        OtpCmd::RemovePin { pin_env, pin_stdin } => {
+            let current = read_secret("current OTP PIN", pin_env.as_deref(), *pin_stdin)?;
+            let mut session = open_otp(transport, debug)?;
+            ensure_otp_feature(&mut session, OtpFeature::OnDevice)?;
+            session.remove_pin(current.as_str())?;
+            println!("OTP PIN removed. Codes are readable without a PIN again.");
         }
     }
     Ok(())

--- a/crates/keyroostctl/src/main.rs
+++ b/crates/keyroostctl/src/main.rs
@@ -238,6 +238,21 @@ mod json_out {
         pub touch_required: bool,
     }
 
+    /// `keyroostctl otp --json pin-status` — the R3.4 OTP-PIN state.
+    ///
+    /// `supported: false` means the key never answered the flag read, so the
+    /// three PIN fields are `null`: the feature is not there to report on.
+    #[derive(Serialize)]
+    pub struct OtpPinStatusJson {
+        pub supported: bool,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub pin_set: Option<bool>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub retries_left: Option<u8>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub max_retries: Option<u8>,
+    }
+
     /// `keyroostctl otp --json get` — a single read OTP code.
     #[derive(Serialize)]
     pub struct OtpGetJson {
@@ -2113,7 +2128,7 @@ enum OtpCmd {
         #[arg(long)]
         seed_stdin: bool,
         /// OTP PIN for a protected (R3.4+) key, from this env var.
-        #[arg(long, value_name = "VAR")]
+        #[arg(long, value_name = "VAR", conflicts_with = "pin_stdin")]
         pin_env: Option<String>,
         /// Read the OTP PIN from stdin (SECOND line, after the seed) to unlock a
         /// protected key.
@@ -2199,6 +2214,10 @@ enum OtpCmd {
     /// Set an OTP PIN on a currently-unprotected key. After this, codes are
     /// readable only after `verify`. The PIN is read from stdin or an env var —
     /// never argv.
+    ///
+    /// There is no PIN reset: wrong attempts count down a retry counter, and a
+    /// blocked PIN is recoverable only by erasing every OTP entry on the key
+    /// (`otp erase-all`). Keep a record of the PIN somewhere you trust.
     SetPin {
         /// Read the PIN from the named environment variable.
         #[arg(long, value_name = "VAR", conflicts_with = "pin_stdin")]
@@ -5111,32 +5130,34 @@ fn run_otp(
                 return Err("--digits must be between 4 and 10".into());
             }
             // On stdin the seed is line 1 and (if --pin-stdin) the PIN is line 2.
-            let (seed_b32, pin): (zeroize::Zeroizing<String>, Option<zeroize::Zeroizing<String>>) =
-                if *seed_stdin && *pin_stdin {
-                    use std::io::BufRead;
-                    let stdin = std::io::stdin();
-                    let mut lines = stdin.lock().lines();
-                    let seed = lines
-                        .next()
-                        .transpose()?
-                        .ok_or("expected base32 seed on stdin line 1")?;
-                    let pin = lines
-                        .next()
-                        .transpose()?
-                        .ok_or("expected OTP PIN on stdin line 2")?;
-                    (
-                        zeroize::Zeroizing::new(seed),
-                        Some(zeroize::Zeroizing::new(pin)),
-                    )
+            let (seed_b32, pin): (
+                zeroize::Zeroizing<String>,
+                Option<zeroize::Zeroizing<String>>,
+            ) = if *seed_stdin && *pin_stdin {
+                use std::io::BufRead;
+                let stdin = std::io::stdin();
+                let mut lines = stdin.lock().lines();
+                let seed = lines
+                    .next()
+                    .transpose()?
+                    .ok_or("expected base32 seed on stdin line 1")?;
+                let pin = lines
+                    .next()
+                    .transpose()?
+                    .ok_or("expected OTP PIN on stdin line 2")?;
+                (
+                    zeroize::Zeroizing::new(seed),
+                    Some(zeroize::Zeroizing::new(pin)),
+                )
+            } else {
+                let seed = read_secret("seed", seed_env.as_deref(), *seed_stdin)?;
+                let pin = if pin_env.is_some() || *pin_stdin {
+                    Some(read_secret("OTP PIN", pin_env.as_deref(), *pin_stdin)?)
                 } else {
-                    let seed = read_secret("seed", seed_env.as_deref(), *seed_stdin)?;
-                    let pin = if pin_env.is_some() || *pin_stdin {
-                        Some(read_secret("OTP PIN", pin_env.as_deref(), *pin_stdin)?)
-                    } else {
-                        None
-                    };
-                    (seed, pin)
+                    None
                 };
+                (seed, pin)
+            };
             let seed = keyroost_token2otp::decode_base32_seed(seed_b32.trim())
                 .map_err(|e| format!("invalid base32 seed: {e}"))?;
             let mut session = open_otp(transport, debug)?;
@@ -5370,14 +5391,27 @@ fn run_otp(
         OtpCmd::PinStatus => {
             let mut session = open_otp(transport, debug)?;
             ensure_otp_feature(&mut session, OtpFeature::OnDevice)?;
+            // `None` = the key never answered the flag read, i.e. it has no
+            // OTP-PIN feature. That is a fact about the key, not a failure.
             let flag = session.pin_status()?;
-            if flag.is_set() {
-                println!(
+            if json_output() {
+                emit_json(&json_out::OtpPinStatusJson {
+                    supported: flag.is_some(),
+                    pin_set: flag.as_ref().map(|f| f.is_set()),
+                    retries_left: flag.as_ref().map(|f| f.retries_left),
+                    max_retries: flag.as_ref().map(|f| f.max_retries),
+                })?;
+                return Ok(());
+            }
+            match flag {
+                Some(f) if f.is_set() => println!(
                     "OTP PIN: set  (retries left: {}, max: {})",
-                    flag.retries_left, flag.max_retries
-                );
-            } else {
-                println!("OTP PIN: not set");
+                    f.retries_left, f.max_retries
+                ),
+                Some(_) => println!("OTP PIN: not set"),
+                None => println!(
+                    "OTP PIN: not offered by this key (the OTP-PIN feature arrived with R3.4)"
+                ),
             }
         }
         OtpCmd::SetPin { pin_env, pin_stdin } => {

--- a/docs/otp.html
+++ b/docs/otp.html
@@ -107,6 +107,48 @@
       the seed, enter a new secret and Save; to remove it, use <strong>Clear slot</strong>.</p>
   </section>
 
+  <section class="kr-section" id="otp-pin">
+    <h2>Putting codes behind a PIN (R3.4+)</h2>
+    <p>Keys running the R3.4 OTP applet can require a <strong>PIN</strong> before they hand
+      out any codes. Set one and the entry list stays sealed until you unlock it; the key
+      keeps the window open for a few minutes and then closes it again. Older keys simply
+      don't have the feature &mdash; they answer the capability question with "no such
+      command", and everything on this page works exactly as it always did.</p>
+    <p>In the GUI, the <strong>On-device OTP</strong> tab shows an unlock prompt in place of
+      the list, and the pane's <strong>&hellip;</strong> menu grows <strong>Set PIN&hellip;</strong>,
+      <strong>Change PIN&hellip;</strong>, <strong>Remove PIN&hellip;</strong> and
+      <strong>Lock now</strong>.</p>
+    <p>On the command line:</p>
+<pre><code>keyroostctl otp pin-status              # is a PIN set, and how many tries are left
+keyroostctl otp set-pin --pin-stdin     # protect this key (PIN on stdin, never argv)
+keyroostctl otp verify --pin-stdin      # open the read window for this connection
+keyroostctl otp change-pin --pin-stdin  # current PIN on line 1, new PIN on line 2
+keyroostctl otp remove-pin --pin-stdin  # back to unprotected
+keyroostctl otp list --pin-stdin        # unlock in passing; same for add and delete</code></pre>
+    <p class="kr-muted">The PIN is read from stdin (<code>--pin-stdin</code>) or from a named
+      environment variable (<code>--pin-env</code>) &mdash; never from the command line, where
+      it would land in your shell history and in the process list. <code>list</code>,
+      <code>add</code> and <code>delete</code> all take both flags.</p>
+    <div class="kr-callout danger">
+      <div class="kr-callout-title danger">A blocked PIN costs every code on the key</div>
+      <p>There is no PIN reset. Wrong attempts count down a retry counter, and once it
+        reaches zero the applet refuses the PIN for good &mdash; the only way back is
+        <code>keyroostctl otp erase-all</code>, which destroys every OTP entry on the key.
+        Keep a record of the PIN somewhere you trust before you set one.</p>
+    </div>
+    <div class="kr-callout note">
+      <div class="kr-callout-title note">What the PIN does and does not protect</div>
+      <p>The PIN never travels in the clear: host and key agree a session key first, and the
+        PIN is only ever sent encrypted under it. But the key also signs that agreement with
+        a P-521 key, and <strong>keyroost does not verify that signature</strong> &mdash; so the
+        session is confidential, not authenticated. Over NFC in particular, something that
+        can run the key agreement itself can capture one unlock attempt and try PINs against
+        it offline, at its own pace, without ever touching the key's retry counter. A short
+        numeric PIN does not survive that. Treat the PIN as protection against someone
+        picking up your key, not against someone standing between you and it.</p>
+    </div>
+  </section>
+
   <section class="kr-section">
     <h2>Command line</h2>
 <pre><code>keyroostctl otp list                  # stored entries

--- a/fuzz/fuzz_targets/token2otp_parse.rs
+++ b/fuzz/fuzz_targets/token2otp_parse.rs
@@ -1,7 +1,8 @@
 //! Token2 OTP-on-FIDO response parsers — fed raw bytes a (possibly malicious
 //! or buggy) Token2 key could return: the variable-tail enumerate-page parser,
-//! the single-entry read parser, the device-info decoder, and the serial-number
-//! decoder. None of these may panic on arbitrary input.
+//! the single-entry read parser, the device-info decoder, the serial-number
+//! decoder, and the R3.4 PIN-flag decoder. None of these may panic on
+//! arbitrary input.
 #![no_main]
 use libfuzzer_sys::fuzz_target;
 
@@ -12,4 +13,8 @@ fuzz_target!(|data: &[u8]| {
     let _ = keyroost_token2otp::entry::parse_read_one(data);
     let _ = keyroost_token2otp::DeviceInfo::parse(data);
     let _ = keyroost_token2otp::parse_serial(data);
+    // The PIN-flag response: a fixed 4-byte head plus an optional challenge
+    // sliced from fixed offsets 9..25 and 25..41, so every length boundary
+    // between 0 and 41 is a chance to index off the end.
+    let _ = keyroost_token2otp::PinFlag::parse(data);
 });


### PR DESCRIPTION
On R3.4+ firmware the OTP applet can require a PIN before it returns codes. Adds the PIN protocol (READ_OTP_PIN_FLAG / SET / VERIFY / CHANGE / READ_AGREEMENT_PUBKEY) and its ECDH session crypto to keyroost-token2otp, session operations (set/verify/change/remove/lock, unlock-aware enumerate and write, encrypted-page decryption) to keyroost-transport, CLI subcommands to keyroostctl, and a GUI unlock prompt plus set/change/remove/lock actions to the OTP pane.

Ported from the Token2 reference client and hardware-tested on a PIN+ key over USB, CCID and NFC. The device's ECC-P521 agreement signature is not verified (the P-256 stack can't check it), so the ECDH gives session confidentiality but not cryptographic device authenticity — same caveat as the reference client.

Closes #107.