### PR TITLE
otp: report a locked PIN from the flag probe; list the Swissbit as PIV-verified

### DIFF
--- a/crates/keyroost-token2otp/src/crypto.rs
+++ b/crates/keyroost-token2otp/src/crypto.rs
@@ -499,14 +499,10 @@ pub fn build_verify_pin_data(
 /// identically, which is why the *old* PIN is hashed before it is encrypted.
 ///
 /// `rand` is read from the same `Lc=0x29` challenge round trip that `verify`
-/// uses, but nothing in the block above binds it: the change proof authenticates
-/// the new PIN block and the old PIN hash, not the device's fresh challenge.
-/// The argument is kept so the signature does not have to change if the binding
-/// turns out to be required.
-// TODO(token2): confirm whether the change proof must bind Rand. If it must,
-// the block layout above is incomplete and CHANGE is replayable within a
-// session; if it must not, the transport's challenge read before a change can
-// go away entirely.
+/// uses, but the change proof does not bind it: it authenticates the current
+/// PIN via `SHA256(current)[..16]` plus the session MAC, which Token2 confirmed
+/// is what the firmware and the reference client do. The argument is kept so
+/// the signature matches `verify`'s.
 pub fn build_change_pin_data(
     keys: &SessionKeys,
     new_pin: &[u8],

--- a/crates/keyroost-transport/src/token2otp.rs
+++ b/crates/keyroost-transport/src/token2otp.rs
@@ -863,6 +863,19 @@ fn probe_hid(t: &mut HidOtpTransport) -> Result<(), OtpTransportError> {
     Ok(())
 }
 
+/// Status words that mean "this applet has no PIN command at all" — the ISO
+/// unknown-instruction family, plus `6AF8`, which R3.4 firmware itself answers a
+/// bodyless flag read with. Every other non-`9000` answer to the flag read is a
+/// real PIN state (Token2 confirmed `6982`/`6983`/`6985`/`6A81`/`63xx` are) and
+/// is surfaced, never mistaken for "no feature".
+const NO_PIN_FEATURE_ANSWERS: [u16; 5] = [
+    0x6D00, // instruction not supported
+    0x6E00, // class not supported
+    0x6A86, // incorrect P1/P2
+    0x6AF8, // what R3.4 itself answers a bodyless flag read
+    0x6700, // wrong length
+];
+
 impl Token2OtpSession {
     /// Open the OTP applet, trying USB-HID first and falling back to PC/SC.
     ///
@@ -1104,7 +1117,12 @@ impl Token2OtpSession {
         let (data, sw) = self.transport.transmit(&apdu, false)?;
         let flag = if sw == t2::sw::OK {
             t2::PinFlag::parse(&data).ok()
+        } else if NO_PIN_FEATURE_ANSWERS.contains(&sw) {
+            None
         } else {
+            // Anything else is the applet reporting a real PIN state — a
+            // locked PIN answers 6983 here — and must reach the caller.
+            t2::OtpError::check(sw)?;
             None
         };
         self.pin_present = flag.as_ref().map(|f| f.is_set());
@@ -2056,16 +2074,28 @@ mod pre_r34_keys_are_unaffected {
         (session, sent)
     }
 
-    /// Every status word an applet has been seen to use for "I don't know that
-    /// instruction", plus the generic wrong-length and wrong-P1P2 answers.
-    const UNKNOWN_INSTRUCTION_ANSWERS: [u16; 6] = [
-        0x6A81, // function not supported in the current state
-        0x6D00, // instruction not supported
-        0x6A86, // incorrect P1/P2
-        0x6AF8, // what R3.4 itself answers a bodyless flag read
-        0x6700, // wrong length
-        0x6E00, // class not supported
-    ];
+    /// The answers that mean "no PIN command here" — shared with the probe so a
+    /// word added there is exercised here.
+    const UNKNOWN_INSTRUCTION_ANSWERS: [u16; 5] = super::NO_PIN_FEATURE_ANSWERS;
+
+    #[test]
+    fn a_locked_pin_is_reported_not_hidden() {
+        // 6983 on the flag read is the applet saying "PIN locked", not "no PIN
+        // feature" — listing must stop with that state, never proceed as if
+        // the key were unprotected. 6A81 is likewise a real state per Token2.
+        for sw in [0x6983u16, 0x6982, 0x6985, 0x6A81] {
+            let (mut session, _) = old_key(sw);
+            let err = session
+                .pin_status()
+                .expect_err("a real PIN state must not be swallowed");
+            assert!(
+                matches!(err, OtpTransportError::Applet(_)),
+                "{sw:#06X} surfaced as {err:?}"
+            );
+            let (mut session, _) = old_key(sw);
+            assert!(session.enumerate_pinned(0, None).is_err(), "{sw:#06X}");
+        }
+    }
 
     #[test]
     fn listing_still_works_and_sends_the_same_bytes_as_before() {

--- a/docs/devices.html
+++ b/docs/devices.html
@@ -103,6 +103,11 @@
           does not. PIV verified on a Nitrokey 3A NFC (firmware 1.8.3),
           contributed by episource. The OpenPGP applet is detected but not yet
           exercised by this project.</td></tr>
+      <tr><td><strong>Swissbit iShield Key 2 Pro</strong></td>
+        <td>PIV</td>
+        <td>Answers the Yubico version extension with four bytes instead of
+          three; keyroost keeps the reply as sent. PIV verified by episource on
+          their own card. Other applets not yet exercised by this project.</td></tr>
     </table>
     </div>
   </section>


### PR DESCRIPTION
Two follow-ups from the #108 and #110 review threads.

The pre-R3.4 tolerance added on #108 treated every non-9000 answer to READ_OTP_PIN_FLAG as "no PIN command", which also hid a locked PIN (6983) and the other real states Token2 listed. Only the ISO unknown-instruction words and 6AF8 mean "no feature" now; everything else goes through the applet's own status-word mapping, with a test showing a locked key stops listing instead of behaving as unprotected. The change-proof comment now states what the firmware does, as Token2 confirmed.

The Swissbit iShield Key 2 Pro is listed on the devices page as PIV-verified by episource on their own card (#110).

re #107, re #110

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SQv9x6xi3CxXs2PvXohaFu
