### PR TITLE
feat(nix): add flake packaging and development shell

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /target
+result
 
 # Personal Claude Code overrides (the shared .claude/settings.json IS committed)
 /.claude/settings.local.json

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1787559586,
+        "narHash": "sha256-onL0VLf9vPllmT0H/OlURIU5r5t5WIEl7t4tVNKT0Nw=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "9d0d87172c374f89da73c1cfe6d81ae62feac1f1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1787498568,
+        "narHash": "sha256-9i/VTdusq/+NM/tz+J1Re+ojkMB8MBf0QshnYfzHz30=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "56c02bc00adcf003215cc4bd996d6efaf4cff188",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1785031560,
+        "narHash": "sha256-OmshNvn2vupOFpYinLUu+1Dnpu4n7Q5N3ggGVNHpkUI=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "0e79af5e3d4dcfcd676ab5ba3f95d2e3352e078c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1787559586,
-        "narHash": "sha256-onL0VLf9vPllmT0H/OlURIU5r5t5WIEl7t4tVNKT0Nw=",
+        "lastModified": 1788450739,
+        "narHash": "sha256-glZLQlzIn1fXH6PazR2iUmTo7kzzyYSshrWhLS9TqCU=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "9d0d87172c374f89da73c1cfe6d81ae62feac1f1",
+        "rev": "31729ca8cbdb4fa927b34e5f4353e6a83f39e993",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1787498568,
-        "narHash": "sha256-9i/VTdusq/+NM/tz+J1Re+ojkMB8MBf0QshnYfzHz30=",
+        "lastModified": 1788614874,
+        "narHash": "sha256-7QYjT2vHLuX9Z1pdxHXDKCbh1CR3D/2rywB9Tx0MPRg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "56c02bc00adcf003215cc4bd996d6efaf4cff188",
+        "rev": "c043004d1c6985732bcc1cbc5a9c9aecbbb4e0f0",
         "type": "github"
       },
       "original": {
@@ -36,11 +36,11 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1785031560,
-        "narHash": "sha256-OmshNvn2vupOFpYinLUu+1Dnpu4n7Q5N3ggGVNHpkUI=",
+        "lastModified": 1788057806,
+        "narHash": "sha256-DTQSMxzDWmT0zhguthvegnVkn7CFqGCv4IHCzk5ZUpM=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "0e79af5e3d4dcfcd676ab5ba3f95d2e3352e078c",
+        "rev": "596e2e3940e09b2abbeb03f75fa1828c57fcd72c",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -140,6 +140,7 @@
             packages = with pkgs; [
               nixfmt
               nixd
+              rust-analyzer
             ];
           };
         };

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,147 @@
+{
+  description = "Vendor Neutral, Rust-Based Management UI and CLI for U2F/FIDO2 and other hardware security keys ";
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-parts.url = "github:hercules-ci/flake-parts";
+  };
+
+  outputs =
+    inputs@{ flake-parts, ... }:
+    flake-parts.lib.mkFlake { inherit inputs; } {
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "aarch64-darwin"
+      ];
+
+      perSystem =
+        {
+          config,
+          pkgs,
+          ...
+        }:
+        let
+          workspaceCargo = fromTOML (builtins.readFile ./Cargo.toml);
+          keyroostCargo = fromTOML (builtins.readFile ./crates/keyroost/Cargo.toml);
+          keyroostctlCargo = fromTOML (builtins.readFile ./crates/keyroostctl/Cargo.toml);
+          version = workspaceCargo.workspace.package.version;
+        in
+        {
+          packages = {
+            keyroost = pkgs.rustPlatform.buildRustPackage {
+              pname = keyroostCargo.package.name;
+              inherit version;
+
+              src = ./.;
+
+              cargoLock = {
+                lockFile = ./Cargo.lock;
+              };
+
+              cargoBuildFlags = [
+                "-p"
+                "keyroost"
+              ];
+
+              buildNoDefaultFeatures = true;
+
+              nativeBuildInputs = with pkgs; [
+                pkg-config
+              ];
+
+              buildInputs =
+                with pkgs;
+                [
+                  pcsclite
+                ]
+                ++ pkgs.lib.optionals pkgs.stdenv.hostPlatform.isLinux [
+                  libxkbcommon
+                  libGL
+                  wayland
+                  libx11
+                  libxcursor
+                  libxi
+                  libxrandr
+                ];
+
+              postFixup = pkgs.lib.optionalString pkgs.stdenv.hostPlatform.isLinux ''
+                patchelf --set-rpath "${
+                  pkgs.lib.makeLibraryPath [
+                    pkgs.pcsclite
+                    pkgs.wayland
+                    pkgs.libx11
+                    pkgs.libxcursor
+                    pkgs.libxi
+                    pkgs.libxrandr
+                    pkgs.libGL
+                    pkgs.libxkbcommon
+                  ]
+                }" $out/bin/keyroost
+              '';
+
+              meta = {
+                description = "Desktop GUI for programming Token2 Molto2 / Molto2v2 TOTP tokens.";
+                homepage = "https://github.com/framefilter/keyroost";
+                license = with pkgs.lib.licenses; [
+                  mit
+                  asl20
+                ];
+                platforms = pkgs.lib.platforms.unix;
+              };
+            };
+
+            keyroostctl = pkgs.rustPlatform.buildRustPackage {
+              pname = keyroostctlCargo.package.name;
+              inherit version;
+
+              src = ./.;
+
+              cargoLock = {
+                lockFile = ./Cargo.lock;
+              };
+
+              cargoBuildFlags = [
+                "-p"
+                "keyroostctl"
+              ];
+
+              nativeBuildInputs = with pkgs; [
+                pkg-config
+              ];
+
+              buildInputs = with pkgs; [
+                pcsclite
+              ];
+
+              postFixup = pkgs.lib.optionalString pkgs.stdenv.hostPlatform.isLinux ''
+                patchelf --set-rpath "${pkgs.lib.makeLibraryPath [ pkgs.pcsclite ]}" $out/bin/keyroostctl
+              '';
+
+              meta = {
+                description = "Command-line tool for programming Token2 Molto2 / Molto2v2 TOTP tokens.";
+                homepage = "https://github.com/framefilter/keyroost";
+                license = with pkgs.lib.licenses; [
+                  mit
+                  asl20
+                ];
+                platforms = pkgs.lib.platforms.unix;
+              };
+            };
+
+            default = config.packages.keyroost;
+          };
+
+          devShells.default = pkgs.mkShell {
+            inputsFrom = [
+              config.packages.keyroost
+              config.packages.keyroostctl
+            ];
+            packages = with pkgs; [
+              nixfmt
+              nixd
+            ];
+          };
+        };
+    };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -11,7 +11,6 @@
       systems = [
         "x86_64-linux"
         "aarch64-linux"
-        "x86_64-darwin"
         "aarch64-darwin"
       ];
 

--- a/flake.nix
+++ b/flake.nix
@@ -59,6 +59,7 @@
                   libGL
                   wayland
                   libx11
+                  libxcb
                   libxcursor
                   libxi
                   libxrandr
@@ -70,6 +71,7 @@
                     pkgs.pcsclite
                     pkgs.wayland
                     pkgs.libx11
+                    pkgs.libxcb
                     pkgs.libxcursor
                     pkgs.libxi
                     pkgs.libxrandr

--- a/flake.nix
+++ b/flake.nix
@@ -55,28 +55,28 @@
                   pcsclite
                 ]
                 ++ pkgs.lib.optionals pkgs.stdenv.hostPlatform.isLinux [
-                  libxkbcommon
                   libGL
-                  wayland
                   libx11
                   libxcb
                   libxcursor
                   libxi
+                  libxkbcommon
                   libxrandr
+                  wayland
                 ];
 
               postFixup = pkgs.lib.optionalString pkgs.stdenv.hostPlatform.isLinux ''
                 patchelf --set-rpath "${
                   pkgs.lib.makeLibraryPath [
-                    pkgs.pcsclite
-                    pkgs.wayland
+                    pkgs.libGL
                     pkgs.libx11
                     pkgs.libxcb
                     pkgs.libxcursor
                     pkgs.libxi
-                    pkgs.libxrandr
-                    pkgs.libGL
                     pkgs.libxkbcommon
+                    pkgs.libxrandr
+                    pkgs.pcsclite
+                    pkgs.wayland
                   ]
                 }" $out/bin/keyroost
               '';


### PR DESCRIPTION
- **feat(flake): create flake.nix**
- **fix(flake): add rust-analyzer to devshell**

## Summary
Adds Nix flake (`flake.nix`, `flake.lock`) providing native packaging for `keyroost` and `keyroostctl`, alongside reproducible development shell.

Packages application without affecting original source code. Package versions pulled directly from `Cargo.toml` and `Cargo.lock`.

> [!NOTE]
> `flake.nix` was created with the assistance of AI in order to get it to successfully build. Checkout `postFixup` inside flake.nix for more details.

## Motivation
Running NixOS means standard dynamically linked binaries fail out of box due to non-standard library paths. Packaging application directly with Nix eliminates setup friction for NixOS users.

While targeted at solving NixOS binary compatibility, any system with Nix package manager installed (including non-NixOS Linux distributions and macOS) can utilize this flake.

## Changes
- Created `flake.nix` defining outputs:
  - `packages.keyroost` (default)
  - `packages.keyroostctl`
  - `devShells.default` containing Rust toolchain, `rust-analyzer`, and `nixd`
- Added lockfile `flake.lock`.

## Supported Systems
Declared targets:
- `"x86_64-linux"` (fully tested)
- `"aarch64-linux"`
- `"x86_64-darwin"`
- `"aarch64-darwin"`

Only `"x86_64-linux"` fully tested. Unable to guarantee execution on other architectures due to lack of test hardware, though builds should succeed.

## How to Test
Verify outputs and build targets:
```sh
nix flake check
nix build .#keyroost
nix build .#keyroostctl
nix develop
```
