### PR TITLE
openpgp: generate ECC keys in any algorithm the card accepts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,11 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `OpenPgpStatus` carries each slot's raw algorithm attributes. The CLI's
   `openpgp status` (and its `--json` `*_algo` fields) now report
   `RSA-2048` / `EdDSA Ed25519` rather than the bare family name.
+  `TransportError` gains two new variants — `OpenPgpSlotMismatch` (a
+  requested algorithm that can't live in the requested slot) and
+  `OpenPgpSlotNotRsa` (an RSA-only operation, i.e. key import, run against a
+  slot that holds an ECC key) — so an exhaustive match over `TransportError`
+  needs new arms.
 
 ### Fixed
 - **Identiv uTrust FIDO2 PIV cards can now be managed.** Their PIV applet

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+- **OpenPGP keys in modern algorithms.** `openpgp generate-key --algorithm`
+  (and the GUI's Generate dialog) can set a slot to Ed25519, X25519, NIST
+  P-256/384/521, secp256k1, brainpool 256/384/512, or RSA 2048/3072/4096
+  before generating; previously a slot could only ever produce its factory
+  default (RSA-2048). The menu comes from the card's own algorithm list
+  (`openpgp algorithms`, new) when it publishes one. `sign`/`authenticate`
+  frame input correctly for ECC slots, `decrypt` performs ECDH on an ECDH
+  slot, and `status` names the curve. Verified on a YubiKey 5.7. Requested
+  by @mdedonno1337. ([#106])
+
+### Changed
+- Library API (`keyroost-openpgp`, `keyroost-transport`): `PublicKey` is now
+  an enum (`Rsa` / `Ecc`), `OpenPgpSession::generate_key` takes an optional
+  algorithm, `rsa_v4_fingerprint_from` is replaced by `v4_fingerprint`, and
+  `OpenPgpStatus` carries each slot's raw algorithm attributes. The CLI's
+  `openpgp status` (and its `--json` `*_algo` fields) now report
+  `RSA-2048` / `EdDSA Ed25519` rather than the bare family name.
+
 ### Fixed
 - **Identiv uTrust FIDO2 PIV cards can now be managed.** Their PIV applet
   answers management-key authentication without the final card-to-host
@@ -916,6 +935,7 @@ multi-vendor hardware-security-key manager, then took its neutral name. Highligh
 [#101]: https://github.com/framefilter/keyroost/pull/101
 [#102]: https://github.com/framefilter/keyroost/pull/102
 [#104]: https://github.com/framefilter/keyroost/pull/104
+[#106]: https://github.com/framefilter/keyroost/issues/106
 [Unreleased]: https://github.com/framefilter/keyroost/compare/v0.8.0...HEAD
 [0.8.0]: https://github.com/framefilter/keyroost/compare/v0.7.8...v0.8.0
 [0.7.8]: https://github.com/framefilter/keyroost/compare/v0.7.7...v0.7.8

--- a/README.md
+++ b/README.md
@@ -51,13 +51,15 @@ a short, vendor-neutral tour of what FIDO2, OATH, OpenPGP, and PIV actually do.
   applet (`oath reset --yes`) — the recovery path for a forgotten password. In
   the GUI, secret fields have a reveal (eye) toggle so you can check an OTP
   secret before committing it.
-- **OpenPGP card (v3.4)** — read status; generate or import RSA-2048 keys (host
-  keygen or a PKCS#1/PKCS#8 PEM/DER file) for the signature, encryption, or
-  authentication slot — each writes the v4 fingerprint and a generation timestamp
-  so GnuPG recognizes the key; sign (SHA-256 or SHA-1); decrypt; authenticate (a
-  client/SSH signature with the Authentication key via INTERNAL AUTHENTICATE);
-  set cardholder name / URL; change the user / admin PIN and unblock a locked
-  PIN; factory-reset the applet.
+- **OpenPGP card (v3.4)** — read status; generate keys on-card in any algorithm
+  the card accepts (RSA 2048/3072/4096, Ed25519, X25519, NIST P-256/384/521,
+  secp256k1, brainpool) for the signature, encryption, or authentication slot,
+  or import an RSA-2048 key (host keygen or a PKCS#1/PKCS#8 PEM/DER file) —
+  each writes the v4 fingerprint and a generation timestamp so GnuPG recognizes
+  the key; sign (SHA-256 or SHA-1); decrypt; authenticate (a client/SSH
+  signature with the Authentication key via INTERNAL AUTHENTICATE); set
+  cardholder name / URL; change the user / admin PIN and unblock a locked PIN;
+  factory-reset the applet.
 - **PIV (SP 800-73-4)** — full management: status (applet/firmware version,
   serial, PIN retries, which slots 9A/9C/9D/9E hold a certificate), on-card key
   generation, certificate import / export, self-signed certs or a CSR for a CA,

--- a/crates/keyroost-openpgp/src/lib.rs
+++ b/crates/keyroost-openpgp/src/lib.rs
@@ -209,6 +209,10 @@ pub const TAG_FINGERPRINTS: u16 = 0x00C5;
 pub const TAG_CA_FINGERPRINTS: u16 = 0x00C6;
 /// Key generation timestamps.
 pub const TAG_GENERATION_TIMES: u16 = 0x00CD;
+/// Algorithm Information (`FA`, spec v3.4 §4.4.3.11): the algorithm-attribute
+/// values each slot *accepts*, as repeated `C1`/`C2`/`C3` objects. Optional —
+/// cards before 3.4 don't have it.
+pub const TAG_ALGORITHM_INFORMATION: u16 = 0x00FA;
 
 /// Fingerprint — signature key (`C7`, 20 bytes); a standalone PUT DATA target.
 pub const TAG_FPR_SIGN: u16 = 0x00C7;
@@ -267,6 +271,12 @@ pub fn get_data(tag: u16) -> Vec<u8> {
 #[must_use]
 pub fn get_application_related_data() -> Vec<u8> {
     get_data(TAG_APPLICATION_RELATED_DATA)
+}
+
+/// `GET DATA 00FA` — the Algorithm Information object: `00 CA 00 FA 00`.
+#[must_use]
+pub fn get_algorithm_information() -> Vec<u8> {
+    get_data(TAG_ALGORITHM_INFORMATION)
 }
 
 /// `GET DATA 00C4` — the standalone PW status bytes: `00 CA 00 C4 00`.
@@ -1910,6 +1920,69 @@ pub fn parse_application_related_data(buf: &[u8]) -> Result<AppRelatedData, Pars
     })
 }
 
+/// The algorithms a card reports each slot accepts (from `FA`), as raw
+/// attribute values in the card's order. This is the device-driven answer to
+/// "what can I generate here" — no vendor table is consulted anywhere.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct AlgorithmInformation {
+    pub sig: Vec<Vec<u8>>,
+    pub dec: Vec<Vec<u8>>,
+    pub aut: Vec<Vec<u8>>,
+}
+
+impl AlgorithmInformation {
+    /// Raw attribute values the card listed for `crt`'s slot.
+    #[must_use]
+    pub fn raw(&self, crt: KeyCrt) -> &[Vec<u8>] {
+        match crt {
+            KeyCrt::Sign => &self.sig,
+            KeyCrt::Decrypt => &self.dec,
+            KeyCrt::Auth => &self.aut,
+        }
+    }
+
+    /// The modelled [`KeyAlg`]s among them, deduplicated, in card order.
+    /// Entries keyroost can't offer (an unmodelled curve, RSA-1024) are left
+    /// out here but remain visible via [`raw`](Self::raw).
+    #[must_use]
+    pub fn key_algs(&self, crt: KeyCrt) -> Vec<KeyAlg> {
+        let mut out: Vec<KeyAlg> = Vec::new();
+        for attr in self.raw(crt) {
+            if let Some(alg) = parse_algorithm_attributes(attr)
+                .ok()
+                .and_then(|a| a.key_alg())
+            {
+                if !out.contains(&alg) {
+                    out.push(alg);
+                }
+            }
+        }
+        out
+    }
+}
+
+/// Parse the Algorithm Information (`FA`) object. `buf` may be the bare value
+/// or the full `FA` envelope. An object with no `C1`/`C2`/`C3` entries at all is
+/// reported as [`ParseError::MissingTag`] for [`TAG_ALGORITHM_INFORMATION`].
+pub fn parse_algorithm_information(buf: &[u8]) -> Result<AlgorithmInformation, ParseError> {
+    let top = parse_tlvs(buf)?;
+    let inner: &[u8] = find_tag(&top, TAG_ALGORITHM_INFORMATION).unwrap_or(buf);
+    let tlvs = parse_tlvs(inner)?;
+    let mut info = AlgorithmInformation::default();
+    for t in &tlvs {
+        match t.tag {
+            TAG_ALGO_ATTR_SIG => info.sig.push(t.value.to_vec()),
+            TAG_ALGO_ATTR_DEC => info.dec.push(t.value.to_vec()),
+            TAG_ALGO_ATTR_AUT => info.aut.push(t.value.to_vec()),
+            _ => {}
+        }
+    }
+    if info.sig.is_empty() && info.dec.is_empty() && info.aut.is_empty() {
+        return Err(ParseError::MissingTag(TAG_ALGORITHM_INFORMATION));
+    }
+    Ok(info)
+}
+
 /// Parse the digital-signature counter from a Security Support Template (`7A`).
 ///
 /// The counter is a 3-byte big-endian value carried in the `93` object nested
@@ -3206,5 +3279,68 @@ mod manufacturer_tests {
         assert_eq!(&apdu[5..], &attr[..]);
         assert_eq!(KeyCrt::Sign.algo_attr_tag(), TAG_ALGO_ATTR_SIG);
         assert_eq!(KeyCrt::Auth.algo_attr_tag(), TAG_ALGO_ATTR_AUT);
+    }
+
+    #[test]
+    fn algorithm_information_parses_per_slot_lists() {
+        // FA { C1 rsa2048, C1 ed25519, C2 rsa2048, C2 x25519, C2 p256-ecdh, C3 ed25519, C3 rsa1024 }
+        let mut v = Vec::new();
+        let mut add = |tag: u8, val: &[u8]| {
+            v.push(tag);
+            v.push(val.len() as u8);
+            v.extend_from_slice(val);
+        };
+        add(0xC1, &[0x01, 0x08, 0x00, 0x00, 0x20, 0x00]);
+        add(
+            0xC1,
+            &[0x16, 0x2B, 0x06, 0x01, 0x04, 0x01, 0xDA, 0x47, 0x0F, 0x01],
+        );
+        add(0xC2, &[0x01, 0x08, 0x00, 0x00, 0x20, 0x00]);
+        add(
+            0xC2,
+            &[
+                0x12, 0x2B, 0x06, 0x01, 0x04, 0x01, 0x97, 0x55, 0x01, 0x05, 0x01,
+            ],
+        );
+        add(
+            0xC2,
+            &[0x12, 0x2A, 0x86, 0x48, 0xCE, 0x3D, 0x03, 0x01, 0x07],
+        );
+        add(
+            0xC3,
+            &[0x16, 0x2B, 0x06, 0x01, 0x04, 0x01, 0xDA, 0x47, 0x0F, 0x01],
+        );
+        add(0xC3, &[0x01, 0x04, 0x00, 0x00, 0x20, 0x00]); // RSA-1024: reported raw, not a KeyAlg
+        let mut blob = vec![0xFA, v.len() as u8];
+        blob.extend_from_slice(&v);
+
+        let info = parse_algorithm_information(&blob).unwrap();
+        assert_eq!(info.sig.len(), 2);
+        assert_eq!(info.dec.len(), 3);
+        assert_eq!(info.aut.len(), 2);
+        assert_eq!(
+            info.key_algs(KeyCrt::Sign),
+            vec![KeyAlg::Rsa2048, KeyAlg::Ed25519]
+        );
+        assert_eq!(
+            info.key_algs(KeyCrt::Decrypt),
+            vec![KeyAlg::Rsa2048, KeyAlg::X25519, KeyAlg::NistP256]
+        );
+        assert_eq!(info.key_algs(KeyCrt::Auth), vec![KeyAlg::Ed25519]);
+        assert_eq!(
+            info.raw(KeyCrt::Auth)[1],
+            vec![0x01, 0x04, 0x00, 0x00, 0x20, 0x00]
+        );
+        // Bare value (no FA envelope) parses the same.
+        assert_eq!(parse_algorithm_information(&v).unwrap(), info);
+        // Nothing usable: error.
+        assert_eq!(
+            parse_algorithm_information(&[0x99, 0x01, 0x00]),
+            Err(ParseError::MissingTag(TAG_ALGORITHM_INFORMATION))
+        );
+        assert_eq!(
+            get_algorithm_information(),
+            vec![0x00, 0xCA, 0x00, 0xFA, 0x00]
+        );
     }
 }

--- a/crates/keyroost-openpgp/src/lib.rs
+++ b/crates/keyroost-openpgp/src/lib.rs
@@ -1166,6 +1166,104 @@ pub fn parse_rsa_algorithm_attributes(attr: &[u8]) -> Result<RsaAttributes, Pars
     })
 }
 
+/// A slot's algorithm attributes (`C1`/`C2`/`C3`), decoded.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AlgorithmAttributes {
+    /// `01 | n_bits | e_bits | [format]`.
+    Rsa(RsaAttributes),
+    /// `<12|13|16> | <curve OID body> | [FF]`. The optional trailing `FF` means
+    /// the card wants ECC private-key imports to carry the public point too
+    /// (spec §4.4.3.10) — recorded, not acted on: ECC import is not in this
+    /// crate.
+    Ecc {
+        kind: EccKind,
+        curve: Curve,
+        import_with_public_key: bool,
+    },
+}
+
+impl AlgorithmAttributes {
+    /// The [`KeyAlg`] this is, if it's one keyroost offers (RSA 2048/3072/4096
+    /// or a modelled curve); `None` for e.g. RSA-1024.
+    #[must_use]
+    pub fn key_alg(&self) -> Option<KeyAlg> {
+        match *self {
+            AlgorithmAttributes::Rsa(r) => match r.n_bits {
+                2048 => Some(KeyAlg::Rsa2048),
+                3072 => Some(KeyAlg::Rsa3072),
+                4096 => Some(KeyAlg::Rsa4096),
+                _ => None,
+            },
+            AlgorithmAttributes::Ecc { curve, .. } => {
+                KeyAlg::ALL.into_iter().find(|a| a.curve() == Some(curve))
+            }
+        }
+    }
+
+    /// Display form: `RSA-2048`, `EdDSA Ed25519`, `ECDH X25519`, `ECDSA NIST P-256`.
+    #[must_use]
+    pub fn label(&self) -> String {
+        match self {
+            AlgorithmAttributes::Rsa(r) => format!("RSA-{}", r.n_bits),
+            AlgorithmAttributes::Ecc { kind, curve, .. } => {
+                format!("{} {}", kind.label(), curve.label())
+            }
+        }
+    }
+}
+
+/// Parse a slot's algorithm attributes of any algorithm this crate models.
+///
+/// Errors: [`ParseError::UnexpectedLength`] for an empty object or a short RSA
+/// one; [`ParseError::UnsupportedAlgorithm`] for an unknown algorithm id or an
+/// ECC OID that isn't a modelled [`Curve`]. Use
+/// [`describe_algorithm_attributes`] where a failure must still render.
+pub fn parse_algorithm_attributes(attr: &[u8]) -> Result<AlgorithmAttributes, ParseError> {
+    let Some(&id) = attr.first() else {
+        return Err(ParseError::UnexpectedLength);
+    };
+    if id == 0x01 {
+        return parse_rsa_algorithm_attributes(attr).map(AlgorithmAttributes::Rsa);
+    }
+    let kind = EccKind::from_id(id).ok_or(ParseError::UnsupportedAlgorithm)?;
+    let mut oid = &attr[1..];
+    let mut import_with_public_key = false;
+    // The optional import-format byte is only FF; a curve OID never ends in FF
+    // (OID last arcs are < 0x80), so stripping it is unambiguous.
+    if let Some((&0xFF, rest)) = oid.split_last() {
+        oid = rest;
+        import_with_public_key = true;
+    }
+    let curve = Curve::from_oid(oid).ok_or(ParseError::UnsupportedAlgorithm)?;
+    Ok(AlgorithmAttributes::Ecc {
+        kind,
+        curve,
+        import_with_public_key,
+    })
+}
+
+/// Best-effort display of raw algorithm attributes for status lines: the
+/// [`AlgorithmAttributes::label`] when they parse, otherwise an honest
+/// "unknown" rendering (`ECDSA (unknown curve <hex>)`, `algorithm 0x2A`), and
+/// `none` for an empty object.
+#[must_use]
+pub fn describe_algorithm_attributes(attr: &[u8]) -> String {
+    if let Ok(a) = parse_algorithm_attributes(attr) {
+        return a.label();
+    }
+    match attr.first() {
+        None => "none".to_string(),
+        Some(&id) => match EccKind::from_id(id) {
+            Some(kind) => {
+                let hex: String = attr[1..].iter().map(|b| format!("{b:02x}")).collect();
+                format!("{} (unknown curve {})", kind.label(), hex)
+            }
+            None if id == 0x01 => "RSA (malformed attributes)".to_string(),
+            None => format!("algorithm 0x{id:02X}"),
+        },
+    }
+}
+
 /// Encode `n` as a minimal big-endian byte sequence (no leading zeros).
 ///
 /// `0` encodes as a single `0x00` byte. Used to build BER length octets.
@@ -2595,6 +2693,95 @@ mod tests {
             parse_rsa_algorithm_attributes(&[0x16, 0x2B]),
             Err(ParseError::UnsupportedAlgorithm)
         );
+    }
+
+    #[test]
+    fn algorithm_attributes_parse_ecc_and_rsa() {
+        // The in-tree ARD fixture's C2 (ECDH cv25519) and C3 (EdDSA Ed25519).
+        let c2 = [
+            0x12, 0x2B, 0x06, 0x01, 0x04, 0x01, 0x97, 0x55, 0x01, 0x05, 0x01,
+        ];
+        assert_eq!(
+            parse_algorithm_attributes(&c2).unwrap(),
+            AlgorithmAttributes::Ecc {
+                kind: EccKind::Ecdh,
+                curve: Curve::X25519,
+                import_with_public_key: false
+            }
+        );
+        let c3 = [0x16, 0x2B, 0x06, 0x01, 0x04, 0x01, 0xDA, 0x47, 0x0F, 0x01];
+        assert_eq!(
+            parse_algorithm_attributes(&c3).unwrap(),
+            AlgorithmAttributes::Ecc {
+                kind: EccKind::EdDsa,
+                curve: Curve::Ed25519,
+                import_with_public_key: false
+            }
+        );
+        // Optional trailing import-format byte FF ("import with public key").
+        let c1 = [0x13, 0x2A, 0x86, 0x48, 0xCE, 0x3D, 0x03, 0x01, 0x07, 0xFF];
+        assert_eq!(
+            parse_algorithm_attributes(&c1).unwrap(),
+            AlgorithmAttributes::Ecc {
+                kind: EccKind::Ecdsa,
+                curve: Curve::NistP256,
+                import_with_public_key: true
+            }
+        );
+        // RSA still goes through the RSA parser.
+        let rsa = [0x01, 0x08, 0x00, 0x00, 0x20, 0x02];
+        assert_eq!(
+            parse_algorithm_attributes(&rsa).unwrap(),
+            AlgorithmAttributes::Rsa(RsaAttributes {
+                n_bits: 2048,
+                e_bits: 32,
+                format: RsaImportFormat::Crt
+            })
+        );
+        // Unknown curve, unknown id, empty: errors, never panics.
+        assert_eq!(
+            parse_algorithm_attributes(&[0x16, 0x2B, 0x65, 0x70]),
+            Err(ParseError::UnsupportedAlgorithm)
+        );
+        assert_eq!(
+            parse_algorithm_attributes(&[0x2A, 0x00]),
+            Err(ParseError::UnsupportedAlgorithm)
+        );
+        assert_eq!(
+            parse_algorithm_attributes(&[]),
+            Err(ParseError::UnexpectedLength)
+        );
+        assert_eq!(
+            parse_algorithm_attributes(&[0x16]),
+            Err(ParseError::UnsupportedAlgorithm)
+        );
+    }
+
+    #[test]
+    fn algorithm_attributes_key_alg_and_labels() {
+        let a = parse_algorithm_attributes(&[0x12, 0x2B, 0x81, 0x04, 0x00, 0x22]).unwrap();
+        assert_eq!(a.key_alg(), Some(KeyAlg::NistP384));
+        assert_eq!(a.label(), "ECDH NIST P-384");
+        let r = parse_algorithm_attributes(&[0x01, 0x10, 0x00, 0x00, 0x20, 0x00]).unwrap();
+        assert_eq!(r.key_alg(), Some(KeyAlg::Rsa4096));
+        assert_eq!(r.label(), "RSA-4096");
+        // An RSA size we don't offer still labels honestly, just isn't a KeyAlg.
+        let odd = parse_algorithm_attributes(&[0x01, 0x04, 0x00, 0x00, 0x20, 0x00]).unwrap();
+        assert_eq!(odd.key_alg(), None);
+        assert_eq!(odd.label(), "RSA-1024");
+        // describe() never fails: the status line must render any card.
+        assert_eq!(
+            describe_algorithm_attributes(&[
+                0x16, 0x2B, 0x06, 0x01, 0x04, 0x01, 0xDA, 0x47, 0x0F, 0x01
+            ]),
+            "EdDSA Ed25519"
+        );
+        assert_eq!(
+            describe_algorithm_attributes(&[0x13, 0x2B, 0x65, 0x70]),
+            "ECDSA (unknown curve 2b6570)"
+        );
+        assert_eq!(describe_algorithm_attributes(&[0x2A]), "algorithm 0x2A");
+        assert_eq!(describe_algorithm_attributes(&[]), "none");
     }
 
     #[test]

--- a/crates/keyroost-openpgp/src/lib.rs
+++ b/crates/keyroost-openpgp/src/lib.rs
@@ -689,9 +689,10 @@ pub fn put_fingerprint(crt: KeyCrt, fpr: &[u8; 20]) -> Vec<u8> {
 /// `PUT DATA CE`/`CF`/`D0` — write the 4-byte big-endian Unix generation
 /// timestamp of the key in `crt`'s slot (see [`KeyCrt::time_tag`]).
 ///
-/// This timestamp *must* match the `creation_time` fed to
-/// [`rsa_v4_fingerprint`]: the v4 fingerprint hashes the creation time, so a
-/// mismatch yields a fingerprint the card and `gpg` disagree on.
+/// This timestamp *must* match the `creation_time` fed to [`v4_fingerprint`]
+/// (RSA: [`rsa_v4_fingerprint`]; ECC: [`ecc_v4_fingerprint`]): the v4
+/// fingerprint hashes the creation time, so a mismatch yields a fingerprint
+/// the card and `gpg` disagree on.
 #[must_use]
 pub fn put_generation_time(crt: KeyCrt, unix_time: u32) -> Vec<u8> {
     put_data(crt.time_tag(), &unix_time.to_be_bytes())
@@ -1333,15 +1334,25 @@ pub fn parse_algorithm_attributes(attr: &[u8]) -> Result<AlgorithmAttributes, Pa
         return parse_rsa_algorithm_attributes(attr).map(AlgorithmAttributes::Rsa);
     }
     let kind = EccKind::from_id(id).ok_or(ParseError::UnsupportedAlgorithm)?;
-    let mut oid = &attr[1..];
-    let mut import_with_public_key = false;
-    // The optional import-format byte is only FF; a curve OID never ends in FF
-    // (OID last arcs are < 0x80), so stripping it is unambiguous.
-    if let Some((&0xFF, rest)) = oid.split_last() {
-        oid = rest;
-        import_with_public_key = true;
-    }
-    let curve = Curve::from_oid(oid).ok_or(ParseError::UnsupportedAlgorithm)?;
+    let oid = &attr[1..];
+    // The optional trailing import-format byte is `00` or `FF` (spec
+    // §4.4.3.10); GnuPG (scd/app-openpgp.c) strips either, and its YubiKey
+    // branch additionally tolerates a bogus trailing byte on 5.2 firmware by
+    // retrying with the last byte dropped. Mirror that: try the OID as-is
+    // first, and only if that fails, retry with the last byte dropped —
+    // remembering "with public key" only when the dropped byte was actually
+    // `FF`. No modelled OID ends in `00` or `FF` (OID last arcs are < 0x80),
+    // so neither strip is ambiguous.
+    let (curve, import_with_public_key) = match Curve::from_oid(oid) {
+        Some(curve) => (curve, false),
+        None => {
+            let Some((&last, rest)) = oid.split_last() else {
+                return Err(ParseError::UnsupportedAlgorithm);
+            };
+            let curve = Curve::from_oid(rest).ok_or(ParseError::UnsupportedAlgorithm)?;
+            (curve, last == 0xFF)
+        }
+    };
     Ok(AlgorithmAttributes::Ecc {
         kind,
         curve,
@@ -3043,7 +3054,33 @@ mod tests {
                 format: RsaImportFormat::Crt
             })
         );
-        // Unknown curve, unknown id, empty: errors, never panics.
+        // Optional trailing import-format byte 00 ("import without public key",
+        // the standard PKCS#8-ish form) parses the same as no trailing byte.
+        let c1_00 = [0x13, 0x2A, 0x86, 0x48, 0xCE, 0x3D, 0x03, 0x01, 0x07, 0x00];
+        assert_eq!(
+            parse_algorithm_attributes(&c1_00).unwrap(),
+            AlgorithmAttributes::Ecc {
+                kind: EccKind::Ecdsa,
+                curve: Curve::NistP256,
+                import_with_public_key: false
+            }
+        );
+        // A bogus trailing byte (neither 00 nor FF, as seen on some YubiKey
+        // 5.2 firmware) is still tolerated by dropping it, per GnuPG.
+        let c3_bogus = [
+            0x16, 0x2B, 0x06, 0x01, 0x04, 0x01, 0xDA, 0x47, 0x0F, 0x01, 0x2A,
+        ];
+        assert_eq!(
+            parse_algorithm_attributes(&c3_bogus).unwrap(),
+            AlgorithmAttributes::Ecc {
+                kind: EccKind::EdDsa,
+                curve: Curve::Ed25519,
+                import_with_public_key: false
+            }
+        );
+        // Unknown curve, unknown id, empty: errors, never panics. Ed448
+        // (2B 65 70) stays unsupported even after the trailing-byte retry:
+        // dropping 70 leaves 2B 65, which is also not a modelled OID.
         assert_eq!(
             parse_algorithm_attributes(&[0x16, 0x2B, 0x65, 0x70]),
             Err(ParseError::UnsupportedAlgorithm)

--- a/crates/keyroost-openpgp/src/lib.rs
+++ b/crates/keyroost-openpgp/src/lib.rs
@@ -678,8 +678,9 @@ pub fn put_url(url: &[u8]) -> Vec<u8> {
 ///
 /// After an on-card GENERATE the applet knows the key material but not the
 /// OpenPGP v4 fingerprint (which folds in the host-chosen creation timestamp);
-/// the host computes it with [`rsa_v4_fingerprint`] and registers it here so
-/// that `gpg` and the card agree on the key's identity.
+/// the host computes it with [`v4_fingerprint`] (RSA: [`rsa_v4_fingerprint`];
+/// ECC: [`ecc_v4_fingerprint`]) and registers it here so that `gpg` and the
+/// card agree on the key's identity.
 #[must_use]
 pub fn put_fingerprint(crt: KeyCrt, fpr: &[u8; 20]) -> Vec<u8> {
     put_data(crt.fpr_tag(), fpr)
@@ -749,21 +750,98 @@ pub fn rsa_v4_fingerprint(modulus: &[u8], exponent: &[u8], creation_time: u32) -
     body.extend_from_slice(&m);
     body.extend_from_slice(&e);
 
+    v4_fingerprint_envelope(&body)
+}
+
+/// Wrap a v4 public-key packet `body` in the old-format CTB envelope and
+/// hash it: `SHA1(0x99 || len16 || body)`. Shared by [`rsa_v4_fingerprint`]
+/// and [`ecc_v4_fingerprint`].
+fn v4_fingerprint_envelope(body: &[u8]) -> [u8; 20] {
     let len = body.len() as u16;
     let mut hashed = Vec::with_capacity(3 + body.len());
     hashed.push(0x99); // old-format CTB: public-key packet, two-octet length
     hashed.push((len >> 8) as u8);
     hashed.push((len & 0xFF) as u8);
-    hashed.extend_from_slice(&body);
+    hashed.extend_from_slice(body);
 
     keyroost_proto::sha1::sha1(&hashed)
 }
 
-/// Convenience wrapper around [`rsa_v4_fingerprint`] taking a parsed
-/// [`PublicKey`] (e.g. straight from [`parse_generated_public_key`]).
+/// RFC 6637 §9 KDF parameters an ECDH key's public-key packet carries:
+/// `03 01 <hash id> <cipher id>`, chosen by curve size exactly as GnuPG's
+/// `ecdh_params()` does (SHA-256/AES-128 up to 256 bits, SHA-384/AES-192 up
+/// to 384, SHA-512/AES-256 above). The card does not store these, yet the v4
+/// fingerprint hashes them — so keyroost must pick what gpg will pick, or the
+/// two disagree on the key's identity.
 #[must_use]
-pub fn rsa_v4_fingerprint_from(key: &PublicKey, creation_time: u32) -> [u8; 20] {
-    rsa_v4_fingerprint(&key.modulus, &key.exponent, creation_time)
+pub const fn ecdh_kdf_params(curve: Curve) -> [u8; 4] {
+    let bits = curve.bits();
+    if bits <= 256 {
+        [0x03, 0x01, 0x08, 0x07]
+    } else if bits <= 384 {
+        [0x03, 0x01, 0x09, 0x08]
+    } else {
+        [0x03, 0x01, 0x0A, 0x09]
+    }
+}
+
+/// Compute the OpenPGP **v4 fingerprint** of an ECC public key.
+///
+/// Body: `04` || creation time || algorithm id ([`EccKind::id`]) || OID length
+/// || curve OID || MPI(point) || (ECDH only) [`ecdh_kdf_params`]. For the
+/// 25519 curves the MPI is over `0x40 || point` (RFC 7748 form as OpenPGP
+/// carries it); a `point` that already starts with `0x40` and is 33 bytes is
+/// used as-is. The envelope (`SHA1(0x99 || len16 || body)`) is shared with
+/// [`rsa_v4_fingerprint`].
+#[must_use]
+pub fn ecc_v4_fingerprint(
+    kind: EccKind,
+    curve: Curve,
+    point: &[u8],
+    creation_time: u32,
+) -> [u8; 20] {
+    let packet_point: Vec<u8> = if curve.is_25519() && point.len() == 32 {
+        let mut p = Vec::with_capacity(33);
+        p.push(0x40);
+        p.extend_from_slice(point);
+        p
+    } else {
+        point.to_vec()
+    };
+    let oid = curve.oid();
+    let p = mpi(&packet_point);
+    let mut body = Vec::with_capacity(1 + 4 + 1 + 1 + oid.len() + p.len() + 4);
+    body.push(0x04);
+    body.extend_from_slice(&creation_time.to_be_bytes());
+    body.push(kind.id());
+    body.push(oid.len() as u8);
+    body.extend_from_slice(oid);
+    body.extend_from_slice(&p);
+    if kind == EccKind::Ecdh {
+        body.extend_from_slice(&ecdh_kdf_params(curve));
+    }
+    v4_fingerprint_envelope(&body)
+}
+
+/// Fingerprint of `key` under the slot's `attrs`: RSA via
+/// [`rsa_v4_fingerprint`], ECC via [`ecc_v4_fingerprint`]. A key whose shape
+/// doesn't match the attributes (an RSA key with ECC attributes or vice
+/// versa) is [`ParseError::UnsupportedAlgorithm`] — a wrong fingerprint must
+/// never be written to the card.
+pub fn v4_fingerprint(
+    key: &PublicKey,
+    attrs: &AlgorithmAttributes,
+    creation_time: u32,
+) -> Result<[u8; 20], ParseError> {
+    match (key, attrs) {
+        (PublicKey::Rsa { modulus, exponent }, AlgorithmAttributes::Rsa(_)) => {
+            Ok(rsa_v4_fingerprint(modulus, exponent, creation_time))
+        }
+        (PublicKey::Ecc { point }, AlgorithmAttributes::Ecc { kind, curve, .. }) => {
+            Ok(ecc_v4_fingerprint(*kind, *curve, point, creation_time))
+        }
+        _ => Err(ParseError::UnsupportedAlgorithm),
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -2017,36 +2095,36 @@ pub fn parse_signature_counter(buf: &[u8]) -> Result<u32, ParseError> {
     Ok((u32::from(v[0]) << 16) | (u32::from(v[1]) << 8) | u32::from(v[2]))
 }
 
-/// The RSA public key parsed from a GENERATE / READ PUBLIC KEY response.
-///
-/// The card returns a `7F49` constructed object; for an RSA key it carries the
-/// modulus *n* (tag `81`) and the public exponent *e* (tag `82`). Both are kept
-/// as raw big-endian bytes (a 2048-bit modulus is 256 bytes — note the card may
-/// or may not include a leading zero byte; we surface the value verbatim).
+/// The public key parsed from a GENERATE / READ PUBLIC KEY response (`7F49`).
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct PublicKey {
-    /// RSA modulus *n* (`81`), big-endian.
-    pub modulus: Vec<u8>,
-    /// RSA public exponent *e* (`82`), big-endian (commonly `01 00 01`).
-    pub exponent: Vec<u8>,
+pub enum PublicKey {
+    /// RSA: modulus *n* (`81`) and public exponent *e* (`82`), big-endian
+    /// (the card may or may not include a leading zero byte; surfaced verbatim).
+    Rsa { modulus: Vec<u8>, exponent: Vec<u8> },
+    /// ECC: the public point (`86`) — uncompressed `04 || X || Y` for the
+    /// Weierstrass curves, the raw 32-byte point for Ed25519 / X25519.
+    Ecc { point: Vec<u8> },
 }
 
 /// Parse the public key from a GENERATE / READ PUBLIC KEY response.
 ///
 /// `buf` may be either the raw value of the `7F49` object *or* the full `7F49`
-/// envelope; both are accepted. Only the **RSA** case is decoded: the `81`
-/// modulus and `82` exponent are pulled out (a 2048-bit modulus forces a
-/// long-form `82` length, which [`parse_tlvs`] handles).
-///
-/// An ECC key carries an `86` public point instead of `81`/`82`; that case is
-/// reported as [`ParseError::MissingTag`] for [`TAG_RSA_MODULUS`] — callers that
-/// expect ECC should read the raw `86` value via [`parse_tlvs`]/[`find_nested`]
-/// against [`TAG_EC_PUBLIC_POINT`].
+/// envelope; both are accepted. An ECC key carries an `86` public point, which
+/// takes priority if present; otherwise the `81` modulus and `82` exponent of
+/// an RSA key are pulled out (a 2048-bit modulus forces a long-form `82`
+/// length, which [`parse_tlvs`] handles). Neither shape present is
+/// [`ParseError::MissingTag`] for [`TAG_RSA_MODULUS`].
 pub fn parse_generated_public_key(buf: &[u8]) -> Result<PublicKey, ParseError> {
     let top = parse_tlvs(buf)?;
     // Accept either the bare value or the wrapping 7F49 envelope.
     let inner: &[u8] = find_tag(&top, TAG_PUBLIC_KEY).unwrap_or(buf);
     let tlvs = parse_tlvs(inner)?;
+
+    if let Some(point) = find_nested(&tlvs, TAG_EC_PUBLIC_POINT) {
+        return Ok(PublicKey::Ecc {
+            point: point.to_vec(),
+        });
+    }
 
     let modulus = find_nested(&tlvs, TAG_RSA_MODULUS)
         .ok_or(ParseError::MissingTag(TAG_RSA_MODULUS))?
@@ -2055,7 +2133,7 @@ pub fn parse_generated_public_key(buf: &[u8]) -> Result<PublicKey, ParseError> {
         .ok_or(ParseError::MissingTag(TAG_RSA_EXPONENT))?
         .to_vec();
 
-    Ok(PublicKey { modulus, exponent })
+    Ok(PublicKey::Rsa { modulus, exponent })
 }
 
 #[cfg(test)]
@@ -2587,17 +2665,33 @@ mod tests {
         blob.extend_from_slice(&inner);
 
         let pk = parse_generated_public_key(&blob).expect("RSA public key parses");
-        assert_eq!(pk.modulus, modulus);
-        assert_eq!(pk.exponent, exponent.to_vec());
+        match pk {
+            PublicKey::Rsa {
+                modulus: m,
+                exponent: e,
+            } => {
+                assert_eq!(m, modulus);
+                assert_eq!(e, exponent.to_vec());
+            }
+            PublicKey::Ecc { .. } => panic!("expected RSA key"),
+        }
 
         // Bare value (without the 7F49 envelope) also works.
         let pk2 = parse_generated_public_key(&inner).expect("bare value parses");
-        assert_eq!(pk2.modulus, modulus);
-        assert_eq!(pk2.exponent, exponent.to_vec());
+        match pk2 {
+            PublicKey::Rsa {
+                modulus: m,
+                exponent: e,
+            } => {
+                assert_eq!(m, modulus);
+                assert_eq!(e, exponent.to_vec());
+            }
+            PublicKey::Ecc { .. } => panic!("expected RSA key"),
+        }
     }
 
     #[test]
-    fn parse_generated_public_key_ecc_reports_missing_modulus() {
+    fn parse_generated_public_key_ecc_point() {
         // An ECC key carries 86 (public point) instead of 81/82.
         let mut inner = Vec::new();
         inner.push(0x86);
@@ -2610,6 +2704,13 @@ mod tests {
         blob.extend_from_slice(&inner);
         assert_eq!(
             parse_generated_public_key(&blob),
+            Ok(PublicKey::Ecc {
+                point: vec![0x04; 32]
+            })
+        );
+        // A 7F49 with neither an RSA modulus nor an EC point is still an error.
+        assert_eq!(
+            parse_generated_public_key(&[0x7F, 0x49, 0x02, 0x99, 0x00]),
             Err(ParseError::MissingTag(TAG_RSA_MODULUS))
         );
     }
@@ -2727,12 +2828,104 @@ mod tests {
             ]
         );
 
-        // The PublicKey convenience wrapper agrees.
-        let key = PublicKey {
+        // The generic wrapper agrees when the attributes say RSA.
+        let key = PublicKey::Rsa {
             modulus: modulus.to_vec(),
             exponent: exponent.to_vec(),
         };
-        assert_eq!(rsa_v4_fingerprint_from(&key, 0x5D2C_0B00), fpr);
+        let attrs = AlgorithmAttributes::Rsa(RsaAttributes {
+            n_bits: 64,
+            e_bits: 17,
+            format: RsaImportFormat::Standard,
+        });
+        assert_eq!(v4_fingerprint(&key, &attrs, 0x5D2C_0B00), Ok(fpr));
+        // Key/attribute shape mismatch is an error, never a wrong fingerprint.
+        let ecc_attrs = AlgorithmAttributes::Ecc {
+            kind: EccKind::EdDsa,
+            curve: Curve::Ed25519,
+            import_with_public_key: false,
+        };
+        assert_eq!(
+            v4_fingerprint(&key, &ecc_attrs, 0),
+            Err(ParseError::UnsupportedAlgorithm)
+        );
+    }
+
+    #[test]
+    fn mpi_of_25519_point_has_263_bits() {
+        // 0x40 || 32 bytes: top byte 0x40 has 7 significant bits -> 7 + 256.
+        let mut p = vec![0x40];
+        p.extend_from_slice(&[0x42; 32]);
+        let m = mpi(&p);
+        assert_eq!(&m[..2], &[0x01, 0x07]);
+        assert_eq!(&m[2..], &p[..]);
+    }
+
+    #[test]
+    fn ecdh_kdf_params_follow_gnupg() {
+        assert_eq!(ecdh_kdf_params(Curve::X25519), [0x03, 0x01, 0x08, 0x07]);
+        assert_eq!(ecdh_kdf_params(Curve::NistP256), [0x03, 0x01, 0x08, 0x07]);
+        assert_eq!(ecdh_kdf_params(Curve::NistP384), [0x03, 0x01, 0x09, 0x08]);
+        assert_eq!(
+            ecdh_kdf_params(Curve::BrainpoolP512r1),
+            [0x03, 0x01, 0x0A, 0x09]
+        );
+        assert_eq!(ecdh_kdf_params(Curve::NistP521), [0x03, 0x01, 0x0A, 0x09]);
+    }
+
+    #[test]
+    fn ecc_v4_fingerprint_known_answers() {
+        // Vectors computed independently (SHA-1 over the RFC 4880 §12.2 packet
+        // with the RFC 6637 §9 field layout) — not derived from this code.
+        let t = 0x5D2C_0B00;
+        let p25519 = [0x42u8; 32]; // raw card form; packet form is 40||point
+        assert_eq!(
+            ecc_v4_fingerprint(EccKind::EdDsa, Curve::Ed25519, &p25519, t),
+            hex20("221e61835aa5b9db5f50718f35bf850566eec58a")
+        );
+        assert_eq!(
+            ecc_v4_fingerprint(EccKind::Ecdh, Curve::X25519, &p25519, t),
+            hex20("31645415dcaad2114d282ef24c8eded03d76cab6")
+        );
+        // A card that already prefixes 0x40 yields the same fingerprint.
+        let mut prefixed = vec![0x40];
+        prefixed.extend_from_slice(&p25519);
+        assert_eq!(
+            ecc_v4_fingerprint(EccKind::EdDsa, Curve::Ed25519, &prefixed, t),
+            hex20("221e61835aa5b9db5f50718f35bf850566eec58a")
+        );
+        let mut p256 = vec![0x04];
+        p256.extend_from_slice(&[0x11; 32]);
+        p256.extend_from_slice(&[0x22; 32]);
+        assert_eq!(
+            ecc_v4_fingerprint(EccKind::Ecdsa, Curve::NistP256, &p256, t),
+            hex20("01059cf3677f627f7b04600559ba4ab49e9e94ba")
+        );
+        assert_eq!(
+            ecc_v4_fingerprint(EccKind::Ecdh, Curve::NistP256, &p256, t),
+            hex20("d8d15006bb31e1366679a954494a35bea0a3541e")
+        );
+        // The generic wrapper routes by attributes.
+        let key = PublicKey::Ecc {
+            point: p25519.to_vec(),
+        };
+        let attrs = AlgorithmAttributes::Ecc {
+            kind: EccKind::Ecdh,
+            curve: Curve::X25519,
+            import_with_public_key: false,
+        };
+        assert_eq!(
+            v4_fingerprint(&key, &attrs, t),
+            Ok(hex20("31645415dcaad2114d282ef24c8eded03d76cab6"))
+        );
+    }
+
+    fn hex20(s: &str) -> [u8; 20] {
+        let mut out = [0u8; 20];
+        for (i, b) in out.iter_mut().enumerate() {
+            *b = u8::from_str_radix(&s[2 * i..2 * i + 2], 16).unwrap();
+        }
+        out
     }
 
     // --- Key import: BER helpers -----------------------------------------

--- a/crates/keyroost-openpgp/src/lib.rs
+++ b/crates/keyroost-openpgp/src/lib.rs
@@ -379,6 +379,18 @@ impl KeyCrt {
             KeyCrt::Auth => TAG_TIME_AUTH,
         }
     }
+
+    /// The data-object tag of this slot's algorithm attributes (`C1`/`C2`/`C3`),
+    /// the target for a [`put_algorithm_attributes`] PUT DATA (and the tag
+    /// under which the card reports them inside `6E`/`73`).
+    #[must_use]
+    pub const fn algo_attr_tag(self) -> u16 {
+        match self {
+            KeyCrt::Sign => TAG_ALGO_ATTR_SIG,
+            KeyCrt::Decrypt => TAG_ALGO_ATTR_DEC,
+            KeyCrt::Auth => TAG_ALGO_ATTR_AUT,
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -723,6 +735,316 @@ pub fn rsa_v4_fingerprint(modulus: &[u8], exponent: &[u8], creation_time: u32) -
 #[must_use]
 pub fn rsa_v4_fingerprint_from(key: &PublicKey, creation_time: u32) -> [u8; 20] {
     rsa_v4_fingerprint(&key.modulus, &key.exponent, creation_time)
+}
+
+// ---------------------------------------------------------------------------
+// Key algorithms (algorithm attributes, OpenPGP Card spec v3.4 §4.4.3.9-11)
+// ---------------------------------------------------------------------------
+
+/// An elliptic curve an OpenPGP card can hold a key on, identified on the wire
+/// by its bare OID body (no DER `06 len` header) inside the slot's algorithm
+/// attributes. The 25519 pair is split by *use* — Ed25519 signs, X25519 agrees
+/// keys — so each is its own curve here, as in the OID registry.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Curve {
+    Ed25519,
+    X25519,
+    NistP256,
+    NistP384,
+    NistP521,
+    Secp256k1,
+    BrainpoolP256r1,
+    BrainpoolP384r1,
+    BrainpoolP512r1,
+}
+
+impl Curve {
+    /// Every curve this crate models, in display order.
+    pub const ALL: [Curve; 9] = [
+        Curve::Ed25519,
+        Curve::X25519,
+        Curve::NistP256,
+        Curve::NistP384,
+        Curve::NistP521,
+        Curve::Secp256k1,
+        Curve::BrainpoolP256r1,
+        Curve::BrainpoolP384r1,
+        Curve::BrainpoolP512r1,
+    ];
+
+    /// The curve's OID body as the card stores it after the algorithm id.
+    #[must_use]
+    pub const fn oid(self) -> &'static [u8] {
+        match self {
+            // 1.3.6.1.4.1.11591.15.1
+            Curve::Ed25519 => &[0x2B, 0x06, 0x01, 0x04, 0x01, 0xDA, 0x47, 0x0F, 0x01],
+            // 1.3.6.1.4.1.3029.1.5.1
+            Curve::X25519 => &[0x2B, 0x06, 0x01, 0x04, 0x01, 0x97, 0x55, 0x01, 0x05, 0x01],
+            // 1.2.840.10045.3.1.7
+            Curve::NistP256 => &[0x2A, 0x86, 0x48, 0xCE, 0x3D, 0x03, 0x01, 0x07],
+            // 1.3.132.0.34
+            Curve::NistP384 => &[0x2B, 0x81, 0x04, 0x00, 0x22],
+            // 1.3.132.0.35
+            Curve::NistP521 => &[0x2B, 0x81, 0x04, 0x00, 0x23],
+            // 1.3.132.0.10
+            Curve::Secp256k1 => &[0x2B, 0x81, 0x04, 0x00, 0x0A],
+            // 1.3.36.3.3.2.8.1.1.7 / .11 / .13
+            Curve::BrainpoolP256r1 => &[0x2B, 0x24, 0x03, 0x03, 0x02, 0x08, 0x01, 0x01, 0x07],
+            Curve::BrainpoolP384r1 => &[0x2B, 0x24, 0x03, 0x03, 0x02, 0x08, 0x01, 0x01, 0x0B],
+            Curve::BrainpoolP512r1 => &[0x2B, 0x24, 0x03, 0x03, 0x02, 0x08, 0x01, 0x01, 0x0D],
+        }
+    }
+
+    /// Resolve a bare OID body to a curve.
+    #[must_use]
+    pub fn from_oid(oid: &[u8]) -> Option<Curve> {
+        Curve::ALL.into_iter().find(|c| c.oid() == oid)
+    }
+
+    /// Human label (GnuPG's spelling where it has one).
+    #[must_use]
+    pub const fn label(self) -> &'static str {
+        match self {
+            Curve::Ed25519 => "Ed25519",
+            Curve::X25519 => "X25519",
+            Curve::NistP256 => "NIST P-256",
+            Curve::NistP384 => "NIST P-384",
+            Curve::NistP521 => "NIST P-521",
+            Curve::Secp256k1 => "secp256k1",
+            Curve::BrainpoolP256r1 => "brainpoolP256r1",
+            Curve::BrainpoolP384r1 => "brainpoolP384r1",
+            Curve::BrainpoolP512r1 => "brainpoolP512r1",
+        }
+    }
+
+    /// Field size in bits — selects the RFC 6637 ECDH KDF parameters.
+    #[must_use]
+    pub const fn bits(self) -> u16 {
+        match self {
+            Curve::Ed25519 | Curve::X25519 => 255,
+            Curve::NistP256 | Curve::Secp256k1 | Curve::BrainpoolP256r1 => 256,
+            Curve::NistP384 | Curve::BrainpoolP384r1 => 384,
+            Curve::NistP521 => 521,
+            Curve::BrainpoolP512r1 => 512,
+        }
+    }
+
+    /// Whether the public point is the 32-byte 25519 form (which the OpenPGP
+    /// packet prefixes with `0x40`) rather than an uncompressed `04||X||Y`.
+    #[must_use]
+    pub const fn is_25519(self) -> bool {
+        matches!(self, Curve::Ed25519 | Curve::X25519)
+    }
+}
+
+/// The ECC algorithm id an attributes object starts with — which of the three
+/// ECC operations the slot performs. The values coincide with the OpenPGP
+/// public-key algorithm ids (RFC 4880 §9.1 / RFC 6637 §5), so the same byte
+/// goes into the v4 fingerprint packet.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EccKind {
+    /// `0x12` — ECDH (decryption slot).
+    Ecdh,
+    /// `0x13` — ECDSA (signature / authentication slots, Weierstrass curves).
+    Ecdsa,
+    /// `0x16` — EdDSA (signature / authentication slots, Ed25519).
+    EdDsa,
+}
+
+impl EccKind {
+    #[must_use]
+    pub const fn id(self) -> u8 {
+        match self {
+            EccKind::Ecdh => 0x12,
+            EccKind::Ecdsa => 0x13,
+            EccKind::EdDsa => 0x16,
+        }
+    }
+
+    #[must_use]
+    pub const fn from_id(id: u8) -> Option<EccKind> {
+        match id {
+            0x12 => Some(EccKind::Ecdh),
+            0x13 => Some(EccKind::Ecdsa),
+            0x16 => Some(EccKind::EdDsa),
+            _ => None,
+        }
+    }
+
+    #[must_use]
+    pub const fn label(self) -> &'static str {
+        match self {
+            EccKind::Ecdh => "ECDH",
+            EccKind::Ecdsa => "ECDSA",
+            EccKind::EdDsa => "EdDSA",
+        }
+    }
+}
+
+/// A key algorithm a user can ask a slot to be set to. RSA sizes plus every
+/// [`Curve`]; the ECC *kind* (ECDH vs ECDSA/EdDSA) follows from the slot, see
+/// [`KeyAlg::attributes`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum KeyAlg {
+    Rsa2048,
+    Rsa3072,
+    Rsa4096,
+    Ed25519,
+    X25519,
+    NistP256,
+    NistP384,
+    NistP521,
+    Secp256k1,
+    BrainpoolP256r1,
+    BrainpoolP384r1,
+    BrainpoolP512r1,
+}
+
+/// The requested algorithm cannot live in the requested slot: Ed25519 is a
+/// signing curve (signature / authentication only) and X25519 a key-agreement
+/// curve (decryption only). Reported rather than silently substituted, because
+/// the substitute would be a different key than the one asked for.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SlotMismatch {
+    pub alg: KeyAlg,
+    pub crt: KeyCrt,
+}
+
+impl core::fmt::Display for SlotMismatch {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self.alg {
+            KeyAlg::Ed25519 => write!(
+                f,
+                "Ed25519 is a signing curve and cannot go in the decryption slot; use X25519 there"
+            ),
+            KeyAlg::X25519 => write!(
+                f,
+                "X25519 is a key-agreement curve and only fits the decryption slot; use Ed25519 for signing or authentication"
+            ),
+            _ => write!(f, "{} cannot be used in the {:?} slot", self.alg.label(), self.crt),
+        }
+    }
+}
+
+impl std::error::Error for SlotMismatch {}
+
+impl KeyAlg {
+    /// Every algorithm, in menu order: RSA sizes first, then the curves.
+    pub const ALL: [KeyAlg; 12] = [
+        KeyAlg::Rsa2048,
+        KeyAlg::Rsa3072,
+        KeyAlg::Rsa4096,
+        KeyAlg::Ed25519,
+        KeyAlg::X25519,
+        KeyAlg::NistP256,
+        KeyAlg::NistP384,
+        KeyAlg::NistP521,
+        KeyAlg::Secp256k1,
+        KeyAlg::BrainpoolP256r1,
+        KeyAlg::BrainpoolP384r1,
+        KeyAlg::BrainpoolP512r1,
+    ];
+
+    #[must_use]
+    pub const fn label(self) -> &'static str {
+        match self {
+            KeyAlg::Rsa2048 => "RSA-2048",
+            KeyAlg::Rsa3072 => "RSA-3072",
+            KeyAlg::Rsa4096 => "RSA-4096",
+            KeyAlg::Ed25519 => Curve::Ed25519.label(),
+            KeyAlg::X25519 => Curve::X25519.label(),
+            KeyAlg::NistP256 => Curve::NistP256.label(),
+            KeyAlg::NistP384 => Curve::NistP384.label(),
+            KeyAlg::NistP521 => Curve::NistP521.label(),
+            KeyAlg::Secp256k1 => Curve::Secp256k1.label(),
+            KeyAlg::BrainpoolP256r1 => Curve::BrainpoolP256r1.label(),
+            KeyAlg::BrainpoolP384r1 => Curve::BrainpoolP384r1.label(),
+            KeyAlg::BrainpoolP512r1 => Curve::BrainpoolP512r1.label(),
+        }
+    }
+
+    /// The curve, for the ECC algorithms; `None` for RSA.
+    #[must_use]
+    pub const fn curve(self) -> Option<Curve> {
+        match self {
+            KeyAlg::Rsa2048 | KeyAlg::Rsa3072 | KeyAlg::Rsa4096 => None,
+            KeyAlg::Ed25519 => Some(Curve::Ed25519),
+            KeyAlg::X25519 => Some(Curve::X25519),
+            KeyAlg::NistP256 => Some(Curve::NistP256),
+            KeyAlg::NistP384 => Some(Curve::NistP384),
+            KeyAlg::NistP521 => Some(Curve::NistP521),
+            KeyAlg::Secp256k1 => Some(Curve::Secp256k1),
+            KeyAlg::BrainpoolP256r1 => Some(Curve::BrainpoolP256r1),
+            KeyAlg::BrainpoolP384r1 => Some(Curve::BrainpoolP384r1),
+            KeyAlg::BrainpoolP512r1 => Some(Curve::BrainpoolP512r1),
+        }
+    }
+
+    /// Modulus size, for the RSA algorithms; `None` for the curves.
+    #[must_use]
+    pub const fn rsa_bits(self) -> Option<u16> {
+        match self {
+            KeyAlg::Rsa2048 => Some(2048),
+            KeyAlg::Rsa3072 => Some(3072),
+            KeyAlg::Rsa4096 => Some(4096),
+            _ => None,
+        }
+    }
+
+    /// Which ECC operation this algorithm performs in `crt`'s slot: ECDH in the
+    /// decryption slot, EdDSA for Ed25519 elsewhere, ECDSA for the Weierstrass
+    /// curves elsewhere. Errors for RSA (no ECC kind) are not possible — RSA is
+    /// handled by [`KeyAlg::attributes`] directly; this returns [`SlotMismatch`]
+    /// for the 25519 curve/slot combinations that don't exist.
+    pub fn ecc_kind(self, crt: KeyCrt) -> Result<EccKind, SlotMismatch> {
+        let mismatch = SlotMismatch { alg: self, crt };
+        match (self, crt) {
+            (KeyAlg::Ed25519, KeyCrt::Decrypt) | (KeyAlg::X25519, KeyCrt::Sign | KeyCrt::Auth) => {
+                Err(mismatch)
+            }
+            (KeyAlg::Ed25519, _) => Ok(EccKind::EdDsa),
+            (_, KeyCrt::Decrypt) => Ok(EccKind::Ecdh),
+            (_, _) => Ok(EccKind::Ecdsa),
+        }
+    }
+
+    /// The algorithm-attributes value to PUT DATA into `crt`'s `C1`/`C2`/`C3`
+    /// so the next GENERATE produces this kind of key.
+    ///
+    /// RSA: `01 | n_bits(2) | e_bits = 0x0020 | format = 0x00` — the shape GnuPG
+    /// writes; the card may answer a later read with its own import-format
+    /// byte, which [`parse_algorithm_attributes`] reports faithfully. ECC:
+    /// `<ecc kind id> | <curve OID body>`.
+    pub fn attributes(self, crt: KeyCrt) -> Result<Vec<u8>, SlotMismatch> {
+        if let Some(bits) = self.rsa_bits() {
+            return Ok(vec![
+                0x01,
+                (bits >> 8) as u8,
+                (bits & 0xFF) as u8,
+                0x00,
+                0x20,
+                0x00,
+            ]);
+        }
+        let kind = self.ecc_kind(crt)?;
+        let curve = self.curve().expect("non-RSA KeyAlg has a curve");
+        let mut out = Vec::with_capacity(1 + curve.oid().len());
+        out.push(kind.id());
+        out.extend_from_slice(curve.oid());
+        Ok(out)
+    }
+}
+
+/// `PUT DATA C1`/`C2`/`C3` — write the algorithm attributes of `crt`'s slot
+/// (see [`KeyCrt::algo_attr_tag`]; build `attr` with [`KeyAlg::attributes`]).
+///
+/// Requires PW3. **Changing a slot's algorithm wipes the key in that slot** on
+/// every card that allows the change at all (OpenPGP Card spec v3.4 §4.4.3.9);
+/// the transport only does this immediately before a GENERATE that overwrites
+/// the slot anyway. Cards that don't allow it answer with an error status.
+#[must_use]
+pub fn put_algorithm_attributes(crt: KeyCrt, attr: &[u8]) -> Vec<u8> {
+    put_data(crt.algo_attr_tag(), attr)
 }
 
 // ---------------------------------------------------------------------------
@@ -2612,5 +2934,90 @@ mod manufacturer_tests {
         assert_eq!(manufacturer_name(0x0000), None); // test card
         assert_eq!(manufacturer_name(0xFFFF), None); // test card
         assert_eq!(manufacturer_name(0xFF42), None); // unmanaged S/N range
+    }
+
+    // --- Key algorithms: curves, attribute bytes ------------------------
+
+    #[test]
+    fn curve_oids_round_trip() {
+        for c in Curve::ALL {
+            assert_eq!(Curve::from_oid(c.oid()), Some(c), "{}", c.label());
+        }
+        assert_eq!(Curve::from_oid(&[0x2B, 0x65, 0x70]), None); // Ed448: not modelled
+        assert_eq!(Curve::from_oid(&[]), None);
+    }
+
+    #[test]
+    fn key_alg_attribute_bytes_exact() {
+        // EdDSA (16) + Ed25519 OID in the signature slot.
+        assert_eq!(
+            KeyAlg::Ed25519.attributes(KeyCrt::Sign).unwrap(),
+            vec![0x16, 0x2B, 0x06, 0x01, 0x04, 0x01, 0xDA, 0x47, 0x0F, 0x01]
+        );
+        // ECDH (12) + cv25519 OID in the decryption slot — the exact bytes of
+        // the in-tree ARD fixture's C2.
+        assert_eq!(
+            KeyAlg::X25519.attributes(KeyCrt::Decrypt).unwrap(),
+            vec![0x12, 0x2B, 0x06, 0x01, 0x04, 0x01, 0x97, 0x55, 0x01, 0x05, 0x01]
+        );
+        // NIST curves: ECDSA (13) for sign/auth, ECDH (12) for decrypt.
+        assert_eq!(
+            KeyAlg::NistP256.attributes(KeyCrt::Auth).unwrap(),
+            vec![0x13, 0x2A, 0x86, 0x48, 0xCE, 0x3D, 0x03, 0x01, 0x07]
+        );
+        assert_eq!(
+            KeyAlg::NistP256.attributes(KeyCrt::Decrypt).unwrap(),
+            vec![0x12, 0x2A, 0x86, 0x48, 0xCE, 0x3D, 0x03, 0x01, 0x07]
+        );
+        assert_eq!(
+            KeyAlg::NistP384.attributes(KeyCrt::Sign).unwrap(),
+            vec![0x13, 0x2B, 0x81, 0x04, 0x00, 0x22]
+        );
+        // RSA: 01 | n_bits | e_bits=0020 | format=00 (standard), as GnuPG writes it.
+        assert_eq!(
+            KeyAlg::Rsa3072.attributes(KeyCrt::Sign).unwrap(),
+            vec![0x01, 0x0C, 0x00, 0x00, 0x20, 0x00]
+        );
+        assert_eq!(
+            KeyAlg::Rsa4096.attributes(KeyCrt::Decrypt).unwrap(),
+            vec![0x01, 0x10, 0x00, 0x00, 0x20, 0x00]
+        );
+    }
+
+    #[test]
+    fn key_alg_slot_mismatch_is_an_error_not_a_guess() {
+        // Ed25519 only signs; X25519 only agrees keys. Silently swapping one
+        // for the other would generate a different key than asked for.
+        let e = KeyAlg::Ed25519.attributes(KeyCrt::Decrypt).unwrap_err();
+        assert_eq!(
+            e,
+            SlotMismatch {
+                alg: KeyAlg::Ed25519,
+                crt: KeyCrt::Decrypt
+            }
+        );
+        assert!(e.to_string().contains("X25519"));
+        assert!(KeyAlg::X25519.attributes(KeyCrt::Sign).is_err());
+        assert!(KeyAlg::X25519.attributes(KeyCrt::Auth).is_err());
+        // Every other algorithm fits every slot.
+        for alg in KeyAlg::ALL {
+            if matches!(alg, KeyAlg::Ed25519 | KeyAlg::X25519) {
+                continue;
+            }
+            for crt in [KeyCrt::Sign, KeyCrt::Decrypt, KeyCrt::Auth] {
+                assert!(alg.attributes(crt).is_ok(), "{} in {:?}", alg.label(), crt);
+            }
+        }
+    }
+
+    #[test]
+    fn put_algorithm_attributes_bytes() {
+        // 00 DA 00 C2 <Lc> <attr>
+        let attr = KeyAlg::X25519.attributes(KeyCrt::Decrypt).unwrap();
+        let apdu = put_algorithm_attributes(KeyCrt::Decrypt, &attr);
+        assert_eq!(&apdu[..5], &[0x00, 0xDA, 0x00, 0xC2, 0x0B]);
+        assert_eq!(&apdu[5..], &attr[..]);
+        assert_eq!(KeyCrt::Sign.algo_attr_tag(), TAG_ALGO_ATTR_SIG);
+        assert_eq!(KeyCrt::Auth.algo_attr_tag(), TAG_ALGO_ATTR_AUT);
     }
 }

--- a/crates/keyroost-openpgp/src/lib.rs
+++ b/crates/keyroost-openpgp/src/lib.rs
@@ -570,6 +570,25 @@ pub fn pso_decipher_chained(data: &[u8], max_chunk: usize) -> Vec<Vec<u8>> {
         .collect()
 }
 
+/// Cipher DO tag for ECDH decipher: the `A6` template (spec v3.4 §7.2.11).
+const TAG_CIPHER_DO_ECDH: u16 = 0x00A6;
+
+/// The ECDH cipher Data Object for PSO:DECIPHER — `A6 { 7F49 { 86 <point> } }`,
+/// where `ephemeral_point` is the sender's ephemeral public point (raw, as the
+/// card wants it: `04||X||Y` for Weierstrass curves, the bare 32 bytes for
+/// X25519 — a leading OpenPGP `0x40` prefix must be stripped by the caller).
+/// The card returns the shared secret (the x-coordinate / the 32-byte X25519
+/// output); the RFC 6637 KDF and key unwrap are the OpenPGP tool's job, as
+/// with the RSA path, where the card returns the raw PKCS#1 payload.
+/// Feed the result to [`pso_decipher`] — there is no `0x00` padding-indicator
+/// byte in the ECDH form.
+#[must_use]
+pub fn ecdh_cipher_do(ephemeral_point: &[u8]) -> Vec<u8> {
+    let point = ber_tlv(TAG_EC_PUBLIC_POINT, ephemeral_point);
+    let pk = ber_tlv(TAG_PUBLIC_KEY, &point);
+    ber_tlv(TAG_CIPHER_DO_ECDH, &pk)
+}
+
 /// `CHANGE REFERENCE DATA` (INS `24`) — change a PIN from `old` to `new`.
 ///
 /// `pw_ref` is the password reference in P2: [`PW1_SIGN`] (`0x81`) changes PW1,
@@ -2483,6 +2502,26 @@ mod tests {
         let mut body = chunks[0][5..].to_vec();
         body.extend_from_slice(&chunks[1][5..chunks[1].len() - 1]);
         assert_eq!(body, data);
+    }
+
+    #[test]
+    fn ecdh_cipher_do_exact_bytes() {
+        // A6 25 { 7F49 22 { 86 20 <32-byte point> } }
+        let point = [0x33u8; 32];
+        let d = ecdh_cipher_do(&point);
+        assert_eq!(&d[..2], &[0xA6, 0x25]);
+        assert_eq!(&d[2..5], &[0x7F, 0x49, 0x22]);
+        assert_eq!(&d[5..7], &[0x86, 0x20]);
+        assert_eq!(&d[7..], &point[..]);
+        assert_eq!(d.len(), 0x27);
+        // A 65-byte uncompressed P-256 point: A6 46 { 7F49 43 { 86 41 ... } }
+        let mut p256 = vec![0x04];
+        p256.extend_from_slice(&[0x55; 64]);
+        let d = ecdh_cipher_do(&p256);
+        assert_eq!(&d[..7], &[0xA6, 0x46, 0x7F, 0x49, 0x43, 0x86, 0x41]);
+        // The DO stays inside a short APDU: pso_decipher must emit the short form.
+        assert!(pso_decipher(&d).len() < 200);
+        assert_eq!(pso_decipher(&d)[4], d.len() as u8);
     }
 
     #[test]

--- a/crates/keyroost-transport/src/lib.rs
+++ b/crates/keyroost-transport/src/lib.rs
@@ -158,6 +158,10 @@ pub enum TransportError {
     /// The requested OpenPGP key algorithm cannot live in the requested slot
     /// (Ed25519 only signs; X25519 only agrees keys).
     OpenPgpSlotMismatch(keyroost_openpgp::SlotMismatch),
+    /// An RSA-only operation (RSA key import) found the slot already holds an
+    /// ECC key instead. `slot` is the CLI's `--slot` value (`sign` / `decrypt`
+    /// / `auth`); `label` is the ECC algorithm's display label.
+    OpenPgpSlotNotRsa { slot: &'static str, label: String },
 }
 
 impl fmt::Display for TransportError {
@@ -302,6 +306,11 @@ impl fmt::Display for TransportError {
                  declared exponent field"
             ),
             TransportError::OpenPgpSlotMismatch(e) => write!(f, "{e}"),
+            TransportError::OpenPgpSlotNotRsa { slot, label } => write!(
+                f,
+                "the {slot} slot holds an ECC key ({label}); RSA import needs an RSA \
+                 slot — run `openpgp generate-key --slot {slot} --algorithm rsa2048` first"
+            ),
         }
     }
 }

--- a/crates/keyroost-transport/src/lib.rs
+++ b/crates/keyroost-transport/src/lib.rs
@@ -50,7 +50,11 @@ pub use token2otp::{
 
 /// Re-exported so front-ends can name a key slot without depending on
 /// `keyroost-openpgp` directly (which would duplicate the crate in their graph).
-pub use keyroost_openpgp::{KeyCrt, RsaPrivateKeyParts};
+pub use keyroost_openpgp::{
+    describe_algorithm_attributes, parse_algorithm_attributes, AlgorithmAttributes,
+    AlgorithmInformation, Curve, EccKind, KeyAlg as OpenPgpKeyAlg, KeyCrt,
+    PublicKey as OpenPgpPublicKey, RsaPrivateKeyParts, SlotMismatch,
+};
 
 /// Things that can go wrong talking to a Molto2.
 #[derive(Debug)]
@@ -151,6 +155,9 @@ pub enum TransportError {
     /// builder would otherwise panic); guards against a malformed card
     /// attribute as well as a genuine key/card mismatch.
     OpenPgpExponentTooWide,
+    /// The requested OpenPGP key algorithm cannot live in the requested slot
+    /// (Ed25519 only signs; X25519 only agrees keys).
+    OpenPgpSlotMismatch(keyroost_openpgp::SlotMismatch),
 }
 
 impl fmt::Display for TransportError {
@@ -294,6 +301,7 @@ impl fmt::Display for TransportError {
                 "the key's RSA public exponent is wider than this OpenPGP card's \
                  declared exponent field"
             ),
+            TransportError::OpenPgpSlotMismatch(e) => write!(f, "{e}"),
         }
     }
 }
@@ -305,6 +313,7 @@ impl std::error::Error for TransportError {
             TransportError::PublicData(e) => Some(e),
             TransportError::OathParse(e) => Some(e),
             TransportError::OpenPgpParse(e) => Some(e),
+            TransportError::OpenPgpSlotMismatch(e) => Some(e),
             TransportError::PivParse(e) => Some(e),
             TransportError::X509(e) => Some(e),
             _ => None,

--- a/crates/keyroost-transport/src/openpgp.rs
+++ b/crates/keyroost-transport/src/openpgp.rs
@@ -452,18 +452,28 @@ impl OpenPgpSession {
             }
             return Ok(None);
         }
-        Ok(pgp::parse_algorithm_information(&bytes).ok())
+        let parsed = pgp::parse_algorithm_information(&bytes).ok();
+        if parsed.is_none() && self.debug {
+            eprintln!(
+                "! openpgp: Algorithm Information object did not parse; offering every algorithm"
+            );
+        }
+        Ok(parsed)
     }
 
-    /// Read and parse the RSA algorithm attributes for `crt`'s slot. Errors if
-    /// the slot isn't RSA.
+    /// Read and parse the RSA algorithm attributes for `crt`'s slot. Errors
+    /// with [`TransportError::OpenPgpSlotNotRsa`] if the slot holds an ECC
+    /// key instead.
     fn rsa_attributes(&mut self, crt: pgp::KeyCrt) -> Result<pgp::RsaAttributes, TransportError> {
         let attr = self.algorithm_attributes(crt)?;
         match pgp::parse_algorithm_attributes(&attr) {
             Ok(pgp::AlgorithmAttributes::Rsa(r)) => Ok(r),
-            Ok(_) => Err(TransportError::OpenPgpParse(
-                pgp::ParseError::UnsupportedAlgorithm,
-            )),
+            Ok(ecc @ pgp::AlgorithmAttributes::Ecc { .. }) => {
+                Err(TransportError::OpenPgpSlotNotRsa {
+                    slot: crt_flag_name(crt),
+                    label: ecc.label(),
+                })
+            }
             Err(e) => Err(TransportError::OpenPgpParse(e)),
         }
     }
@@ -688,6 +698,16 @@ impl OpenPgpSession {
             cmd_sensitive,
             resp_sensitive,
         )
+    }
+}
+
+/// The `--slot` value the CLI accepts for `crt`, for use in a "run this
+/// command" hint in an error message.
+fn crt_flag_name(crt: pgp::KeyCrt) -> &'static str {
+    match crt {
+        pgp::KeyCrt::Sign => "sign",
+        pgp::KeyCrt::Decrypt => "decrypt",
+        pgp::KeyCrt::Auth => "auth",
     }
 }
 

--- a/crates/keyroost-transport/src/openpgp.rs
+++ b/crates/keyroost-transport/src/openpgp.rs
@@ -30,6 +30,10 @@ pub struct OpenPgpStatus {
     pub dec_algo_id: Option<u8>,
     /// Algorithm id of the authentication key.
     pub aut_algo_id: Option<u8>,
+    /// Raw algorithm attributes (`C1`/`C2`/`C3`); render with [`algorithm_label`](Self::algorithm_label).
+    pub sig_attrs: Vec<u8>,
+    pub dec_attrs: Vec<u8>,
+    pub aut_attrs: Vec<u8>,
     /// Signature, decryption, and authentication key fingerprints (20 bytes each;
     /// all-zero when no key occupies that slot).
     pub fingerprint_sig: pgp::Fingerprint,
@@ -52,6 +56,18 @@ impl OpenPgpStatus {
         self.aid
             .get(10..14)
             .map(|b| u32::from_be_bytes([b[0], b[1], b[2], b[3]]))
+    }
+
+    /// Human label of the algorithm in `crt`'s slot (`RSA-2048`, `EdDSA
+    /// Ed25519`, …), or `none` for an empty attributes object. Never fails.
+    #[must_use]
+    pub fn algorithm_label(&self, crt: pgp::KeyCrt) -> String {
+        let attrs = match crt {
+            pgp::KeyCrt::Sign => &self.sig_attrs,
+            pgp::KeyCrt::Decrypt => &self.dec_attrs,
+            pgp::KeyCrt::Auth => &self.aut_attrs,
+        };
+        pgp::describe_algorithm_attributes(attrs)
     }
 }
 
@@ -133,6 +149,9 @@ impl OpenPgpSession {
             sig_algo_id: ard.sig_algo_id(),
             dec_algo_id: ard.dec_algo_id(),
             aut_algo_id: ard.aut_algo_id(),
+            sig_attrs: ard.algo_attr_sig,
+            dec_attrs: ard.algo_attr_dec,
+            aut_attrs: ard.algo_attr_aut,
             aid: ard.aid,
             fingerprint_sig: ard.fingerprint_sig,
             fingerprint_dec: ard.fingerprint_dec,
@@ -260,7 +279,28 @@ impl OpenPgpSession {
     /// public key. **Destructive** — overwrites any existing key in that slot.
     /// Requires the admin PIN (PW3) to have been verified first via
     /// [`verify_pin`](Self::verify_pin); on a YubiKey it also needs a touch.
-    pub fn generate_key(&mut self, crt: pgp::KeyCrt) -> Result<pgp::PublicKey, TransportError> {
+    ///
+    /// `alg`: `Some` sets the slot's algorithm first when it differs (the
+    /// attribute write is only issued when needed, since it wipes the slot —
+    /// which the GENERATE overwrites anyway); `None` generates whatever the
+    /// slot's current attributes say.
+    pub fn generate_key(
+        &mut self,
+        crt: pgp::KeyCrt,
+        alg: Option<pgp::KeyAlg>,
+    ) -> Result<pgp::PublicKey, TransportError> {
+        if let Some(alg) = alg {
+            let current = self.algorithm_attributes(crt)?;
+            if needs_attribute_write(&current, alg) {
+                if self.debug {
+                    eprintln!(
+                        "! openpgp generate: setting {crt:?} slot algorithm to {}",
+                        alg.label()
+                    );
+                }
+                self.set_algorithm(crt, alg)?;
+            }
+        }
         let (data, sw) = self.transmit_full(&pgp::generate_key(crt))?;
         ok_or_apdu("openpgp generate key", sw)?;
         pgp::parse_generated_public_key(&data).map_err(TransportError::OpenPgpParse)
@@ -363,23 +403,74 @@ impl OpenPgpSession {
         Ok(Vec::new()) // unreachable for a non-empty chunk list
     }
 
-    /// Read and parse the RSA algorithm attributes for `crt`'s slot from the
-    /// Application Related Data (`6E`). Errors if the slot isn't RSA.
-    fn rsa_attributes(&mut self, crt: pgp::KeyCrt) -> Result<pgp::RsaAttributes, TransportError> {
+    /// Raw algorithm attributes (`C1`/`C2`/`C3`) of `crt`'s slot, from a fresh
+    /// Application Related Data read. Read-only; no PIN.
+    pub fn algorithm_attributes(&mut self, crt: pgp::KeyCrt) -> Result<Vec<u8>, TransportError> {
         let (ard_bytes, sw) = self.transmit_full(&pgp::get_application_related_data())?;
         ok_or_apdu("get application related data", sw)?;
         let ard = pgp::parse_application_related_data(&ard_bytes)
             .map_err(TransportError::OpenPgpParse)?;
-        let attr = match crt {
-            pgp::KeyCrt::Sign => &ard.algo_attr_sig,
-            pgp::KeyCrt::Decrypt => &ard.algo_attr_dec,
-            pgp::KeyCrt::Auth => &ard.algo_attr_aut,
-        };
-        pgp::parse_rsa_algorithm_attributes(attr).map_err(TransportError::OpenPgpParse)
+        Ok(match crt {
+            pgp::KeyCrt::Sign => ard.algo_attr_sig,
+            pgp::KeyCrt::Decrypt => ard.algo_attr_dec,
+            pgp::KeyCrt::Auth => ard.algo_attr_aut,
+        })
+    }
+
+    /// Set `crt`'s slot to `alg` (PUT DATA of the algorithm attributes).
+    /// **Destructive**: cards wipe the slot's key when its algorithm changes.
+    /// Requires PW3 verified first. A slot/algorithm combination that doesn't
+    /// exist (Ed25519 in the decryption slot, X25519 elsewhere) is
+    /// [`TransportError::OpenPgpSlotMismatch`]; a card that doesn't allow the
+    /// change (or that algorithm) answers with an APDU error, surfaced as-is.
+    pub fn set_algorithm(
+        &mut self,
+        crt: pgp::KeyCrt,
+        alg: pgp::KeyAlg,
+    ) -> Result<(), TransportError> {
+        let attr = alg
+            .attributes(crt)
+            .map_err(TransportError::OpenPgpSlotMismatch)?;
+        let (_, sw) = self.transmit_full(&pgp::put_algorithm_attributes(crt, &attr))?;
+        ok_or_apdu("openpgp set algorithm attributes", sw)
+    }
+
+    /// The algorithms the card reports each slot accepts (Algorithm Information,
+    /// `FA`), or `Ok(None)` when the card doesn't publish it (pre-3.4 cards) —
+    /// callers then offer every algorithm and let the card's status word
+    /// answer. Read-only; no PIN.
+    pub fn supported_algorithms(
+        &mut self,
+    ) -> Result<Option<pgp::AlgorithmInformation>, TransportError> {
+        let (bytes, sw) = self.transmit_full(&pgp::get_algorithm_information())?;
+        if sw != pgp::SW_OK {
+            if self.debug {
+                eprintln!(
+                    "! openpgp: card has no Algorithm Information object (SW={sw:04X}); \
+                     offering every algorithm"
+                );
+            }
+            return Ok(None);
+        }
+        Ok(pgp::parse_algorithm_information(&bytes).ok())
+    }
+
+    /// Read and parse the RSA algorithm attributes for `crt`'s slot. Errors if
+    /// the slot isn't RSA.
+    fn rsa_attributes(&mut self, crt: pgp::KeyCrt) -> Result<pgp::RsaAttributes, TransportError> {
+        let attr = self.algorithm_attributes(crt)?;
+        match pgp::parse_algorithm_attributes(&attr) {
+            Ok(pgp::AlgorithmAttributes::Rsa(r)) => Ok(r),
+            Ok(_) => Err(TransportError::OpenPgpParse(
+                pgp::ParseError::UnsupportedAlgorithm,
+            )),
+            Err(e) => Err(TransportError::OpenPgpParse(e)),
+        }
     }
 
     /// Read the public key currently in `crt`'s slot. Read-only; no PIN. Returns
-    /// an `OpenPgpParse` error if the slot is empty or holds a non-RSA key.
+    /// an `OpenPgpParse` error if the slot is empty or holds a key of a kind
+    /// this crate can't parse.
     pub fn read_public_key(&mut self, crt: pgp::KeyCrt) -> Result<pgp::PublicKey, TransportError> {
         let (data, sw) = self.transmit_full(&pgp::read_public_key(crt))?;
         ok_or_apdu("openpgp read public key", sw)?;
@@ -414,21 +505,42 @@ impl OpenPgpSession {
     /// card applies the private key and strips the PKCS#1 padding. Requires PW1
     /// verified in the "other"/decipher context ([`keyroost_openpgp::PW1_OTHER`]);
     /// on a YubiKey it also needs a touch.
-    ///
-    /// The RSA cipher DO is a `0x00` padding-indicator byte followed by the
-    /// cryptogram (257 bytes for RSA-2048), which exceeds the short-APDU limit,
-    /// so this sends an extended-length APDU and falls back to ISO command
-    /// chaining on `6700` / `6883` — the same strategy as
-    /// [`import_key`](Self::import_key). `KEYROOST_OPENPGP_FORCE_CHAINING` forces
-    /// the chaining path for testing.
     pub fn decrypt(&mut self, cryptogram: &[u8]) -> Result<Vec<u8>, TransportError> {
         // RSA cipher DO: 0x00 padding-indicator byte + the cryptogram.
         let mut data = Vec::with_capacity(1 + cryptogram.len());
         data.push(0x00);
         data.extend_from_slice(cryptogram);
+        self.decipher(&data)
+    }
 
+    /// ECDH with the on-card decryption key (PSO:DECIPHER, `A6` template):
+    /// returns the shared secret the card derives from `ephemeral_point` (the
+    /// sender's ephemeral public point — `04||X||Y` for Weierstrass curves, 32
+    /// raw bytes for X25519; a leading OpenPGP `0x40` is stripped here). The
+    /// RFC 6637 KDF / key unwrap is the OpenPGP tool's job, matching the RSA
+    /// path's raw contract. Requires PW1 in the "other" context; on a YubiKey
+    /// also a touch.
+    pub fn decrypt_ecdh(&mut self, ephemeral_point: &[u8]) -> Result<Vec<u8>, TransportError> {
+        let point = match ephemeral_point {
+            [0x40, rest @ ..] if rest.len() == 32 => rest,
+            p => p,
+        };
+        let cipher_do = pgp::ecdh_cipher_do(point);
+        self.decipher(&cipher_do)
+    }
+
+    /// Send a PSO:DECIPHER `cipher_do` (either the RSA `0x00||cryptogram` form
+    /// or the ECDH `A6` template) and return the recovered plaintext / shared
+    /// secret.
+    ///
+    /// `cipher_do` can exceed the short-APDU limit (257 bytes for RSA-2048),
+    /// so this sends an extended-length APDU and falls back to ISO command
+    /// chaining on `6700` / `6883` — the same strategy as
+    /// [`import_key`](Self::import_key). `KEYROOST_OPENPGP_FORCE_CHAINING` forces
+    /// the chaining path for testing.
+    fn decipher(&mut self, cipher_do: &[u8]) -> Result<Vec<u8>, TransportError> {
         if std::env::var_os("KEYROOST_OPENPGP_FORCE_CHAINING").is_none() {
-            let (plain, sw) = self.transmit_full(&pgp::pso_decipher(&data))?;
+            let (plain, sw) = self.transmit_full(&pgp::pso_decipher(cipher_do))?;
             if sw == pgp::SW_OK {
                 return Ok(plain);
             }
@@ -447,7 +559,7 @@ impl OpenPgpSession {
             eprintln!("! openpgp decipher: forcing command chaining (env override)");
         }
 
-        let chunks = pgp::pso_decipher_chained(&data, 254);
+        let chunks = pgp::pso_decipher_chained(cipher_do, 254);
         self.transmit_chain("openpgp decipher", &chunks)
     }
 
@@ -480,8 +592,12 @@ impl OpenPgpSession {
         crt: pgp::KeyCrt,
         creation_time: u32,
     ) -> Result<[u8; 20], TransportError> {
+        let attrs = self.algorithm_attributes(crt)?;
+        let attrs =
+            pgp::parse_algorithm_attributes(&attrs).map_err(TransportError::OpenPgpParse)?;
         let key = self.read_public_key(crt)?;
-        let fpr = pgp::rsa_v4_fingerprint_from(&key, creation_time);
+        let fpr = pgp::v4_fingerprint(&key, &attrs, creation_time)
+            .map_err(TransportError::OpenPgpParse)?;
         let (_, sw) = self.transmit_full(&pgp::put_generation_time(crt, creation_time))?;
         ok_or_apdu("openpgp put generation time", sw)?;
         let (_, sw) = self.transmit_full(&pgp::put_fingerprint(crt, &fpr))?;
@@ -585,5 +701,65 @@ fn ok_or_apdu(label: &'static str, sw: u16) -> Result<(), TransportError> {
             sw1: (sw >> 8) as u8,
             sw2: sw as u8,
         })
+    }
+}
+
+/// Whether generating `alg` in a slot whose attributes currently read `current`
+/// requires writing new attributes first. Equal algorithms skip the write —
+/// an attribute write wipes the slot, and the card may echo RSA attributes back
+/// with its own import-format byte, so compare by parsed algorithm, not bytes.
+fn needs_attribute_write(current: &[u8], alg: pgp::KeyAlg) -> bool {
+    pgp::parse_algorithm_attributes(current)
+        .ok()
+        .and_then(|a| a.key_alg())
+        != Some(alg)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn needs_attribute_write_only_when_the_slot_differs() {
+        // Same algorithm: no write (a write would wipe the slot for nothing).
+        let cur = pgp::KeyAlg::Ed25519.attributes(pgp::KeyCrt::Sign).unwrap();
+        assert!(!needs_attribute_write(&cur, pgp::KeyAlg::Ed25519));
+        // RSA-2048 reported with the card's own import-format byte still counts as RSA-2048.
+        assert!(!needs_attribute_write(
+            &[0x01, 0x08, 0x00, 0x00, 0x20, 0x02],
+            pgp::KeyAlg::Rsa2048
+        ));
+        // Different algorithm, unknown attributes, or garbage: write.
+        assert!(needs_attribute_write(&cur, pgp::KeyAlg::X25519));
+        assert!(needs_attribute_write(
+            &[0x16, 0x2B, 0x65, 0x70],
+            pgp::KeyAlg::Ed25519
+        ));
+        assert!(needs_attribute_write(&[], pgp::KeyAlg::Rsa2048));
+    }
+
+    #[test]
+    fn status_algorithm_labels_come_from_the_raw_attributes() {
+        let st = OpenPgpStatus {
+            aid: vec![],
+            sig_algo_id: Some(0x16),
+            dec_algo_id: Some(0x12),
+            aut_algo_id: None,
+            sig_attrs: vec![0x16, 0x2B, 0x06, 0x01, 0x04, 0x01, 0xDA, 0x47, 0x0F, 0x01],
+            dec_attrs: vec![
+                0x12, 0x2B, 0x06, 0x01, 0x04, 0x01, 0x97, 0x55, 0x01, 0x05, 0x01,
+            ],
+            aut_attrs: vec![],
+            fingerprint_sig: [0; 20],
+            fingerprint_dec: [0; 20],
+            fingerprint_aut: [0; 20],
+            tries_pw1: 3,
+            tries_rc: 0,
+            tries_pw3: 3,
+            signature_count: None,
+        };
+        assert_eq!(st.algorithm_label(pgp::KeyCrt::Sign), "EdDSA Ed25519");
+        assert_eq!(st.algorithm_label(pgp::KeyCrt::Decrypt), "ECDH X25519");
+        assert_eq!(st.algorithm_label(pgp::KeyCrt::Auth), "none");
     }
 }

--- a/crates/keyroost/src/main.rs
+++ b/crates/keyroost/src/main.rs
@@ -566,6 +566,12 @@ struct OpenPgpState {
     /// Every per-key action — generate on-card, import — targets this key, the
     /// same way the PIV pane's `selected_slot` drives its per-slot cards.
     selected_key: OpenPgpSlotSel,
+    /// Algorithm chosen in the Generate-key modal for the selected slot.
+    gen_alg: OpenPgpKeyAlgSel,
+    /// The card's own Algorithm Information (`FA`) object, when it publishes
+    /// one — feeds the Generate-key modal's algorithm choices. `None` means
+    /// the card didn't publish one (pre-3.4 cards), not that it has none.
+    supported: Option<keyroost_transport::AlgorithmInformation>,
     /// Path to an RSA key file for import-from-file (text-entered).
     import_path: String,
     /// Change-user-PIN (PW1) old/new entries. Cleared after use.
@@ -1264,14 +1270,61 @@ impl OpenPgpSlotSel {
             OpenPgpSlotSel::Auth => "Authentication",
         }
     }
-    /// This key's algorithm id and fingerprint out of an `OpenPgpStatus`,
-    /// so the per-key state line can read directly from the selected key.
-    fn status_fields(self, st: &keyroost_transport::OpenPgpStatus) -> (Option<u8>, &[u8; 20]) {
+    /// This key's raw algorithm attributes and fingerprint out of an
+    /// `OpenPgpStatus`, so the per-key state line can read directly from the
+    /// selected key.
+    fn status_fields(self, st: &keyroost_transport::OpenPgpStatus) -> (&[u8], &[u8; 20]) {
         match self {
-            OpenPgpSlotSel::Sign => (st.sig_algo_id, &st.fingerprint_sig),
-            OpenPgpSlotSel::Decrypt => (st.dec_algo_id, &st.fingerprint_dec),
-            OpenPgpSlotSel::Auth => (st.aut_algo_id, &st.fingerprint_aut),
+            OpenPgpSlotSel::Sign => (&st.sig_attrs, &st.fingerprint_sig),
+            OpenPgpSlotSel::Decrypt => (&st.dec_attrs, &st.fingerprint_dec),
+            OpenPgpSlotSel::Auth => (&st.aut_attrs, &st.fingerprint_aut),
         }
+    }
+}
+
+/// OpenPGP key-generation algorithm selector: the slot's current algorithm
+/// ("card default"), or an explicit one.
+#[derive(Clone, Copy, Default, PartialEq, Eq, Debug)]
+enum OpenPgpKeyAlgSel {
+    #[default]
+    CardDefault,
+    Alg(keyroost_transport::OpenPgpKeyAlg),
+}
+
+impl OpenPgpKeyAlgSel {
+    fn to_alg(self) -> Option<keyroost_transport::OpenPgpKeyAlg> {
+        match self {
+            OpenPgpKeyAlgSel::CardDefault => None,
+            OpenPgpKeyAlgSel::Alg(a) => Some(a),
+        }
+    }
+    fn label(self) -> &'static str {
+        match self {
+            OpenPgpKeyAlgSel::CardDefault => "Card default",
+            OpenPgpKeyAlgSel::Alg(a) => a.label(),
+        }
+    }
+    /// The menu for `crt`'s slot: what the card lists in its Algorithm
+    /// Information when it publishes one for that slot, else every algorithm
+    /// that fits the slot — unknown means offer the surface and let the card
+    /// answer, never a vendor table.
+    fn choices(
+        supported: Option<&keyroost_transport::AlgorithmInformation>,
+        crt: keyroost_transport::KeyCrt,
+    ) -> Vec<OpenPgpKeyAlgSel> {
+        let mut out = vec![OpenPgpKeyAlgSel::CardDefault];
+        let listed = supported.map(|i| i.key_algs(crt)).unwrap_or_default();
+        if !listed.is_empty() {
+            out.extend(listed.into_iter().map(OpenPgpKeyAlgSel::Alg));
+        } else {
+            out.extend(
+                keyroost_transport::OpenPgpKeyAlg::ALL
+                    .into_iter()
+                    .filter(|a| a.attributes(crt).is_ok())
+                    .map(OpenPgpKeyAlgSel::Alg),
+            );
+        }
+        out
     }
 }
 
@@ -5380,17 +5433,26 @@ impl App {
         };
         let for_device = self.selected_device.clone();
         self.spawn_job("Reading OpenPGP status\u{2026}", move || {
-            let result = (|| -> Result<keyroost_transport::OpenPgpStatus, TransportError> {
+            let result = (|| -> Result<
+                (
+                    keyroost_transport::OpenPgpStatus,
+                    Option<keyroost_transport::AlgorithmInformation>,
+                ),
+                TransportError,
+            > {
                 let mut session = keyroost_transport::OpenPgpSession::open(&name)?;
-                session.status()
+                let status = session.status()?;
+                let supported = session.supported_algorithms().unwrap_or(None);
+                Ok((status, supported))
             })();
             Box::new(move |app: &mut App| {
                 if !completion_still_valid(for_device.as_ref(), app.selected_device.as_ref()) {
                     return; // selection changed mid-read; discard
                 }
                 match result {
-                    Ok(status) => {
+                    Ok((status, supported)) => {
                         app.openpgp.status = Some(status);
+                        app.openpgp.supported = supported;
                         app.openpgp.loaded = true;
                     }
                     Err(e) => app.openpgp.error = Some(e.to_string()),
@@ -5508,12 +5570,13 @@ impl App {
         };
         let pin = zeroize::Zeroizing::new(self.openpgp_admin_pin_value());
         let slot = self.openpgp.selected_key;
+        let alg = self.openpgp.gen_alg.to_alg();
         let creation_time = unix_now();
         self.openpgp.notice = None;
         self.spawn_job("Generating key… (touch the key if it blinks)", move || {
             let result = (|| -> Result<(keyroost_transport::OpenPgpStatus, [u8; 20]), TransportError> {
                 let mut s = Self::openpgp_open_admin(&name, &pin)?;
-                let _ = s.generate_key(slot.to_crt())?;
+                let _ = s.generate_key(slot.to_crt(), alg)?;
                 let fpr = s.register_key(slot.to_crt(), creation_time)?;
                 Ok((s.status()?, fpr))
             })();
@@ -5774,18 +5837,6 @@ fn typed_reset_modal(
             *confirm = Some(buf);
         }
         false
-    }
-}
-
-/// Map an OpenPGP algorithm id (first attribute byte) to a short label.
-fn algo_id_label(id: Option<u8>) -> &'static str {
-    match id {
-        Some(0x01) => "RSA",
-        Some(0x12) => "ECDH",
-        Some(0x13) => "ECDSA",
-        Some(0x16) => "EdDSA",
-        Some(_) => "other",
-        None => "none",
     }
 }
 
@@ -7619,6 +7670,23 @@ fn piv_keyalg_combo(ui: &mut egui::Ui, id: &str, sel: &mut PivKeyAlgSel) {
         });
 }
 
+/// An OpenPGP key-algorithm picker combo, restricted to `choices` (the card's
+/// own Algorithm Information menu, or every algorithm that fits the slot).
+fn openpgp_keyalg_combo(
+    ui: &mut egui::Ui,
+    id: &str,
+    sel: &mut OpenPgpKeyAlgSel,
+    choices: &[OpenPgpKeyAlgSel],
+) {
+    egui::ComboBox::from_id_salt(id)
+        .selected_text(sel.label())
+        .show_ui(ui, |ui| {
+            for &opt in choices {
+                ui.selectable_value(sel, opt, opt.label());
+            }
+        });
+}
+
 /// A PIV PIN/touch policy value selectable in the Generate key modal's combo
 /// boxes: its display label and the full set of choices, in menu order.
 /// `Default` is always first — it's the initial selection, and the plain PIV
@@ -9414,7 +9482,7 @@ impl App {
                                 ui,
                                 &format!(
                                     "Signature \u{00B7} {}",
-                                    slot_summary(st.sig_algo_id, &st.fingerprint_sig)
+                                    slot_summary(&st.sig_attrs, &st.fingerprint_sig)
                                 ),
                                 p.txt2,
                                 p.raised2,
@@ -9423,7 +9491,7 @@ impl App {
                                 ui,
                                 &format!(
                                     "Encryption \u{00B7} {}",
-                                    slot_summary(st.dec_algo_id, &st.fingerprint_dec)
+                                    slot_summary(&st.dec_attrs, &st.fingerprint_dec)
                                 ),
                                 p.txt2,
                                 p.raised2,
@@ -9432,7 +9500,7 @@ impl App {
                                 ui,
                                 &format!(
                                     "Auth \u{00B7} {}",
-                                    slot_summary(st.aut_algo_id, &st.fingerprint_aut)
+                                    slot_summary(&st.aut_attrs, &st.fingerprint_aut)
                                 ),
                                 p.txt2,
                                 p.raised2,
@@ -12513,6 +12581,34 @@ impl App {
                             card_note(ui, p, "Authorizes writing the public-key URL.");
                         }
                         OpenPgpCredKind::GenerateKey => {
+                            let crt = self.openpgp.selected_key.to_crt();
+                            let choices =
+                                OpenPgpKeyAlgSel::choices(self.openpgp.supported.as_ref(), crt);
+                            ui.horizontal(|ui| {
+                                ui.add_sized(
+                                    [96.0, 22.0],
+                                    egui::Label::new(
+                                        egui::RichText::new("Algorithm")
+                                            .font(theme::f_reg(13.0))
+                                            .color(p.txt2),
+                                    ),
+                                );
+                                openpgp_keyalg_combo(
+                                    ui,
+                                    "openpgp-gen-alg",
+                                    &mut self.openpgp.gen_alg,
+                                    &choices,
+                                );
+                            });
+                            ui.add_space(4.0);
+                            if self.openpgp.supported.is_none() {
+                                card_note(
+                                    ui,
+                                    p,
+                                    "This card does not list its algorithms; the card \
+                                     rejects any it cannot do.",
+                                );
+                            }
                             self.openpgp_modal_admin_field(ui, p, kind);
                             card_note(
                                 ui,
@@ -13008,11 +13104,15 @@ impl App {
         // self.
         let sel_state: String = match &self.openpgp.status {
             Some(st) => {
-                let (algo, fpr) = selected.status_fields(st);
+                let (attrs, fpr) = selected.status_fields(st);
                 if fpr.iter().all(|&b| b == 0) {
                     "no key".to_string()
                 } else {
-                    format!("{} \u{00B7} fpr {}", algo_id_label(algo), hex_lower(fpr))
+                    format!(
+                        "{} \u{00B7} fpr {}",
+                        keyroost_transport::describe_algorithm_attributes(attrs),
+                        hex_lower(fpr)
+                    )
                 }
             }
             None => "read status to view this key".to_string(),
@@ -13176,6 +13276,7 @@ impl App {
         // Apply collected intents now that the card borrows have ended.
         if let Some(key) = clicked_key {
             self.openpgp.selected_key = key;
+            self.openpgp.gen_alg = OpenPgpKeyAlgSel::CardDefault;
         }
         if do_refresh {
             self.load_openpgp_status();
@@ -15122,17 +15223,48 @@ fn editor_row(ui: &mut egui::Ui, p: &Palette, label: &str, add: impl FnOnce(&mut
 }
 
 /// Summarize an OpenPGP key slot: its algorithm label, or "empty" when no key.
-fn slot_summary(algo: Option<u8>, fpr: &[u8; 20]) -> &'static str {
+fn slot_summary(attrs: &[u8], fpr: &[u8; 20]) -> String {
     if fpr.iter().all(|&b| b == 0) {
-        "empty"
+        "empty".to_string()
     } else {
-        algo_id_label(algo)
+        keyroost_transport::describe_algorithm_attributes(attrs)
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn openpgp_algorithm_choices_are_the_cards_list_or_everything() {
+        use keyroost_transport::{KeyCrt, OpenPgpKeyAlg};
+        // No FA: card default + every algorithm that fits the slot.
+        let all = OpenPgpKeyAlgSel::choices(None, KeyCrt::Decrypt);
+        assert_eq!(all[0], OpenPgpKeyAlgSel::CardDefault);
+        assert!(all.contains(&OpenPgpKeyAlgSel::Alg(OpenPgpKeyAlg::X25519)));
+        assert!(!all.contains(&OpenPgpKeyAlgSel::Alg(OpenPgpKeyAlg::Ed25519)));
+        assert!(OpenPgpKeyAlgSel::choices(None, KeyCrt::Sign)
+            .contains(&OpenPgpKeyAlgSel::Alg(OpenPgpKeyAlg::Ed25519)));
+        // FA present: exactly what the card listed (modelled entries), in card order.
+        let info = keyroost_transport::AlgorithmInformation {
+            sig: vec![
+                vec![0x16, 0x2B, 0x06, 0x01, 0x04, 0x01, 0xDA, 0x47, 0x0F, 0x01],
+                vec![0x01, 0x08, 0x00, 0x00, 0x20, 0x00],
+            ],
+            dec: vec![],
+            aut: vec![],
+        };
+        assert_eq!(
+            OpenPgpKeyAlgSel::choices(Some(&info), KeyCrt::Sign),
+            vec![
+                OpenPgpKeyAlgSel::CardDefault,
+                OpenPgpKeyAlgSel::Alg(OpenPgpKeyAlg::Ed25519),
+                OpenPgpKeyAlgSel::Alg(OpenPgpKeyAlg::Rsa2048)
+            ]
+        );
+        // A slot the card lists nothing for still offers everything (unknown ≠ none).
+        assert!(OpenPgpKeyAlgSel::choices(Some(&info), KeyCrt::Auth).len() > 1);
+    }
 
     /// #98: the top bar's version chip is the only place the running app
     /// states its version — keep it a well-formed "vX.Y.Z" so it never

--- a/crates/keyroost/src/main.rs
+++ b/crates/keyroost/src/main.rs
@@ -6170,6 +6170,8 @@ impl App {
         self.openpgp.notice = None;
         self.openpgp.name_input.clear();
         self.openpgp.url_input.clear();
+        self.openpgp.supported = None;
+        self.openpgp.gen_alg = OpenPgpKeyAlgSel::CardDefault;
         self.piv = PivState::default();
         // Typed secrets must never survive a selection change — a PIN entered
         // for one key would otherwise be sent to another (the OATH pane even

--- a/crates/keyroostctl/src/main.rs
+++ b/crates/keyroostctl/src/main.rs
@@ -1003,12 +1003,19 @@ enum OpenpgpCmd {
         #[arg(long, value_name = "SUBSTR")]
         reader: Option<String>,
     },
-    /// Read the public key from a slot (read-only; no PIN). RSA keys print their
-    /// modulus and exponent in hex.
+    /// Read the public key from a slot (read-only; no PIN). RSA keys print
+    /// modulus and exponent, ECC keys the public point, in hex.
     PublicKey {
         /// Which key slot: `sign`, `decrypt`, or `auth`.
         #[arg(long, value_enum, default_value_t = OpenpgpSlot::Sign)]
         slot: OpenpgpSlot,
+        #[arg(long, value_name = "SUBSTR")]
+        reader: Option<String>,
+    },
+    /// List the key algorithms this card reports accepting per slot (read-only;
+    /// no PIN). Cards that don't publish the list accept any attempt and answer
+    /// with an error if they can't.
+    Algorithms {
         #[arg(long, value_name = "SUBSTR")]
         reader: Option<String>,
     },
@@ -1049,14 +1056,21 @@ enum OpenpgpCmd {
         #[arg(long, value_name = "SUBSTR")]
         reader: Option<String>,
     },
-    /// Generate a fresh key pair in a slot. DESTRUCTIVE — overwrites any existing
-    /// key in that slot. Requires the admin PIN (PW3) and `--yes`; on a YubiKey a
-    /// touch is also required. Also writes the key's v4 fingerprint and a
-    /// generation timestamp so an OpenPGP tool (e.g. gpg) recognizes the key.
+    /// Generate a fresh key pair in a slot, optionally switching the slot's
+    /// algorithm first. DESTRUCTIVE — overwrites any existing key in that slot.
+    /// Requires the admin PIN (PW3) and `--yes`; on a YubiKey a touch is also
+    /// required. Also writes the key's v4 fingerprint and a generation
+    /// timestamp so an OpenPGP tool (e.g. gpg) recognizes the key.
     GenerateKey {
         /// Which key slot to (over)write: `sign`, `decrypt`, or `auth`.
         #[arg(long, value_enum, default_value_t = OpenpgpSlot::Sign)]
         slot: OpenpgpSlot,
+        /// Key algorithm to generate. Omit to keep the slot's current algorithm
+        /// (RSA-2048 on a factory card). Ed25519 fits the sign/auth slots,
+        /// X25519 the decrypt slot; the NIST/brainpool/secp256k1 curves fit any.
+        /// See `openpgp algorithms` for what this card accepts.
+        #[arg(long, value_enum)]
+        algorithm: Option<CliOpenpgpKeyAlg>,
         /// Confirm you really want to overwrite the slot.
         #[arg(long)]
         yes: bool,
@@ -1101,9 +1115,9 @@ enum OpenpgpCmd {
         reader: Option<String>,
     },
     /// Sign a file with the on-card signature key (PSO:CDS). Hashes the input
-    /// (SHA-256 by default, or SHA-1 via `--hash`), wraps it in a PKCS#1
-    /// DigestInfo, and has the card produce an RSA signature. Requires the
-    /// signing PIN (PW1) and, on a YubiKey, a touch.
+    /// (SHA-256 by default, or SHA-1 via `--hash`). RSA slots sign a PKCS#1
+    /// DigestInfo; ECC slots sign the bare digest. Requires the signing PIN
+    /// (PW1) and, on a YubiKey, a touch.
     Sign {
         /// File whose contents to sign.
         #[arg(long, value_name = "FILE")]
@@ -1125,17 +1139,16 @@ enum OpenpgpCmd {
         #[arg(long, value_name = "SUBSTR")]
         reader: Option<String>,
     },
-    /// Decrypt a file with the on-card decryption key (PSO:DECIPHER). The input
-    /// is a raw RSA cryptogram — for RSA-2048, the 256-byte value produced by
-    /// RSA-encrypting a PKCS#1 v1.5 block under the decryption slot's public
-    /// key. The card applies the private key, strips the padding, and returns
-    /// the plaintext. Requires the user PIN (PW1) and, on a YubiKey, a touch.
+    /// Decrypt a file with the on-card decryption key (PSO:DECIPHER). Requires
+    /// the user PIN (PW1) and, on a YubiKey, a touch.
     Decrypt {
-        /// File holding the raw RSA cryptogram to decrypt.
+        /// For an RSA slot `--in` is the raw cryptogram; for an ECDH slot it is
+        /// the sender's ephemeral public point (`04||X||Y`, or 32 raw bytes for
+        /// X25519) and the output is the shared secret.
         #[arg(long, value_name = "FILE")]
         r#in: std::path::PathBuf,
-        /// Write the recovered plaintext here. Without it, the plaintext is
-        /// printed as hex to stdout.
+        /// Write the recovered plaintext (or, for ECDH, the shared secret)
+        /// here. Without it, the bytes are printed as hex to stdout.
         #[arg(long, value_name = "FILE")]
         out: Option<std::path::PathBuf>,
         /// Read the user PIN (PW1) from the named environment variable.
@@ -1148,9 +1161,10 @@ enum OpenpgpCmd {
         reader: Option<String>,
     },
     /// Produce a client/SSH authentication signature with the on-card
-    /// Authentication key (INTERNAL AUTHENTICATE). Hashes the input, wraps it in
-    /// a PKCS#1 DigestInfo, and has the card sign it. Requires the user PIN (PW1)
-    /// and, on a YubiKey, a touch.
+    /// Authentication key (INTERNAL AUTHENTICATE). Hashes the input (SHA-256 by
+    /// default, or SHA-1 via `--hash`). RSA slots sign a PKCS#1 DigestInfo; ECC
+    /// slots sign the bare digest. Requires the user PIN (PW1) and, on a
+    /// YubiKey, a touch.
     Authenticate {
         /// File whose contents to authenticate-sign.
         #[arg(long, value_name = "FILE")]
@@ -1273,6 +1287,15 @@ impl SignHash {
             SignHash::Sha256 => "SHA-256",
         }
     }
+
+    /// The bare digest of `data` — no DigestInfo wrapper. ECDSA and EdDSA
+    /// slots sign this directly.
+    fn digest(self, data: &[u8]) -> Vec<u8> {
+        match self {
+            SignHash::Sha1 => keyroost_proto::sha1::sha1(data).to_vec(),
+            SignHash::Sha256 => keyroost_proto::sha256::sha256(data).to_vec(),
+        }
+    }
 }
 impl OpenpgpSlot {
     fn to_crt(self) -> keyroost_openpgp::KeyCrt {
@@ -1287,6 +1310,51 @@ impl OpenpgpSlot {
             OpenpgpSlot::Sign => "signature",
             OpenpgpSlot::Decrypt => "decryption",
             OpenpgpSlot::Auth => "authentication",
+        }
+    }
+}
+
+/// Key algorithm for `openpgp generate-key --algorithm`. Names follow GnuPG's
+/// (`cv25519` is accepted as an alias of `x25519`).
+#[derive(Copy, Clone, ValueEnum)]
+enum CliOpenpgpKeyAlg {
+    Rsa2048,
+    Rsa3072,
+    Rsa4096,
+    Ed25519,
+    #[value(alias = "cv25519")]
+    X25519,
+    #[value(name = "nistp256")]
+    NistP256,
+    #[value(name = "nistp384")]
+    NistP384,
+    #[value(name = "nistp521")]
+    NistP521,
+    Secp256k1,
+    #[value(name = "brainpoolp256")]
+    BrainpoolP256r1,
+    #[value(name = "brainpoolp384")]
+    BrainpoolP384r1,
+    #[value(name = "brainpoolp512")]
+    BrainpoolP512r1,
+}
+
+impl CliOpenpgpKeyAlg {
+    fn to_alg(self) -> keyroost_openpgp::KeyAlg {
+        use keyroost_openpgp::KeyAlg::*;
+        match self {
+            CliOpenpgpKeyAlg::Rsa2048 => Rsa2048,
+            CliOpenpgpKeyAlg::Rsa3072 => Rsa3072,
+            CliOpenpgpKeyAlg::Rsa4096 => Rsa4096,
+            CliOpenpgpKeyAlg::Ed25519 => Ed25519,
+            CliOpenpgpKeyAlg::X25519 => X25519,
+            CliOpenpgpKeyAlg::NistP256 => NistP256,
+            CliOpenpgpKeyAlg::NistP384 => NistP384,
+            CliOpenpgpKeyAlg::NistP521 => NistP521,
+            CliOpenpgpKeyAlg::Secp256k1 => Secp256k1,
+            CliOpenpgpKeyAlg::BrainpoolP256r1 => BrainpoolP256r1,
+            CliOpenpgpKeyAlg::BrainpoolP384r1 => BrainpoolP384r1,
+            CliOpenpgpKeyAlg::BrainpoolP512r1 => BrainpoolP512r1,
         }
     }
 }
@@ -5278,6 +5346,34 @@ fn oath_algo_str(a: keyroost_oath::Algorithm) -> &'static str {
     }
 }
 
+/// What to hand the card for a signature: RSA slots take a PKCS#1 DigestInfo;
+/// ECDSA and EdDSA slots take the bare digest (the card signs those bytes
+/// directly — GnuPG does the same). Attributes that don't parse are treated
+/// as RSA, the only kind that existed before #106.
+fn openpgp_sign_input(slot_attrs: &[u8], hash: SignHash, data: &[u8]) -> Vec<u8> {
+    match keyroost_openpgp::parse_algorithm_attributes(slot_attrs) {
+        Ok(keyroost_openpgp::AlgorithmAttributes::Ecc { .. }) => hash.digest(data),
+        _ => hash.digest_info(data),
+    }
+}
+
+/// Print a public key read from (or freshly generated into) an OpenPGP slot:
+/// RSA prints modulus and exponent, ECC the public point, both in hex.
+fn print_openpgp_public_key(slot_label: &str, attrs: &[u8], key: &keyroost_openpgp::PublicKey) {
+    println!(
+        "{} key ({}):",
+        slot_label,
+        keyroost_openpgp::describe_algorithm_attributes(attrs)
+    );
+    match key {
+        keyroost_openpgp::PublicKey::Rsa { modulus, exponent } => {
+            println!("  modulus:  {}", hex_encode(modulus));
+            println!("  exponent: {}", hex_encode(exponent));
+        }
+        keyroost_openpgp::PublicKey::Ecc { point } => println!("  point:    {}", hex_encode(point)),
+    }
+}
+
 fn run_openpgp(cmd: &OpenpgpCmd, debug: bool) -> Result<(), Box<dyn std::error::Error>> {
     match cmd {
         OpenpgpCmd::Status { reader } => {
@@ -5297,9 +5393,9 @@ fn run_openpgp(cmd: &OpenpgpCmd, debug: bool) -> Result<(), Box<dyn std::error::
                 emit_json(&json_out::OpenpgpStatusJson {
                     aid: hex_encode(&status.aid),
                     serial: status.serial(),
-                    sig_algo: algo_id_str(status.sig_algo_id).to_string(),
-                    dec_algo: algo_id_str(status.dec_algo_id).to_string(),
-                    aut_algo: algo_id_str(status.aut_algo_id).to_string(),
+                    sig_algo: status.algorithm_label(keyroost_openpgp::KeyCrt::Sign),
+                    dec_algo: status.algorithm_label(keyroost_openpgp::KeyCrt::Decrypt),
+                    aut_algo: status.algorithm_label(keyroost_openpgp::KeyCrt::Auth),
                     fingerprint_sig: fpr(&status.fingerprint_sig),
                     fingerprint_dec: fpr(&status.fingerprint_dec),
                     fingerprint_aut: fpr(&status.fingerprint_aut),
@@ -5319,9 +5415,9 @@ fn run_openpgp(cmd: &OpenpgpCmd, debug: bool) -> Result<(), Box<dyn std::error::
             }
             println!(
                 "Key algorithms: sig={} dec={} aut={}",
-                algo_id_str(status.sig_algo_id),
-                algo_id_str(status.dec_algo_id),
-                algo_id_str(status.aut_algo_id),
+                status.algorithm_label(keyroost_openpgp::KeyCrt::Sign),
+                status.algorithm_label(keyroost_openpgp::KeyCrt::Decrypt),
+                status.algorithm_label(keyroost_openpgp::KeyCrt::Auth),
             );
             print_fingerprint("Signature  fpr", &status.fingerprint_sig);
             print_fingerprint("Decryption fpr", &status.fingerprint_dec);
@@ -5348,10 +5444,32 @@ fn run_openpgp(cmd: &OpenpgpCmd, debug: bool) -> Result<(), Box<dyn std::error::
         }
         OpenpgpCmd::PublicKey { slot, reader } => {
             let mut session = open_openpgp(reader.as_deref(), debug)?;
+            let attrs = session.algorithm_attributes(slot.to_crt())?;
             let key = session.read_public_key(slot.to_crt())?;
-            println!("{} key (RSA):", slot.label());
-            println!("  modulus:  {}", hex_encode(&key.modulus));
-            println!("  exponent: {}", hex_encode(&key.exponent));
+            print_openpgp_public_key(slot.label(), &attrs, &key);
+        }
+        OpenpgpCmd::Algorithms { reader } => {
+            let mut session = open_openpgp(reader.as_deref(), debug)?;
+            match session.supported_algorithms()? {
+                None => println!(
+                    "This card does not publish an algorithm list (pre-3.4 OpenPGP card). \
+                     Any --algorithm may be tried; the card rejects what it cannot do."
+                ),
+                Some(info) => {
+                    for (name, crt) in [
+                        ("sign", keyroost_openpgp::KeyCrt::Sign),
+                        ("decrypt", keyroost_openpgp::KeyCrt::Decrypt),
+                        ("auth", keyroost_openpgp::KeyCrt::Auth),
+                    ] {
+                        let labels: Vec<String> = info
+                            .raw(crt)
+                            .iter()
+                            .map(|a| keyroost_openpgp::describe_algorithm_attributes(a))
+                            .collect();
+                        println!("{:<8} {}", format!("{name}:"), labels.join(", "));
+                    }
+                }
+            }
         }
         OpenpgpCmd::Reset { yes, reader } => {
             // Resolve and identify the target *before* the --yes gate, so the
@@ -5379,6 +5497,7 @@ fn run_openpgp(cmd: &OpenpgpCmd, debug: bool) -> Result<(), Box<dyn std::error::
         }
         OpenpgpCmd::GenerateKey {
             slot,
+            algorithm,
             yes,
             admin_pin_env,
             admin_pin_stdin,
@@ -5402,10 +5521,9 @@ fn run_openpgp(cmd: &OpenpgpCmd, debug: bool) -> Result<(), Box<dyn std::error::
                 "Generating {} key — touch the key if it blinks…",
                 slot.label()
             );
-            let key = session.generate_key(slot.to_crt())?;
-            println!("Generated {} key (RSA):", slot.label());
-            println!("  modulus:  {}", hex_encode(&key.modulus));
-            println!("  exponent: {}", hex_encode(&key.exponent));
+            let key = session.generate_key(slot.to_crt(), algorithm.map(|a| a.to_alg()))?;
+            let attrs = session.algorithm_attributes(slot.to_crt())?;
+            print_openpgp_public_key(&format!("Generated {}", slot.label()), &attrs, &key);
             // Register the key (fingerprint + creation timestamp) so gpg and
             // other OpenPGP tools recognize it. Use the host's current time as
             // the key's creation time; the card stores both, so read-back is
@@ -5516,15 +5634,15 @@ fn run_openpgp(cmd: &OpenpgpCmd, debug: bool) -> Result<(), Box<dyn std::error::
         } => {
             let data = std::fs::read(r#in)
                 .map_err(|e| format!("cannot read {}: {}", r#in.display(), e))?;
-            // PKCS#1 v1.5 DigestInfo (SHA-256 by default, SHA-1 on request): the
-            // card wraps it in EMSA padding and RSA-signs it. Both hashes are
-            // in-tree (keyroost-proto); the card signs whatever DigestInfo it gets.
-            let digest_info = hash.digest_info(&data);
             let pin = read_secret("signing PIN (PW1)", pin_env.as_deref(), *pin_stdin)?;
             let mut session = open_openpgp(reader.as_deref(), debug)?;
             session.verify_pin(keyroost_openpgp::PW1_SIGN, pin.as_bytes())?;
+            // RSA slots want a PKCS#1 v1.5 DigestInfo (the card EMSA-pads and
+            // RSA-signs it); ECDSA/EdDSA slots want the bare digest.
+            let attrs = session.algorithm_attributes(keyroost_openpgp::KeyCrt::Sign)?;
+            let input = openpgp_sign_input(&attrs, *hash, &data);
             eprintln!("Signing ({}) — touch the key if it blinks…", hash.label());
-            let sig = session.sign(&digest_info)?;
+            let sig = session.sign(&input)?;
             match out {
                 Some(path) => {
                     write_private_file(path, &sig)
@@ -5548,17 +5666,26 @@ fn run_openpgp(cmd: &OpenpgpCmd, debug: bool) -> Result<(), Box<dyn std::error::
             // Decryption authorizes under PW1 in the "other"/decipher context
             // (ref 0x82), not the signing context (0x81).
             session.verify_pin(keyroost_openpgp::PW1_OTHER, pin.as_bytes())?;
-            eprintln!("Decrypting — touch the key if it blinks…");
-            let plain = session.decrypt(&cryptogram)?;
+            let attrs = session.algorithm_attributes(keyroost_openpgp::KeyCrt::Decrypt)?;
+            let is_ecdh = matches!(
+                keyroost_openpgp::parse_algorithm_attributes(&attrs),
+                Ok(keyroost_openpgp::AlgorithmAttributes::Ecc {
+                    kind: keyroost_openpgp::EccKind::Ecdh,
+                    ..
+                })
+            );
+            let (plain, noun) = if is_ecdh {
+                eprintln!("Deriving shared secret — touch the key if it blinks…");
+                (session.decrypt_ecdh(&cryptogram)?, "shared-secret")
+            } else {
+                eprintln!("Decrypting — touch the key if it blinks…");
+                (session.decrypt(&cryptogram)?, "plaintext")
+            };
             match out {
                 Some(path) => {
                     write_private_file(path, &plain)
                         .map_err(|e| format!("cannot write {}: {}", path.display(), e))?;
-                    eprintln!(
-                        "Wrote {} plaintext bytes to {}",
-                        plain.len(),
-                        path.display()
-                    );
+                    eprintln!("Wrote {} {} bytes to {}", plain.len(), noun, path.display());
                 }
                 None => println!("{}", hex_encode(&plain)),
             }
@@ -5573,19 +5700,20 @@ fn run_openpgp(cmd: &OpenpgpCmd, debug: bool) -> Result<(), Box<dyn std::error::
         } => {
             let data = std::fs::read(r#in)
                 .map_err(|e| format!("cannot read {}: {}", r#in.display(), e))?;
-            // PKCS#1 v1.5 DigestInfo (SHA-256 by default, SHA-1 on request): the
-            // card wraps it in EMSA padding and RSA-signs it with the Auth key.
-            let digest_info = hash.digest_info(&data);
             let pin = read_secret("user PIN (PW1)", pin_env.as_deref(), *pin_stdin)?;
             let mut session = open_openpgp(reader.as_deref(), debug)?;
             // INTERNAL AUTHENTICATE authorizes under PW1 in the "other" context
             // (ref 0x82) — the same context as decipher, not the signing context.
             session.verify_pin(keyroost_openpgp::PW1_OTHER, pin.as_bytes())?;
+            // RSA slots want a PKCS#1 v1.5 DigestInfo; ECDSA/EdDSA slots want
+            // the bare digest.
+            let attrs = session.algorithm_attributes(keyroost_openpgp::KeyCrt::Auth)?;
+            let input = openpgp_sign_input(&attrs, *hash, &data);
             eprintln!(
                 "Authenticating ({}) — touch the key if it blinks…",
                 hash.label()
             );
-            let sig = session.internal_authenticate(&digest_info)?;
+            let sig = session.internal_authenticate(&input)?;
             match out {
                 Some(path) => {
                     write_private_file(path, &sig)
@@ -6341,18 +6469,6 @@ fn load_pubkey_material(
             )
         })?;
     Ok((alg, key))
-}
-
-/// Map an OpenPGP algorithm id (first attribute byte) to a short label.
-fn algo_id_str(id: Option<u8>) -> &'static str {
-    match id {
-        Some(0x01) => "RSA",
-        Some(0x12) => "ECDH",
-        Some(0x13) => "ECDSA",
-        Some(0x16) => "EdDSA",
-        Some(_) => "other",
-        None => "none",
-    }
 }
 
 /// Print a key fingerprint, rendering an all-zero (no key) slot as "(none)".
@@ -9350,6 +9466,71 @@ mod cli_tests {
     }
 
     #[test]
+    fn openpgp_generate_key_algorithm_is_optional_and_named_like_gpg() {
+        // No --algorithm: None — generate whatever the slot's attributes say
+        // (the pre-#106 behaviour, unchanged for scripts).
+        match parse(&["keyroostctl", "openpgp", "generate-key", "--yes"])
+            .unwrap()
+            .command
+        {
+            Some(Cmd::Openpgp {
+                cmd: OpenpgpCmd::GenerateKey { algorithm, .. },
+            }) => assert!(algorithm.is_none()),
+            _ => panic!("expected openpgp generate-key"),
+        }
+        for (name, want) in [
+            ("ed25519", keyroost_openpgp::KeyAlg::Ed25519),
+            ("x25519", keyroost_openpgp::KeyAlg::X25519),
+            ("cv25519", keyroost_openpgp::KeyAlg::X25519),
+            ("nistp256", keyroost_openpgp::KeyAlg::NistP256),
+            ("brainpoolp512", keyroost_openpgp::KeyAlg::BrainpoolP512r1),
+            ("rsa4096", keyroost_openpgp::KeyAlg::Rsa4096),
+        ] {
+            match parse(&[
+                "keyroostctl",
+                "openpgp",
+                "generate-key",
+                "--yes",
+                "--algorithm",
+                name,
+            ])
+            .unwrap()
+            .command
+            {
+                Some(Cmd::Openpgp {
+                    cmd:
+                        OpenpgpCmd::GenerateKey {
+                            algorithm: Some(a), ..
+                        },
+                }) => assert_eq!(a.to_alg(), want, "{name}"),
+                _ => panic!("expected openpgp generate-key --algorithm {name}"),
+            }
+        }
+        assert!(parse(&["keyroostctl", "openpgp", "algorithms"]).is_ok());
+    }
+
+    #[test]
+    fn openpgp_sign_input_framing_follows_the_slot_algorithm() {
+        let data = b"hello";
+        // RSA: PKCS#1 DigestInfo. ECC (ECDSA/EdDSA): the bare digest.
+        let rsa = [0x01, 0x08, 0x00, 0x00, 0x20, 0x02];
+        let ed = [0x16, 0x2B, 0x06, 0x01, 0x04, 0x01, 0xDA, 0x47, 0x0F, 0x01];
+        assert_eq!(
+            openpgp_sign_input(&rsa, SignHash::Sha256, data),
+            SignHash::Sha256.digest_info(data)
+        );
+        assert_eq!(
+            openpgp_sign_input(&ed, SignHash::Sha256, data),
+            keyroost_proto::sha256::sha256(data).to_vec()
+        );
+        // Unknown attributes: assume RSA (the pre-#106 behaviour).
+        assert_eq!(
+            openpgp_sign_input(&[], SignHash::Sha1, data),
+            SignHash::Sha1.digest_info(data)
+        );
+    }
+
+    #[test]
     fn molto_is_nested() {
         assert!(parse(&["keyroostctl", "molto", "info"]).is_ok());
         assert!(parse(&[
@@ -9662,9 +9843,9 @@ mod cli_tests {
         let o = json_out::OpenpgpStatusJson {
             aid: "d2760001240103040006...".into(),
             serial: Some(12345678),
-            sig_algo: "RSA".into(),
-            dec_algo: "RSA".into(),
-            aut_algo: "RSA".into(),
+            sig_algo: "RSA-2048".into(),
+            dec_algo: "RSA-2048".into(),
+            aut_algo: "RSA-2048".into(),
             fingerprint_sig: Some("aabb...".into()),
             fingerprint_dec: None,
             fingerprint_aut: None,

--- a/crates/keyroostctl/src/main.rs
+++ b/crates/keyroostctl/src/main.rs
@@ -1117,7 +1117,9 @@ enum OpenpgpCmd {
     /// Sign a file with the on-card signature key (PSO:CDS). Hashes the input
     /// (SHA-256 by default, or SHA-1 via `--hash`). RSA slots sign a PKCS#1
     /// DigestInfo; ECC slots sign the bare digest. Requires the signing PIN
-    /// (PW1) and, on a YubiKey, a touch.
+    /// (PW1) and, on a YubiKey, a touch. The output is the card's raw
+    /// signature: PKCS#1 for RSA, `r||s` (not DER) for ECDSA, `R||S` for
+    /// Ed25519.
     Sign {
         /// File whose contents to sign.
         #[arg(long, value_name = "FILE")]
@@ -1164,7 +1166,8 @@ enum OpenpgpCmd {
     /// Authentication key (INTERNAL AUTHENTICATE). Hashes the input (SHA-256 by
     /// default, or SHA-1 via `--hash`). RSA slots sign a PKCS#1 DigestInfo; ECC
     /// slots sign the bare digest. Requires the user PIN (PW1) and, on a
-    /// YubiKey, a touch.
+    /// YubiKey, a touch. The output is the card's raw signature: PKCS#1 for
+    /// RSA, `r||s` (not DER) for ECDSA, `R||S` for Ed25519.
     Authenticate {
         /// File whose contents to authenticate-sign.
         #[arg(long, value_name = "FILE")]
@@ -5346,14 +5349,38 @@ fn oath_algo_str(a: keyroost_oath::Algorithm) -> &'static str {
     }
 }
 
-/// What to hand the card for a signature: RSA slots take a PKCS#1 DigestInfo;
-/// ECDSA and EdDSA slots take the bare digest (the card signs those bytes
-/// directly — GnuPG does the same). Attributes that don't parse are treated
-/// as RSA, the only kind that existed before #106.
-fn openpgp_sign_input(slot_attrs: &[u8], hash: SignHash, data: &[u8]) -> Vec<u8> {
-    match keyroost_openpgp::parse_algorithm_attributes(slot_attrs) {
-        Ok(keyroost_openpgp::AlgorithmAttributes::Ecc { .. }) => hash.digest(data),
-        _ => hash.digest_info(data),
+/// What to hand the card for a signature: RSA slots (algorithm id `0x01`)
+/// take a PKCS#1 DigestInfo; ECDSA/EdDSA slots (`0x12`/`0x13`/`0x16`) take the
+/// bare digest (the card signs those bytes directly — GnuPG does the same).
+/// Framing is keyed off the algorithm-id byte alone; attributes this crate
+/// can't identify (including an empty object) are an error, not a guess.
+fn openpgp_sign_input(
+    slot_label: &str,
+    slot_attrs: &[u8],
+    hash: SignHash,
+    data: &[u8],
+) -> Result<Vec<u8>, String> {
+    match slot_attrs.first() {
+        Some(0x01) => Ok(hash.digest_info(data)),
+        Some(0x12 | 0x13 | 0x16) => {
+            let is_ecc = matches!(
+                keyroost_openpgp::parse_algorithm_attributes(slot_attrs),
+                Ok(keyroost_openpgp::AlgorithmAttributes::Ecc { .. })
+            );
+            if is_ecc && matches!(hash, SignHash::Sha1) {
+                return Err(
+                    "SHA-1 cannot be used with an ECC signing key (OpenPGP requires a \
+                     256-bit or wider hash for Ed25519/ECDSA); use --hash sha256"
+                        .to_string(),
+                );
+            }
+            Ok(hash.digest(data))
+        }
+        _ => Err(format!(
+            "cannot tell the {slot_label} slot's algorithm from the card's attributes ({}); \
+             refusing to guess how to frame the input",
+            hex_encode(slot_attrs)
+        )),
     }
 }
 
@@ -5510,6 +5537,9 @@ fn run_openpgp(cmd: &OpenpgpCmd, debug: bool) -> Result<(), Box<dyn std::error::
                 )
                 .into());
             }
+            if let Some(a) = algorithm {
+                a.to_alg().attributes(slot.to_crt())?;
+            }
             let admin_pin = read_secret(
                 "admin PIN (PW3)",
                 admin_pin_env.as_deref(),
@@ -5640,7 +5670,7 @@ fn run_openpgp(cmd: &OpenpgpCmd, debug: bool) -> Result<(), Box<dyn std::error::
             // RSA slots want a PKCS#1 v1.5 DigestInfo (the card EMSA-pads and
             // RSA-signs it); ECDSA/EdDSA slots want the bare digest.
             let attrs = session.algorithm_attributes(keyroost_openpgp::KeyCrt::Sign)?;
-            let input = openpgp_sign_input(&attrs, *hash, &data);
+            let input = openpgp_sign_input("signature", &attrs, *hash, &data)?;
             eprintln!("Signing ({}) — touch the key if it blinks…", hash.label());
             let sig = session.sign(&input)?;
             match out {
@@ -5667,19 +5697,26 @@ fn run_openpgp(cmd: &OpenpgpCmd, debug: bool) -> Result<(), Box<dyn std::error::
             // (ref 0x82), not the signing context (0x81).
             session.verify_pin(keyroost_openpgp::PW1_OTHER, pin.as_bytes())?;
             let attrs = session.algorithm_attributes(keyroost_openpgp::KeyCrt::Decrypt)?;
-            let is_ecdh = matches!(
-                keyroost_openpgp::parse_algorithm_attributes(&attrs),
-                Ok(keyroost_openpgp::AlgorithmAttributes::Ecc {
-                    kind: keyroost_openpgp::EccKind::Ecdh,
-                    ..
-                })
-            );
-            let (plain, noun) = if is_ecdh {
-                eprintln!("Deriving shared secret — touch the key if it blinks…");
-                (session.decrypt_ecdh(&cryptogram)?, "shared-secret")
-            } else {
-                eprintln!("Decrypting — touch the key if it blinks…");
-                (session.decrypt(&cryptogram)?, "plaintext")
+            // Framing is keyed off the algorithm-id byte alone: 0x12 (ECDH)
+            // derives a shared secret, 0x01 (RSA) decrypts. Anything else
+            // (including empty attributes) is refused rather than guessed.
+            let (plain, noun) = match attrs.first() {
+                Some(0x12) => {
+                    eprintln!("Deriving shared secret — touch the key if it blinks…");
+                    (session.decrypt_ecdh(&cryptogram)?, "shared-secret")
+                }
+                Some(0x01) => {
+                    eprintln!("Decrypting — touch the key if it blinks…");
+                    (session.decrypt(&cryptogram)?, "plaintext")
+                }
+                _ => {
+                    return Err(format!(
+                        "cannot tell the decryption slot's algorithm from the card's \
+                         attributes ({}); refusing to guess how to frame the input",
+                        hex_encode(&attrs)
+                    )
+                    .into());
+                }
             };
             match out {
                 Some(path) => {
@@ -5708,7 +5745,7 @@ fn run_openpgp(cmd: &OpenpgpCmd, debug: bool) -> Result<(), Box<dyn std::error::
             // RSA slots want a PKCS#1 v1.5 DigestInfo; ECDSA/EdDSA slots want
             // the bare digest.
             let attrs = session.algorithm_attributes(keyroost_openpgp::KeyCrt::Auth)?;
-            let input = openpgp_sign_input(&attrs, *hash, &data);
+            let input = openpgp_sign_input("authentication", &attrs, *hash, &data)?;
             eprintln!(
                 "Authenticating ({}) — touch the key if it blinks…",
                 hash.label()
@@ -9514,19 +9551,31 @@ mod cli_tests {
         let data = b"hello";
         // RSA: PKCS#1 DigestInfo. ECC (ECDSA/EdDSA): the bare digest.
         let rsa = [0x01, 0x08, 0x00, 0x00, 0x20, 0x02];
+        let ecdsa = [0x13, 0x2A, 0x86, 0x48, 0xCE, 0x3D, 0x03, 0x01, 0x07];
         let ed = [0x16, 0x2B, 0x06, 0x01, 0x04, 0x01, 0xDA, 0x47, 0x0F, 0x01];
         assert_eq!(
-            openpgp_sign_input(&rsa, SignHash::Sha256, data),
+            openpgp_sign_input("signature", &rsa, SignHash::Sha256, data).unwrap(),
             SignHash::Sha256.digest_info(data)
         );
         assert_eq!(
-            openpgp_sign_input(&ed, SignHash::Sha256, data),
+            openpgp_sign_input("signature", &ecdsa, SignHash::Sha256, data).unwrap(),
             keyroost_proto::sha256::sha256(data).to_vec()
         );
-        // Unknown attributes: assume RSA (the pre-#106 behaviour).
         assert_eq!(
-            openpgp_sign_input(&[], SignHash::Sha1, data),
-            SignHash::Sha1.digest_info(data)
+            openpgp_sign_input("signature", &ed, SignHash::Sha256, data).unwrap(),
+            keyroost_proto::sha256::sha256(data).to_vec()
+        );
+        // Unknown / empty attributes: refuse to guess rather than assume RSA.
+        let err = openpgp_sign_input("signature", &[], SignHash::Sha1, data).unwrap_err();
+        assert!(
+            err.contains("cannot tell the signature slot's algorithm"),
+            "{err}"
+        );
+        // SHA-1 is refused on an ECC signing key.
+        let err = openpgp_sign_input("signature", &ed, SignHash::Sha1, data).unwrap_err();
+        assert!(
+            err.contains("SHA-1 cannot be used with an ECC signing key"),
+            "{err}"
         );
     }
 

--- a/docs/openpgp.html
+++ b/docs/openpgp.html
@@ -101,23 +101,27 @@
     <div class="kr-tool">
       <span class="kr-mark mono">k</span>
       <p>Read card status and a slot's <strong>public key</strong>, and <strong>verify</strong>
-        a PIN without changing anything; <strong>generate</strong> or <strong>import</strong>
-        RSA keys — RSA-2048 on a factory card, since on-card generation follows the slot's own
-        algorithm attributes — by host keygen or from a PKCS#1/PKCS#8 PEM/DER file, for the
-        sign, encrypt, or <strong>auth</strong> slot (<code>--slot auth</code>);
-        <strong>sign</strong> (SHA-256 or
+        a PIN without changing anything; <strong>generate</strong> keys on-card in any
+        algorithm the card accepts — RSA 2048/3072/4096, Ed25519, X25519, NIST P-256/384/521,
+        secp256k1, brainpool — the choice offered from the card's own algorithm list
+        (<code>keyroostctl openpgp algorithms</code>), or <strong>import</strong> an RSA key by
+        host keygen or from a PKCS#1/PKCS#8 PEM/DER file, for the sign, encrypt, or
+        <strong>auth</strong> slot (<code>--slot auth</code>); <strong>sign</strong> (SHA-256 or
         SHA-1), <strong>decrypt</strong>, and <strong>authenticate</strong> (client/SSH
         signature with the Authentication key); set cardholder name / URL; register a key for
         GnuPG; <strong>change the user or admin PIN</strong> and <strong>unblock a
         locked PIN</strong> (via the admin PIN / PW3); and factory-reset the applet.</p>
     </div>
 <pre><code>keyroostctl openpgp status --reader yubikey
+keyroostctl openpgp generate-key --slot sign --algorithm ed25519 --yes --admin-pin-stdin --reader yubikey
 keyroostctl openpgp sign --in msg.txt --pin-stdin --reader yubikey
 keyroostctl openpgp authenticate --in chal.bin --pin-stdin --reader yubikey
 keyroostctl openpgp change-pin --old-pin-stdin --new-pin-stdin --reader yubikey</code></pre>
     <p class="kr-muted">The card byte layer is a pure-Rust, in-tree implementation of the
       OpenPGP Card spec (APDU + BER-TLV); RSA keygen/parsing is the one scoped host-side
-      dependency.</p>
+      dependency. Host-side import of ECC keys and local signature verification are not
+      offered; they would need new cryptographic dependencies, which this project adds only
+      deliberately.</p>
   </section>
 
   <section class="kr-section kr-res-section">

--- a/docs/openpgp.html
+++ b/docs/openpgp.html
@@ -110,7 +110,10 @@
         SHA-1), <strong>decrypt</strong>, and <strong>authenticate</strong> (client/SSH
         signature with the Authentication key); set cardholder name / URL; register a key for
         GnuPG; <strong>change the user or admin PIN</strong> and <strong>unblock a
-        locked PIN</strong> (via the admin PIN / PW3); and factory-reset the applet.</p>
+        locked PIN</strong> (via the admin PIN / PW3); and factory-reset the applet. The
+        output of <code>sign</code>/<code>authenticate</code> is the card's raw signature:
+        PKCS#1 for RSA, <code>r||s</code> (not DER) for ECDSA, <code>R||S</code> for
+        Ed25519.</p>
     </div>
 <pre><code>keyroostctl openpgp status --reader yubikey
 keyroostctl openpgp generate-key --slot sign --algorithm ed25519 --yes --admin-pin-stdin --reader yubikey

--- a/fuzz/fuzz_targets/openpgp_parse.rs
+++ b/fuzz/fuzz_targets/openpgp_parse.rs
@@ -9,4 +9,6 @@ fuzz_target!(|data: &[u8]| {
     let _ = keyroost_openpgp::parse_signature_counter(data);
     let _ = keyroost_openpgp::parse_generated_public_key(data);
     let _ = keyroost_openpgp::parse_rsa_algorithm_attributes(data);
+    let _ = keyroost_openpgp::parse_algorithm_attributes(data);
+    let _ = keyroost_openpgp::describe_algorithm_attributes(data);
 });

--- a/fuzz/fuzz_targets/openpgp_parse.rs
+++ b/fuzz/fuzz_targets/openpgp_parse.rs
@@ -11,4 +11,5 @@ fuzz_target!(|data: &[u8]| {
     let _ = keyroost_openpgp::parse_rsa_algorithm_attributes(data);
     let _ = keyroost_openpgp::parse_algorithm_attributes(data);
     let _ = keyroost_openpgp::describe_algorithm_attributes(data);
+    let _ = keyroost_openpgp::parse_algorithm_information(data);
 });


### PR DESCRIPTION
The OpenPGP applet could only generate a slot's factory default (RSA-2048). This sets the slot's algorithm before GENERATE — only when it differs, since the write wipes the slot — offers the card's own algorithm list (DO FA) in the CLI and GUI, and adds ECC fingerprints, the ECDH decipher template, and ECC-aware sign/authenticate/decrypt/status. Zero new dependencies.

Verified on a YubiKey 5.7: OpenSSL verifies the card's Ed25519 and P-256 signatures and the X25519 shared secret; GnuPG, building keys from the card, computes fingerprints identical to the ones keyroost registers. RSA generate/sign/import unchanged.

Library API changes (recorded in CHANGELOG): PublicKey is an enum, generate_key takes an optional algorithm, rsa_v4_fingerprint_from is replaced by v4_fingerprint, OpenPgpStatus carries raw attributes, TransportError gains two variants.

re #106

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SQv9x6xi3CxXs2PvXohaFu
