### PR TITLE
Tolerate any-length GET VERSION / Swissbit iShield Key 2 Pro compat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+- **PIV cards that answer GET VERSION with more than three bytes can now be
+  managed.** The Swissbit iShield Key 2 Pro replies to the Yubico version
+  extension with four bytes; keyroost rejected the reply and with it the
+  card. The version is now kept as the card sent it and shown as-is (dotted
+  for up to four bytes, hex beyond), and the firmware checks that gate
+  YubiKey-specific behaviour compare the leading bytes exactly as before.
+  Contributed by @episource. ([#110])
+
 ## [0.8.0] - 2026-08-24
 
 **Why 0.8.0 and not 0.7.9:** this release changes the published library
@@ -906,6 +915,7 @@ multi-vendor hardware-security-key manager, then took its neutral name. Highligh
 [#98]: https://github.com/framefilter/keyroost/issues/98
 [#101]: https://github.com/framefilter/keyroost/pull/101
 [#102]: https://github.com/framefilter/keyroost/pull/102
+[#110]: https://github.com/framefilter/keyroost/pull/110
 [Unreleased]: https://github.com/framefilter/keyroost/compare/v0.8.0...HEAD
 [0.8.0]: https://github.com/framefilter/keyroost/compare/v0.7.8...v0.8.0
 [0.7.8]: https://github.com/framefilter/keyroost/compare/v0.7.7...v0.7.8

--- a/crates/keyroost-piv/src/lib.rs
+++ b/crates/keyroost-piv/src/lib.rs
@@ -1311,11 +1311,26 @@ pub fn unwrap_data_object(buf: &[u8]) -> Result<&[u8], ParseError> {
     buf.get(start..end).ok_or(ParseError::Truncated)
 }
 
-/// Parse a Yubico GET VERSION reply (exactly 3 bytes) into `(major, minor, patch)`.
-pub fn parse_version(buf: &[u8]) -> Result<(u8, u8, u8), ParseError> {
-    match buf {
-        [a, b, c] => Ok((*a, *b, *c)),
-        _ => Err(ParseError::BadResponse("version is not 3 bytes")),
+/// Format a Yubico `GET VERSION` reply for display — tolerant of any
+/// non-empty length. Feature gates on the transport side (`move_key_supported`
+/// et al.) compare the same raw bytes directly as a slice rather than parsing
+/// them into a fixed-width tuple first, so there's no separate strict parse
+/// to defer to here either. Up to 4 bytes still reads as a version number, so
+/// it's dot-joined as decimal (`major.minor.patch[...]`, covering both real
+/// Yubico firmware's 3 bytes and small vendor variants like a 4-byte reply
+/// observed from a Swissbit OpenFIPS201 build). Past 4 bytes, dot-joining
+/// stops being a meaningful "version" and just obscures the actual bytes, so
+/// it falls back to plain lowercase hex.
+#[must_use]
+pub fn format_version_bytes(bytes: &[u8]) -> String {
+    if bytes.len() <= 4 {
+        bytes
+            .iter()
+            .map(u8::to_string)
+            .collect::<Vec<_>>()
+            .join(".")
+    } else {
+        keyroost_proto::codec::hex_encode(bytes)
     }
 }
 
@@ -1552,11 +1567,29 @@ mod tests {
     }
 
     #[test]
-    fn parse_version_and_serial_values() {
-        assert_eq!(parse_version(&[5, 7, 1]).unwrap(), (5, 7, 1));
-        assert!(parse_version(&[5, 7]).is_err());
+    fn parse_serial_values() {
         assert_eq!(parse_serial(&[0x02, 0x40, 0x8A, 0x1B]).unwrap(), 0x02408A1B);
         assert!(parse_serial(&[0x00, 0x01]).is_err());
+    }
+
+    #[test]
+    fn format_version_bytes_dots_up_to_four_bytes() {
+        assert_eq!(format_version_bytes(&[5, 7, 1]), "5.7.1");
+        assert_eq!(format_version_bytes(&[1, 0, 0, 0]), "1.0.0.0");
+        assert_eq!(format_version_bytes(&[9]), "9");
+        assert_eq!(format_version_bytes(&[]), "");
+    }
+
+    #[test]
+    fn format_version_bytes_falls_back_to_hex_past_four_bytes() {
+        assert_eq!(
+            format_version_bytes(&[0x01, 0x02, 0x03, 0x04, 0x05]),
+            "0102030405"
+        );
+        assert_eq!(
+            format_version_bytes(&[0xDE, 0xAD, 0xBE, 0xEF, 0xCA, 0xFE]),
+            "deadbeefcafe"
+        );
     }
 
     #[test]

--- a/crates/keyroost-transport/src/piv.rs
+++ b/crates/keyroost-transport/src/piv.rs
@@ -1040,8 +1040,10 @@ impl PivSession {
         // no way back from the blocked PIN and PUK this path deliberately
         // creates. GET VERSION and GET SERIAL come from the same extension
         // family, so a card that answers neither is exactly the card that must
-        // be refused. Decide here, before the first wrong VERIFY: afterwards the
-        // damage is already done.
+        // be refused. Any-length answers count: a card that replies to GET
+        // VERSION with four bytes (Swissbit iShield Key 2 Pro) is still speaking
+        // the extension family, which is what this gate is asking. Decide here,
+        // before the first wrong VERIFY: afterwards the damage is already done.
         let st = self.status()?;
         if st.version.is_none() && st.serial.is_none() {
             return Err(TransportError::PivForceResetUnsupported);

--- a/crates/keyroost-transport/src/piv.rs
+++ b/crates/keyroost-transport/src/piv.rs
@@ -126,9 +126,18 @@ fn map_reset_stage_error(e: TransportError) -> TransportError {
 /// A read-only snapshot of a PIV application's state.
 #[derive(Debug, Clone)]
 pub struct PivStatus {
-    /// Applet/firmware version `(major, minor, patch)` from the Yubico GET
-    /// VERSION extension, if the card supports it.
-    pub version: Option<(u8, u8, u8)>,
+    /// Reply to Yubico's proprietary `GET VERSION` extension (`INS FD`), raw
+    /// bytes, any non-empty length. Real Yubico firmware answers with exactly
+    /// 3 (`major.minor.patch`) — but this extension is implemented by many
+    /// devices beyond genuine YubiKeys (observed: a Swissbit iShield Key 2
+    /// Pro, an OpenFIPS201 build, answering `9000` with 4 bytes that don't
+    /// trace back to anything in OpenFIPS201's own source), so a reply here
+    /// means "answers this Yubico extension," not "is a YubiKey." `None` if
+    /// the card doesn't answer it, or answers empty. Feature gates (e.g.
+    /// [`move_key_supported`]) compare this directly as a byte slice rather
+    /// than requiring an exact 3-byte shape. See
+    /// [`keyroost_piv::format_version_bytes`] for display formatting.
+    pub version: Option<Vec<u8>>,
     /// Device serial (Yubico GET SERIAL; firmware 5+), if supported.
     pub serial: Option<u32>,
     /// Remaining PIN tries from a no-op VERIFY (`63 Cx`); `Some(0)` when blocked,
@@ -227,12 +236,17 @@ impl PubkeyCache {
     }
 }
 
-/// Whether MOVE KEY is available given the reported firmware `(major, minor, _)`.
-/// fw 5.7+ (Yubico). Unknown version → allow the attempt; the card refuses if
-/// it truly can't (belt-and-suspenders with the pre-check).
-fn move_key_supported(version: Option<(u8, u8, u8)>) -> bool {
+/// Whether MOVE KEY is available given the reported firmware version — fw
+/// 5.7+ (Yubico). Compared as a plain byte slice, not a fixed 3-part tuple:
+/// [`PivStatus::version`] isn't guaranteed to be exactly 3 bytes, and slice
+/// order gets a length mismatch right on its own (`[5, 7] < [5, 7, 0] <
+/// [5, 7, 1] < [5, 8]`), so `[5, 7]` alone is a correct "5.7 or newer"
+/// threshold without needing a trailing zero. Unknown version → allow the
+/// attempt; the card refuses if it truly can't (belt-and-suspenders with the
+/// pre-check).
+fn move_key_supported(version: Option<&[u8]>) -> bool {
     match version {
-        Some((major, minor, _)) => major > 5 || (major == 5 && minor >= 7),
+        Some(v) => v >= [5, 7].as_slice(),
         None => true,
     }
 }
@@ -340,13 +354,16 @@ impl PivSession {
         })
     }
 
-    /// Yubico GET VERSION; `None` if the card doesn't support the extension.
-    fn version(&mut self) -> Option<(u8, u8, u8)> {
+    /// Yubico's proprietary GET VERSION extension (`INS FD`), raw reply
+    /// bytes, tolerant of any non-empty length — see [`PivStatus::version`]
+    /// for why. `None` if the command errors, the card answers a non-`9000`
+    /// status, or the reply is empty. Feature gates (`move_key_supported`,
+    /// the `new_enough` check in [`Self::delete_key`]) call this directly and
+    /// compare the raw bytes as a slice, rather than requiring an exact
+    /// 3-byte shape like real Yubico firmware's.
+    fn version(&mut self) -> Option<Vec<u8>> {
         let (data, sw) = self.transmit_full(&piv::get_version()).ok()?;
-        if sw != piv::SW_OK {
-            return None;
-        }
-        piv::parse_version(&data).ok()
+        (sw == piv::SW_OK && !data.is_empty()).then_some(data)
     }
 
     /// Yubico GET SERIAL; `None` if unsupported (older firmware / non-Yubico).
@@ -658,7 +675,10 @@ impl PivSession {
     /// [`authenticate_management`]: PivSession::authenticate_management
     pub fn delete_key(&mut self, slot: Slot) -> Result<(), TransportError> {
         // Version-gate: MOVE/DELETE KEY landed in YubiKey firmware 5.7.
-        let new_enough = matches!(self.version(), Some(v) if v >= (5, 7, 0));
+        // Compared as a byte slice, not a fixed 3-part tuple — see
+        // `move_key_supported`'s doc for why `[5, 7]` alone is the right
+        // threshold.
+        let new_enough = matches!(self.version(), Some(v) if v.as_slice() >= [5, 7].as_slice());
         if !new_enough {
             return Err(TransportError::PivFirmwareTooOld(
                 "deleting a key requires YubiKey firmware 5.7 or newer (older cards can only overwrite the slot)",
@@ -951,7 +971,7 @@ impl PivSession {
                 "source and destination slots are the same",
             ));
         }
-        if !move_key_supported(self.version()) {
+        if !move_key_supported(self.version().as_deref()) {
             return Err(TransportError::PivFirmwareTooOld(
                 "moving a key requires YubiKey firmware 5.7 or newer",
             ));
@@ -1406,10 +1426,15 @@ mod tests {
     #[test]
     fn move_key_firmware_gate() {
         // MOVE KEY needs fw 5.7+. Below that -> refuse.
-        assert!(!move_key_supported(Some((5, 6, 0))));
-        assert!(move_key_supported(Some((5, 7, 0))));
-        assert!(move_key_supported(Some((5, 7, 4))));
-        assert!(move_key_supported(Some((6, 0, 0))));
+        assert!(!move_key_supported(Some(&[5, 6, 0])));
+        assert!(move_key_supported(Some(&[5, 7, 0])));
+        assert!(move_key_supported(Some(&[5, 7, 4])));
+        assert!(move_key_supported(Some(&[6, 0, 0])));
+        // A bare [5, 7] itself clears the bar too — slice order puts a
+        // shorter-but-otherwise-equal reply below anything with a 3rd byte,
+        // not above it (`[5, 7] < [5, 7, 0]`), so the threshold has to be
+        // written as [5, 7] rather than [5, 7, 0] to include it.
+        assert!(move_key_supported(Some(&[5, 7])));
         // Unknown version -> allow the attempt (card will reject if unsupported).
         assert!(move_key_supported(None));
     }

--- a/crates/keyroost/src/main.rs
+++ b/crates/keyroost/src/main.rs
@@ -13262,9 +13262,16 @@ impl App {
             // Status body: version / serial / PIN retries collapsed onto one
             // dotted line.
             if let Some(st) = &self.piv.status {
+                // Tolerant of any non-empty GET VERSION reply, not just real
+                // Yubico firmware's 3 bytes — some third-party PIV applets
+                // that answer this vendor extension at all use a different
+                // byte count (observed: a Swissbit iShield Key 2 Pro replies
+                // with 4).
                 let ver = st
                     .version
-                    .map_or("\u{2014}".to_string(), |(a, b, c)| format!("{a}.{b}.{c}"));
+                    .as_deref()
+                    .map(keyroost_piv::format_version_bytes)
+                    .unwrap_or_else(|| "\u{2014}".to_string());
                 let serial = st.serial.map_or("\u{2014}".to_string(), |s| s.to_string());
                 let retries = st
                     .pin_retries
@@ -13491,8 +13498,8 @@ impl App {
         // explain) when the loaded status reports an older — or unknown —
         // version. Clearing a certificate works everywhere.
         let can_delete_key = matches!(
-            self.piv.status.as_ref().and_then(|s| s.version),
-            Some(v) if v >= (5, 7, 0)
+            self.piv.status.as_ref().and_then(|s| s.version.as_deref()),
+            Some(v) if v >= [5, 7].as_slice()
         );
         // --- Slot sub-tab strip ---------------------------------------------
         // Each PIV slot is a tab, exactly like the FIDO2 sub-tab strip

--- a/crates/keyroostctl/src/main.rs
+++ b/crates/keyroostctl/src/main.rs
@@ -148,6 +148,8 @@ mod json_out {
     /// `keyroostctl piv --json status`.
     #[derive(Serialize)]
     pub struct PivStatusJson {
+        /// Yubico GET VERSION's raw reply, dotted (or hex past 4 bytes),
+        /// tolerant of any non-empty byte count.
         pub version: Option<String>,
         pub serial: Option<u32>,
         pub pin_retries: Option<u8>,
@@ -5661,7 +5663,10 @@ fn run_piv(cmd: &PivCmd, debug: bool) -> Result<(), Box<dyn std::error::Error>> 
 
             if json_output() {
                 emit_json(&json_out::PivStatusJson {
-                    version: status.version.map(|(a, b, c)| format!("{a}.{b}.{c}")),
+                    version: status
+                        .version
+                        .as_deref()
+                        .map(keyroost_piv::format_version_bytes),
                     serial: status.serial,
                     pin_retries: status.pin_retries,
                     chuid: status.chuid.as_ref().map(|c| json_out::PivChuidJson {
@@ -5684,8 +5689,12 @@ fn run_piv(cmd: &PivCmd, debug: bool) -> Result<(), Box<dyn std::error::Error>> 
                 return Ok(());
             }
 
-            match status.version {
-                Some((a, b, c)) => println!("Version:     {}.{}.{}", a, b, c),
+            // Tolerant of any non-empty GET VERSION reply, not just real
+            // Yubico firmware's 3 bytes — some third-party PIV applets that
+            // answer this vendor extension at all use a different byte count
+            // (observed: a Swissbit iShield Key 2 Pro replies with 4).
+            match status.version.as_deref() {
+                Some(v) => println!("Version:     {}", keyroost_piv::format_version_bytes(v)),
                 None => println!("Version:     (unavailable)"),
             }
             match status.serial {
@@ -9654,7 +9663,16 @@ mod cli_tests {
                 cert_len: 800,
             }],
         };
-        assert_json_has_keys(&p, &["version", "serial", "pin_retries", "chuid", "slots"]);
+        assert_json_has_keys(
+            &p,
+            &[
+                "version",
+                "serial",
+                "pin_retries",
+                "chuid",
+                "slots",
+            ],
+        );
     }
 
     #[test]

--- a/crates/keyroostctl/src/main.rs
+++ b/crates/keyroostctl/src/main.rs
@@ -9663,16 +9663,7 @@ mod cli_tests {
                 cert_len: 800,
             }],
         };
-        assert_json_has_keys(
-            &p,
-            &[
-                "version",
-                "serial",
-                "pin_retries",
-                "chuid",
-                "slots",
-            ],
-        );
+        assert_json_has_keys(&p, &["version", "serial", "pin_retries", "chuid", "slots"]);
     }
 
     #[test]

--- a/fuzz/fuzz_targets/piv_parse.rs
+++ b/fuzz/fuzz_targets/piv_parse.rs
@@ -4,7 +4,7 @@ use libfuzzer_sys::fuzz_target;
 
 fuzz_target!(|data: &[u8]| {
     let _ = keyroost_piv::unwrap_data_object(data);
-    let _ = keyroost_piv::parse_version(data);
+    let _ = keyroost_piv::format_version_bytes(data);
     let _ = keyroost_piv::parse_serial(data);
     // Write-path response parsers: GENERAL AUTHENTICATE templates, generated
     // public keys, and GET METADATA — all carry attacker-influenceable BER.


### PR DESCRIPTION
A Swissbit iShield Key 2 Pro answers the Yubico GET VERSION extension (INS FD) with 4 data bytes instead of real Yubico firmware's 3. Prior to this commit this was rejected. This PR changes version handling to tolerate any number of bytes returned.