### PR TITLE
Wire PIV module into activity log, including APDU trace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- **The activity log now covers PIV.** User actions and background reads
+  are told apart, and with tracing on each APDU appears by name (for example
+  `GET DATA 5FC105`) with the same redaction as `--debug`. The log can be
+  detached into its own window and cleared. Contributed by @episource.
+  ([#114])
 - **OpenPGP keys in modern algorithms.** `openpgp generate-key --algorithm`
   (and the GUI's Generate dialog) can set a slot to Ed25519, X25519, NIST
   P-256/384/521, secp256k1, brainpool 256/384/512, or RSA 2048/3072/4096
@@ -52,6 +57,8 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   variant (an exhaustive `match` needs a new arm).
 
 ### Fixed
+- The PIV slot tabs wrap instead of overflowing in a narrow window.
+  Contributed by @episource. ([#114])
 - **PIV cards that answer GET VERSION with more than three bytes can now be
   managed.** The Swissbit iShield Key 2 Pro replies to the Yubico version
   extension with four bytes; keyroost rejected the reply and with it the
@@ -971,6 +978,7 @@ multi-vendor hardware-security-key manager, then took its neutral name. Highligh
 [#106]: https://github.com/framefilter/keyroost/issues/106
 [#107]: https://github.com/framefilter/keyroost/issues/107
 [#110]: https://github.com/framefilter/keyroost/pull/110
+[#114]: https://github.com/framefilter/keyroost/pull/114
 [Unreleased]: https://github.com/framefilter/keyroost/compare/v0.8.0...HEAD
 [0.8.0]: https://github.com/framefilter/keyroost/compare/v0.7.8...v0.8.0
 [0.7.8]: https://github.com/framefilter/keyroost/compare/v0.7.7...v0.7.8

--- a/crates/keyroost-piv/src/lib.rs
+++ b/crates/keyroost-piv/src/lib.rs
@@ -1577,7 +1577,10 @@ mod tests {
             assert_eq!(Instruction::from_code(ins.code()), Some(ins));
             assert!(!ins.name().is_empty());
         }
-        assert_eq!(Instruction::GetVersion.name(), "GET VERSION (yubico extension)");
+        assert_eq!(
+            Instruction::GetVersion.name(),
+            "GET VERSION (yubico extension)"
+        );
         assert_eq!(Instruction::Select.name(), "SELECT");
         assert_eq!(Instruction::from_code(0x00), None);
     }
@@ -1588,7 +1591,10 @@ mod tests {
             data_object_name(&[0x5F, 0xC1, 0x05]).as_deref(),
             Some("X.509 Certificate for PIV Authentication")
         );
-        assert_eq!(data_object_name(&[0x7E]).as_deref(), Some("Discovery Object"));
+        assert_eq!(
+            data_object_name(&[0x7E]).as_deref(),
+            Some("Discovery Object")
+        );
         // Numbered ranges: 5F C1 0D..20 -> Retired 1..20; 5F FF 11..15 -> MSROOTS 1..5.
         assert_eq!(
             data_object_name(&Slot::Retired(1).cert_object_tag()).as_deref(),

--- a/crates/keyroost-piv/src/lib.rs
+++ b/crates/keyroost-piv/src/lib.rs
@@ -123,6 +123,59 @@ impl Instruction {
     pub const fn code(self) -> u8 {
         self as u8
     }
+
+    /// Recognise a raw INS byte. `None` for any instruction this crate does not
+    /// build. Note `0xF6` (MOVE KEY) doubles as DELETE KEY via a `P1 == 0xFF`
+    /// sentinel — the byte alone can't tell them apart; see the `--debug` trace
+    /// labelling in `keyroost-transport` for that distinction.
+    #[must_use]
+    pub const fn from_code(code: u8) -> Option<Self> {
+        Some(match code {
+            0xA4 => Self::Select,
+            0x20 => Self::Verify,
+            0xCB => Self::GetData,
+            0xC0 => Self::GetResponse,
+            0x87 => Self::GeneralAuthenticate,
+            0x47 => Self::GenerateKeyPair,
+            0xDB => Self::PutData,
+            0x24 => Self::ChangeReference,
+            0x2C => Self::ResetRetryCounter,
+            0xFD => Self::GetVersion,
+            0xF8 => Self::GetSerial,
+            0xF7 => Self::GetMetadata,
+            0xF6 => Self::MoveKey,
+            0xFF => Self::SetManagementKey,
+            0xFA => Self::SetPinRetries,
+            0xFB => Self::Reset,
+            0xF9 => Self::Attest,
+            _ => return None,
+        })
+    }
+
+    /// Human-readable command name, for the `--debug` / activity-log APDU trace.
+    /// Yubico's proprietary instructions are marked as such.
+    #[must_use]
+    pub const fn name(self) -> &'static str {
+        match self {
+            Self::Select => "SELECT",
+            Self::Verify => "VERIFY",
+            Self::GetData => "GET DATA",
+            Self::GetResponse => "GET RESPONSE",
+            Self::GeneralAuthenticate => "GENERAL AUTHENTICATE",
+            Self::GenerateKeyPair => "GENERATE ASYMMETRIC KEY PAIR",
+            Self::PutData => "PUT DATA",
+            Self::ChangeReference => "CHANGE REFERENCE DATA",
+            Self::ResetRetryCounter => "RESET RETRY COUNTER",
+            Self::GetVersion => "GET VERSION (yubico extension)",
+            Self::GetSerial => "GET SERIAL (yubico extension)",
+            Self::GetMetadata => "GET METADATA (yubico extension)",
+            Self::MoveKey => "MOVE KEY (yubico extension)",
+            Self::SetManagementKey => "SET MANAGEMENT KEY (yubico extension)",
+            Self::SetPinRetries => "SET PIN RETRIES (yubico extension)",
+            Self::Reset => "RESET (yubico extension)",
+            Self::Attest => "ATTEST (yubico extension)",
+        }
+    }
 }
 
 const INS_SELECT_P1_BY_AID: u8 = 0x04;
@@ -570,6 +623,49 @@ pub fn get_data(tag: &[u8]) -> Vec<u8> {
     );
     apdu.push(0x00); // case-4 Le
     apdu
+}
+
+/// Human-readable name for a PIV data-object tag — the BER tag a GET DATA / PUT
+/// DATA command carries in its `5C` field. Covers the SP 800-73-4 Part 1
+/// objects and the Yubico extension objects that PivApplet / OpenFIPS201 also
+/// follow; `None` for a tag with no assigned name, which the caller renders as
+/// raw hex. Diagnostic only (activity-log / `--debug` trace labelling).
+#[must_use]
+pub fn data_object_name(tag: &[u8]) -> Option<String> {
+    // Numbered ranges first: retired key-management certs 1..20 sit at
+    // `5F C1 0D..=5F C1 20` (Slot::Retired(n) -> 5F C1 0C+n), and Yubico's
+    // MSROOTS 1..5 at `5F FF 11..=5F FF 15`.
+    if let [0x5F, 0xC1, n @ 0x0D..=0x20] = tag {
+        return Some(format!(
+            "Retired X.509 Certificate for Key Management {}",
+            n - 0x0C
+        ));
+    }
+    if let [0x5F, 0xFF, n @ 0x11..=0x15] = tag {
+        return Some(format!("Yubico MSROOTS {}", n - 0x10));
+    }
+    let name = match tag {
+        [0x7E] => "Discovery Object",
+        [0x5F, 0xC1, 0x01] => "X.509 Certificate for Card Authentication",
+        [0x5F, 0xC1, 0x02] => "Card Holder Unique Identifier",
+        [0x5F, 0xC1, 0x03] => "Cardholder Fingerprints",
+        [0x5F, 0xC1, 0x05] => "X.509 Certificate for PIV Authentication",
+        [0x5F, 0xC1, 0x06] => "Security Object",
+        [0x5F, 0xC1, 0x07] => "Card Capability Container",
+        [0x5F, 0xC1, 0x08] => "Cardholder Facial Image",
+        [0x5F, 0xC1, 0x09] => "Printed Information",
+        [0x5F, 0xC1, 0x0A] => "X.509 Certificate for Digital Signature",
+        [0x5F, 0xC1, 0x0B] => "X.509 Certificate for Key Management",
+        [0x5F, 0xC1, 0x0C] => "Key History Object",
+        [0x5F, 0xC1, 0x21] => "Cardholder Iris Images",
+        [0x5F, 0xC1, 0x22] => "Biometric Information Templates Group Template",
+        [0x5F, 0xC1, 0x23] => "Secure Messaging Certificate Signer",
+        [0x5F, 0xC1, 0x24] => "Pairing Code Reference Data Container",
+        [0x5F, 0xFF, 0x01] => "Yubico PIV Attestation Certificate",
+        [0x5F, 0xFF, 0x10] => "Yubico MSCMAP",
+        _ => return None,
+    };
+    Some(name.to_string())
 }
 
 /// VERIFY the application PIN. The PIN is padded to 8 bytes with `0xFF` per
@@ -1453,6 +1549,66 @@ mod tests {
             select(),
             vec![0x00, 0xA4, 0x04, 0x00, 0x05, 0xA0, 0x00, 0x00, 0x03, 0x08, 0x00]
         );
+    }
+
+    #[test]
+    fn instruction_code_round_trips_to_a_name() {
+        // Every instruction this crate builds decodes from its own byte and
+        // carries a non-empty human name; Yubico extensions say so.
+        for ins in [
+            Instruction::Select,
+            Instruction::Verify,
+            Instruction::GetData,
+            Instruction::GetResponse,
+            Instruction::GeneralAuthenticate,
+            Instruction::GenerateKeyPair,
+            Instruction::PutData,
+            Instruction::ChangeReference,
+            Instruction::ResetRetryCounter,
+            Instruction::GetVersion,
+            Instruction::GetSerial,
+            Instruction::GetMetadata,
+            Instruction::MoveKey,
+            Instruction::SetManagementKey,
+            Instruction::SetPinRetries,
+            Instruction::Reset,
+            Instruction::Attest,
+        ] {
+            assert_eq!(Instruction::from_code(ins.code()), Some(ins));
+            assert!(!ins.name().is_empty());
+        }
+        assert_eq!(Instruction::GetVersion.name(), "GET VERSION (yubico extension)");
+        assert_eq!(Instruction::Select.name(), "SELECT");
+        assert_eq!(Instruction::from_code(0x00), None);
+    }
+
+    #[test]
+    fn data_object_names() {
+        assert_eq!(
+            data_object_name(&[0x5F, 0xC1, 0x05]).as_deref(),
+            Some("X.509 Certificate for PIV Authentication")
+        );
+        assert_eq!(data_object_name(&[0x7E]).as_deref(), Some("Discovery Object"));
+        // Numbered ranges: 5F C1 0D..20 -> Retired 1..20; 5F FF 11..15 -> MSROOTS 1..5.
+        assert_eq!(
+            data_object_name(&Slot::Retired(1).cert_object_tag()).as_deref(),
+            Some("Retired X.509 Certificate for Key Management 1")
+        );
+        assert_eq!(
+            data_object_name(&Slot::Retired(20).cert_object_tag()).as_deref(),
+            Some("Retired X.509 Certificate for Key Management 20")
+        );
+        assert_eq!(
+            data_object_name(&[0x5F, 0xFF, 0x13]).as_deref(),
+            Some("Yubico MSROOTS 3")
+        );
+        assert_eq!(
+            data_object_name(&[0x5F, 0xFF, 0x01]).as_deref(),
+            Some("Yubico PIV Attestation Certificate")
+        );
+        // Unassigned tags have no name.
+        assert_eq!(data_object_name(&[0x5F, 0xC1, 0x99]), None);
+        assert_eq!(data_object_name(&[]), None);
     }
 
     #[test]

--- a/crates/keyroost-transport/src/lib.rs
+++ b/crates/keyroost-transport/src/lib.rs
@@ -1240,6 +1240,39 @@ pub(crate) fn sw_tries_remaining(sw: u16) -> Option<u8> {
     ((sw & 0xFFF0) == 0x63C0).then_some((sw & 0x000F) as u8)
 }
 
+/// A short plain-language reading of an ISO 7816-4 status word, for the trace's
+/// `< … << SW = …` annotation line (emitted only for applets that opt into
+/// command labelling via [`AppletIo::describe`]). Covers the status words the
+/// PIV applets actually return; anything else is reported as non-standard
+/// rather than guessed at.
+pub(crate) fn iso_sw_summary(sw1: u8, sw2: u8) -> &'static str {
+    match (sw1, sw2) {
+        (0x90, 0x00) => "success",
+        (0x61, _) => "success — more response bytes pending, GET RESPONSE needed",
+        (0x63, 0x00) => "verification failed",
+        (0x63, n) if n & 0xF0 == 0xC0 => {
+            "verification failed — retries remaining in SW2 low nibble"
+        }
+        (0x69, 0x82) => "security status not satisfied — authenticate first",
+        (0x69, 0x83) => "authentication method blocked",
+        (0x69, 0x85) => "conditions of use not satisfied",
+        (0x69, 0x86) => "command not allowed",
+        (0x6A, 0x80) => "incorrect parameters in the command data field",
+        (0x6A, 0x81) => "function not supported",
+        (0x6A, 0x82) => "file or application not found",
+        (0x6A, 0x84) => "not enough memory",
+        (0x6A, 0x86) => "incorrect P1/P2",
+        (0x6A, 0x88) => "referenced data not found",
+        (0x67, 0x00) => "wrong length",
+        (0x6C, _) => "wrong Le — reissue with the length in SW2",
+        (0x6D, 0x00) => "instruction not supported or invalid",
+        (0x6E, 0x00) => "class not supported",
+        (0x68, 0x82) => "secure messaging not supported",
+        (0x6F, 0x00) => "no precise diagnosis",
+        _ => "non-standard status word",
+    }
+}
+
 /// Decode the remaining-attempts counter from SW2 of a Molto2 `63xx`
 /// auth-failure.
 ///
@@ -1268,11 +1301,18 @@ pub(crate) fn dump_resp(resp: &[u8], sensitive: bool) -> String {
 }
 
 /// Static per-applet plumbing for [`transmit_applet`]: the trace label, the
-/// SW1 byte that signals more data pending, and the continuation-APDU builder.
+/// SW1 byte that signals more data pending, the continuation-APDU builder, and
+/// an optional command-namer.
 pub(crate) struct AppletIo {
     pub label: &'static str,
     pub more_data_sw: u8,
     pub get_response: fn() -> Vec<u8>,
+    /// When set, each transmitted APDU (the caller's command *and* every GET
+    /// RESPONSE / Le-corrected reissue) gets two extra trace lines: a `>` line
+    /// naming the command via this function, and a `<` line reading its status
+    /// word ([`iso_sw_summary`]). `None` leaves the applet's trace as bare
+    /// `>`/`<` hex.
+    pub describe: Option<fn(&[u8]) -> String>,
 }
 
 /// What [`transmit_applet`] should do after one exchange, given the status word.
@@ -1384,6 +1424,9 @@ pub(crate) fn transmit_applet(
     let mut to_send = zeroize::Zeroizing::new(apdu.to_vec());
     let mut chunks = 0usize;
     loop {
+        if let Some(describe) = io.describe {
+            trace::line(debug, || format!("> {:>14} >> {}", io.label, describe(&to_send)));
+        }
         trace::line(debug, || {
             format!(
                 "> {:>14} >> {}",
@@ -1404,6 +1447,16 @@ pub(crate) fn transmit_applet(
             });
         }
         let (data, sw) = resp.split_at(resp.len() - 2);
+        if io.describe.is_some() {
+            let (sw1, sw2) = (sw[0], sw[1]);
+            trace::line(debug, || {
+                format!(
+                    "< {:>14} << SW = {sw1:02X} {sw2:02X} ({})",
+                    io.label,
+                    iso_sw_summary(sw1, sw2)
+                )
+            });
+        }
         chunks += 1;
         if chunks > MAX_RESPONSE_CHUNKS {
             return Err(TransportError::MalformedResponse(
@@ -1450,6 +1503,17 @@ mod redaction_tests {
         assert_eq!(classify_sw(0x90, 0x61, 0x00), SwAction::Done); // 9000 OK
         assert_eq!(classify_sw(0x6A, 0x61, 0x82), SwAction::Done); // 6A82 not found
         assert_eq!(classify_sw(0x69, 0x61, 0x83), SwAction::Done); // 6983 blocked
+    }
+
+    #[test]
+    fn iso_sw_summary_reads_common_status_words() {
+        assert_eq!(iso_sw_summary(0x90, 0x00), "success");
+        assert_eq!(iso_sw_summary(0x6A, 0x82), "file or application not found");
+        assert_eq!(iso_sw_summary(0x69, 0x82), "security status not satisfied — authenticate first");
+        assert!(iso_sw_summary(0x61, 0x11).starts_with("success"));
+        assert!(iso_sw_summary(0x63, 0xC3).starts_with("verification failed"));
+        assert!(iso_sw_summary(0x6C, 0x20).starts_with("wrong Le"));
+        assert_eq!(iso_sw_summary(0x12, 0x34), "non-standard status word");
     }
 
     /// A `6Cxx` on the case-2 GET DATA APDU that OpenPGP `status()` sends

--- a/crates/keyroost-transport/src/lib.rs
+++ b/crates/keyroost-transport/src/lib.rs
@@ -48,6 +48,11 @@ pub use token2otp::{
     Token2OtpSession,
 };
 
+/// Opt-in per-thread APDU trace capture, for front ends that want the wire
+/// exchange behind one operation rather than only a stderr stream. See the
+/// module doc for why this is thread-local instead of a passed-in sink.
+pub mod trace;
+
 /// Re-exported so front-ends can name a key slot without depending on
 /// `keyroost-openpgp` directly (which would duplicate the crate in their graph).
 pub use keyroost_openpgp::{
@@ -426,18 +431,18 @@ impl Session {
     /// Send a pre-built Command and return the response payload (without the SW1/SW2 trailer).
     /// Returns an error if the device responds with anything other than `9000`.
     fn transmit(&mut self, cmd: &Command) -> Result<Vec<u8>, TransportError> {
-        if self.debug {
-            eprintln!(
+        trace::line(self.debug, || {
+            format!(
                 "> {:>20} >> {}",
                 cmd.label,
                 dump_cmd(&cmd.apdu, molto2_cmd_sensitive(&cmd.apdu))
-            );
-        }
+            )
+        });
         let mut buf = [0u8; 2048];
         let response = self.card.transmit(&cmd.apdu, &mut buf)?;
-        if self.debug {
-            eprintln!("< {:>20} << {}", cmd.label, hex_dump(response));
-        }
+        trace::line(self.debug, || {
+            format!("< {:>20} << {}", cmd.label, hex_dump(response))
+        });
         if response.len() < 2 {
             return Err(TransportError::ShortResponse {
                 label: cmd.label,
@@ -465,18 +470,18 @@ impl Session {
     /// Send a Command but allow non-9000 status words. Returns `(data, sw1, sw2)`.
     /// Used for the probing subcommand.
     pub fn transmit_raw(&mut self, cmd: &Command) -> Result<(Vec<u8>, u8, u8), TransportError> {
-        if self.debug {
-            eprintln!(
+        trace::line(self.debug, || {
+            format!(
                 "> {:>20} >> {}",
                 cmd.label,
                 dump_cmd(&cmd.apdu, molto2_cmd_sensitive(&cmd.apdu))
-            );
-        }
+            )
+        });
         let mut buf = [0u8; 2048];
         let response = self.card.transmit(&cmd.apdu, &mut buf)?;
-        if self.debug {
-            eprintln!("< {:>20} << {}", cmd.label, hex_dump(response));
-        }
+        trace::line(self.debug, || {
+            format!("< {:>20} << {}", cmd.label, hex_dump(response))
+        });
         if response.len() < 2 {
             return Err(TransportError::ShortResponse {
                 label: cmd.label,
@@ -1379,18 +1384,18 @@ pub(crate) fn transmit_applet(
     let mut to_send = zeroize::Zeroizing::new(apdu.to_vec());
     let mut chunks = 0usize;
     loop {
-        if debug {
-            eprintln!(
+        trace::line(debug, || {
+            format!(
                 "> {:>14} >> {}",
                 io.label,
                 dump_cmd(&to_send, cmd_sensitive)
-            );
-        }
+            )
+        });
         let mut buf = [0u8; 4096];
         let resp = card.transmit(&to_send, &mut buf)?;
-        if debug {
-            eprintln!("< {:>14} << {}", io.label, dump_resp(resp, resp_sensitive));
-        }
+        trace::line(debug, || {
+            format!("< {:>14} << {}", io.label, dump_resp(resp, resp_sensitive))
+        });
         if resp.len() < 2 {
             return Err(TransportError::ShortResponse {
                 label: io.label,

--- a/crates/keyroost-transport/src/lib.rs
+++ b/crates/keyroost-transport/src/lib.rs
@@ -1425,7 +1425,9 @@ pub(crate) fn transmit_applet(
     let mut chunks = 0usize;
     loop {
         if let Some(describe) = io.describe {
-            trace::line(debug, || format!("> {:>14} >> {}", io.label, describe(&to_send)));
+            trace::line(debug, || {
+                format!("> {:>14} >> {}", io.label, describe(&to_send))
+            });
         }
         trace::line(debug, || {
             format!(
@@ -1509,7 +1511,10 @@ mod redaction_tests {
     fn iso_sw_summary_reads_common_status_words() {
         assert_eq!(iso_sw_summary(0x90, 0x00), "success");
         assert_eq!(iso_sw_summary(0x6A, 0x82), "file or application not found");
-        assert_eq!(iso_sw_summary(0x69, 0x82), "security status not satisfied — authenticate first");
+        assert_eq!(
+            iso_sw_summary(0x69, 0x82),
+            "security status not satisfied — authenticate first"
+        );
         assert!(iso_sw_summary(0x61, 0x11).starts_with("success"));
         assert!(iso_sw_summary(0x63, 0xC3).starts_with("verification failed"));
         assert!(iso_sw_summary(0x6C, 0x20).starts_with("wrong Le"));

--- a/crates/keyroost-transport/src/oath.rs
+++ b/crates/keyroost-transport/src/oath.rs
@@ -241,6 +241,7 @@ impl OathSession {
             label: "oath",
             more_data_sw: oath::SW_MORE_DATA,
             get_response: oath::send_remaining,
+            describe: None,
         };
         crate::transmit_applet(
             &self.card,

--- a/crates/keyroost-transport/src/openpgp.rs
+++ b/crates/keyroost-transport/src/openpgp.rs
@@ -10,7 +10,7 @@
 //! PIN verification/changes, key generation and import, PSO signing/decryption,
 //! and factory reset.
 
-use crate::TransportError;
+use crate::{trace, TransportError};
 use keyroost_openpgp as pgp;
 use pcsc::{Card, Context, Protocols, Scope, ShareMode};
 use zeroize::Zeroizing;
@@ -352,14 +352,16 @@ impl OpenPgpSession {
             if sw != 0x6700 && sw != 0x6883 {
                 return ok_or_apdu("openpgp import key", sw);
             }
-            if self.debug {
-                eprintln!(
+            trace::line(self.debug, || {
+                format!(
                     "! openpgp import: extended length rejected (SW={sw:04X}); \
                      retrying with command chaining"
-                );
-            }
-        } else if self.debug {
-            eprintln!("! openpgp import: forcing command chaining (env override)");
+                )
+            });
+        } else {
+            trace::line(self.debug, || {
+                "! openpgp import: forcing command chaining (env override)".to_string()
+            });
         }
 
         let chunks: Vec<Zeroizing<Vec<u8>>> =
@@ -559,14 +561,16 @@ impl OpenPgpSession {
             if sw != 0x6700 && sw != 0x6883 {
                 ok_or_apdu("openpgp decipher", sw)?;
             }
-            if self.debug {
-                eprintln!(
+            trace::line(self.debug, || {
+                format!(
                     "! openpgp decipher: extended length rejected (SW={sw:04X}); \
                      retrying with command chaining"
-                );
-            }
-        } else if self.debug {
-            eprintln!("! openpgp decipher: forcing command chaining (env override)");
+                )
+            });
+        } else {
+            trace::line(self.debug, || {
+                "! openpgp decipher: forcing command chaining (env override)".to_string()
+            });
         }
 
         let chunks = pgp::pso_decipher_chained(cipher_do, 254);

--- a/crates/keyroost-transport/src/openpgp.rs
+++ b/crates/keyroost-transport/src/openpgp.rs
@@ -693,6 +693,7 @@ impl OpenPgpSession {
             label: "openpgp",
             more_data_sw: pgp::SW_MORE_DATA,
             get_response: pgp::get_response,
+            describe: None,
         };
         crate::transmit_applet(
             &self.card,

--- a/crates/keyroost-transport/src/piv.rs
+++ b/crates/keyroost-transport/src/piv.rs
@@ -1547,7 +1547,10 @@ mod tests {
             "GET DATA (5F C1 99)"
         );
         assert_eq!(
-            describe_apdu(&piv::put_data(&Slot::Signature.cert_object_tag(), &[0x53, 0x00])),
+            describe_apdu(&piv::put_data(
+                &Slot::Signature.cert_object_tag(),
+                &[0x53, 0x00]
+            )),
             "PUT DATA (5F C1 0A \u{2192} X.509 Certificate for Digital Signature)"
         );
         assert_eq!(

--- a/crates/keyroost-transport/src/piv.rs
+++ b/crates/keyroost-transport/src/piv.rs
@@ -1186,10 +1186,16 @@ impl PivSession {
         // returns recovered plaintext — redact uniformly so a future caller
         // can't leak through a trace.
         let resp_sensitive = apdu.get(1) == Some(&0x87);
+        // `describe` makes `transmit_applet` bracket every transmitted APDU —
+        // the caller's command and each GET RESPONSE / Le-corrected reissue —
+        // with a `>` line naming the command and a `<` line reading its status
+        // word. The CLI's `--debug` output and the GUI activity log both take
+        // this straight from `trace`, so it covers both.
         const IO: crate::AppletIo = crate::AppletIo {
             label: "piv",
             more_data_sw: piv::SW_MORE_DATA,
             get_response: piv::get_response,
+            describe: Some(describe_apdu),
         };
         crate::transmit_applet(
             &self.card,
@@ -1246,6 +1252,73 @@ const CHAIN_CHUNK: usize = 254;
 /// so byte 4 being the `0x00` extended-length marker is unambiguous.
 fn uses_extended_length(apdu: &[u8]) -> bool {
     apdu.get(4) == Some(&0x00)
+}
+
+/// The command-name string that precedes a PIV APDU in a `--debug` /
+/// activity-log trace. Resolves `apdu[1]` via [`piv::Instruction`], names the
+/// data object GET DATA / PUT DATA is aimed at, sharpens two more cases the INS
+/// byte alone leaves ambiguous, and falls back to the raw INS for an
+/// instruction this crate never builds.
+fn describe_apdu(apdu: &[u8]) -> String {
+    let Some(&ins) = apdu.get(1) else {
+        return "(malformed APDU)".to_string();
+    };
+    match piv::Instruction::from_code(ins) {
+        // GET DATA / PUT DATA both open their body with a `5C <len> <tag>`
+        // object selector — name what's being read/written, or show the raw
+        // tag when it's one we don't have a name for. (A chained PUT DATA's
+        // continuation chunks carry no selector and stay bare.)
+        Some(verb @ (piv::Instruction::GetData | piv::Instruction::PutData)) => {
+            let verb = verb.name();
+            match object_selector_tag(apdu) {
+                Some(tag) => {
+                    let hex = crate::hex_dump(tag);
+                    match piv::data_object_name(tag) {
+                        // Raw tag first, then its name — the tag is always shown
+                        // so an unfamiliar reader can cross-check the spec.
+                        Some(name) => format!("{verb} ({hex} \u{2192} {name})"),
+                        None => format!("{verb} ({hex})"),
+                    }
+                }
+                None => verb.to_string(),
+            }
+        }
+        // 0xF6 is MOVE KEY, or DELETE KEY when P1 is the 0xFF sentinel
+        // (`piv::delete_key` builds `00 F6 FF <slot>`).
+        Some(piv::Instruction::MoveKey) if apdu.get(2) == Some(&0xFF) => {
+            "DELETE KEY (yubico extension)".to_string()
+        }
+        // A bodyless VERIFY (`00 20 00 80`, no Lc) queries the PIN retry
+        // counter rather than presenting a PIN.
+        Some(piv::Instruction::Verify) if apdu.len() <= 4 => {
+            "VERIFY (retry-counter query)".to_string()
+        }
+        Some(known) => known.name().to_string(),
+        None => format!("INS {ins:#04X}"),
+    }
+}
+
+/// The data field of an APDU, handling both the short (`Lc` in one byte) and
+/// extended (`00 Lc_hi Lc_lo`) length encodings. Any trailing `Le` is ignored.
+fn command_data(apdu: &[u8]) -> Option<&[u8]> {
+    match apdu.get(4..)? {
+        [] => None,
+        // Extended length: 0x00 marker, then a two-byte Lc, then the body.
+        [0x00, hi, lo, rest @ ..] if !rest.is_empty() => {
+            rest.get(..(usize::from(*hi) << 8 | usize::from(*lo)))
+        }
+        // Short form: one Lc byte, then the body (possibly with a trailing Le).
+        [lc, rest @ ..] => rest.get(..usize::from(*lc)).or(Some(rest)),
+    }
+}
+
+/// The `5C <len> <tag>` object selector at the head of a GET DATA / PUT DATA
+/// body, if present.
+fn object_selector_tag(apdu: &[u8]) -> Option<&[u8]> {
+    match command_data(apdu)? {
+        [0x5C, len, rest @ ..] => rest.get(..usize::from(*len)),
+        _ => None,
+    }
 }
 
 /// `KEYROOST_PIV_FORCE_CHAINING` forces the command-chaining path (so the
@@ -1455,6 +1528,51 @@ fn block_crypt(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn describe_apdu_names_the_command() {
+        assert_eq!(describe_apdu(&piv::select_full()), "SELECT");
+        assert_eq!(
+            describe_apdu(&piv::get_version()),
+            "GET VERSION (yubico extension)"
+        );
+        // GET DATA / PUT DATA name the object in their 5C selector; an
+        // unknown tag falls back to raw hex; both length encodings parse.
+        assert_eq!(
+            describe_apdu(&piv::get_data(&Slot::Authentication.cert_object_tag())),
+            "GET DATA (5F C1 05 \u{2192} X.509 Certificate for PIV Authentication)"
+        );
+        assert_eq!(
+            describe_apdu(&piv::get_data(&[0x5F, 0xC1, 0x99])),
+            "GET DATA (5F C1 99)"
+        );
+        assert_eq!(
+            describe_apdu(&piv::put_data(&Slot::Signature.cert_object_tag(), &[0x53, 0x00])),
+            "PUT DATA (5F C1 0A \u{2192} X.509 Certificate for Digital Signature)"
+        );
+        assert_eq!(
+            describe_apdu(&piv::put_data_chained(&[0x5F, 0xC1, 0x0C], &[0x01], 254)[0]),
+            "PUT DATA (5F C1 0C \u{2192} Key History Object)"
+        );
+        // 0xF6 with the P1 == 0xFF sentinel is DELETE, not MOVE.
+        assert_eq!(
+            describe_apdu(&piv::delete_key(Slot::Signature)),
+            "DELETE KEY (yubico extension)"
+        );
+        assert_eq!(
+            describe_apdu(&piv::move_key(Slot::Retired(1), Slot::Authentication)),
+            "MOVE KEY (yubico extension)"
+        );
+        // Bodyless VERIFY is a retry-counter query.
+        assert_eq!(
+            describe_apdu(&piv::verify_pin_status()),
+            "VERIFY (retry-counter query)"
+        );
+        assert!(describe_apdu(&piv::verify_pin(b"12345678").unwrap()).starts_with("VERIFY"));
+        // Unknown / malformed fall back rather than panic.
+        assert_eq!(describe_apdu(&[0x00, 0x99, 0x00, 0x00]), "INS 0x99");
+        assert_eq!(describe_apdu(&[]), "(malformed APDU)");
+    }
 
     #[test]
     fn move_key_firmware_gate() {

--- a/crates/keyroost-transport/src/piv.rs
+++ b/crates/keyroost-transport/src/piv.rs
@@ -9,7 +9,7 @@
 //! PIN/PUK change and unblock, set-pin-retries, set-management-key, key
 //! generation, certificate import/export, and applet reset.
 
-use crate::TransportError;
+use crate::{trace, TransportError};
 use keyroost_piv as piv;
 use keyroost_piv::{KeyAlg, Metadata, MgmtAlg, PinPolicy, PublicKey, Slot, TouchPolicy};
 use pcsc::{Card, Context, Protocols, Scope, ShareMode};
@@ -467,13 +467,12 @@ impl PivSession {
             // Say so in the trace: the assurance on this card is one-sided,
             // and a reviewer (or a user wondering why a swapped card was
             // accepted) should be able to see that the weaker path was taken.
-            if self.debug {
-                eprintln!(
-                    "! piv authenticate: card returned no 0x82 challenge response; \
-                     accepting host-only (client) authentication — this card cannot \
-                     prove it holds the management key"
-                );
-            }
+            trace::line(self.debug, || {
+                "! piv authenticate: card returned no 0x82 challenge response; \
+                 accepting host-only (client) authentication — this card cannot \
+                 prove it holds the management key"
+                    .to_string()
+            });
             return Ok(());
         }
         // Verify the card encrypted our challenge correctly (authenticates the
@@ -620,9 +619,9 @@ impl PivSession {
         let tag = slot.cert_object_tag();
         let apdu = piv::put_data(&tag, &value);
         let sw = if force_chaining() {
-            if self.debug {
-                eprintln!("! piv import certificate: forcing command chaining (env override)");
-            }
+            trace::line(self.debug, || {
+                "! piv import certificate: forcing command chaining (env override)".to_string()
+            });
             self.transmit_chain(
                 "piv import certificate",
                 &piv::put_data_chained(&tag, &value, CHAIN_CHUNK),
@@ -633,12 +632,12 @@ impl PivSession {
             if sw == piv::SW_OK || !uses_extended_length(&apdu) {
                 sw
             } else {
-                if self.debug {
-                    eprintln!(
+                trace::line(self.debug, || {
+                    format!(
                         "! piv import certificate: extended length rejected (SW={sw:04X}); \
                          retrying with command chaining"
-                    );
-                }
+                    )
+                });
                 self.transmit_chain(
                     "piv import certificate",
                     &piv::put_data_chained(&tag, &value, CHAIN_CHUNK),
@@ -846,9 +845,9 @@ impl PivSession {
         let key_ref = slot.key_ref();
         let apdu = piv::general_auth_sign(alg, key_ref, prepared);
         let (data, sw) = if force_chaining() {
-            if self.debug {
-                eprintln!("! piv sign: forcing command chaining (env override)");
-            }
+            trace::line(self.debug, || {
+                "! piv sign: forcing command chaining (env override)".to_string()
+            });
             self.transmit_chain(
                 "piv sign",
                 &piv::general_auth_sign_chained(alg, key_ref, prepared, CHAIN_CHUNK),
@@ -858,12 +857,12 @@ impl PivSession {
             if sw == piv::SW_OK || !uses_extended_length(&apdu) {
                 (data, sw)
             } else {
-                if self.debug {
-                    eprintln!(
+                trace::line(self.debug, || {
+                    format!(
                         "! piv sign: extended length rejected (SW={sw:04X}); retrying with \
                          command chaining"
-                    );
-                }
+                    )
+                });
                 self.transmit_chain(
                     "piv sign",
                     &piv::general_auth_sign_chained(alg, key_ref, prepared, CHAIN_CHUNK),

--- a/crates/keyroost-transport/src/token2prog.rs
+++ b/crates/keyroost-transport/src/token2prog.rs
@@ -13,7 +13,7 @@
 use keyroost_token2prog::{self as prog, Command};
 use pcsc::{Card, Context, Protocols, Scope, ShareMode};
 
-use crate::TransportError;
+use crate::{trace, TransportError};
 
 /// A session against a single-profile programmable token over a reader.
 pub struct Token2ProgSession {
@@ -47,29 +47,29 @@ impl Token2ProgSession {
     /// continuation (contact readers), and return the response payload without
     /// the SW1/SW2 trailer. Errors on any status word other than `9000`.
     fn transmit(&mut self, cmd: &Command) -> Result<Vec<u8>, TransportError> {
-        if self.debug {
-            // INS 0xC5 (set_seed) and 0xCE (answer_challenge) carry a
-            // secret-bearing body. That body is SM4-encrypted under a PUBLIC,
-            // hardcoded device key, so it is effectively plaintext — redact it
-            // from the trace and print only the header (mirrors the seed-body
-            // redaction in `token2otp`). The header still reveals CLA/INS/P1/P2/Lc,
-            // which is what's useful for bring-up.
-            let sensitive = matches!(cmd.apdu.get(1), Some(0xC5) | Some(0xCE));
+        // INS 0xC5 (set_seed) and 0xCE (answer_challenge) carry a
+        // secret-bearing body. That body is SM4-encrypted under a PUBLIC,
+        // hardcoded device key, so it is effectively plaintext — redact it
+        // from the trace and print only the header (mirrors the seed-body
+        // redaction in `token2otp`). The header still reveals CLA/INS/P1/P2/Lc,
+        // which is what's useful for bring-up.
+        let sensitive = matches!(cmd.apdu.get(1), Some(0xC5) | Some(0xCE));
+        trace::line(self.debug, || {
             if sensitive && cmd.apdu.len() > 5 {
-                eprintln!(
+                format!(
                     "> {:>16} >> {}<{} bytes redacted>",
                     cmd.label,
                     hex(&cmd.apdu[..5]),
                     cmd.apdu.len() - 5
-                );
+                )
             } else {
-                eprintln!("> {:>16} >> {}", cmd.label, hex(&cmd.apdu));
+                format!("> {:>16} >> {}", cmd.label, hex(&cmd.apdu))
             }
-        }
+        });
         let (data, sw1, sw2) = self.exchange_full(&cmd.apdu, cmd.label)?;
-        if self.debug {
-            eprintln!("< {:>16} << ...{:02X}{:02X}", cmd.label, sw1, sw2);
-        }
+        trace::line(self.debug, || {
+            format!("< {:>16} << ...{:02X}{:02X}", cmd.label, sw1, sw2)
+        });
         // The challenge answer replies with a bare 9000 (no data) on success and
         // 6983 when the device key is locked; surface the latter clearly.
         if (sw1, sw2) == (0x69, 0x83) {

--- a/crates/keyroost-transport/src/trace.rs
+++ b/crates/keyroost-transport/src/trace.rs
@@ -1,0 +1,63 @@
+//! The one place a `--debug` APDU trace line is produced, shared by every
+//! transport session (Molto2, PIV, OATH, OpenPGP, ...ProgToken).
+//!
+//! Two independent consumers, both driven from here:
+//!
+//! * **The CLI's `--debug` flag** — each session still carries its own
+//!   `debug: bool` (set via `set_debug`, exactly as before); when a session
+//!   has it on, [`line`] prints straight to stderr, byte-for-byte what the
+//!   old scattered `eprintln!` calls produced. That's the only thing that
+//!   changed here: every call site used to format and print the line itself;
+//!   now it hands the (lazy) line to this one function instead.
+//! * **The GUI's activity log** — a front end that wants the exact wire
+//!   exchange behind one operation, not a shared stderr stream, calls
+//!   [`begin`] before the operation and [`take`] after to collect whatever
+//!   was recorded on the calling thread in between — independent of any
+//!   session's own `debug` flag, so a session the GUI never told to print
+//!   can still be traced. This works because the GUI's blocking device jobs
+//!   run to completion on one dedicated worker thread before their result
+//!   crosses back to the UI thread (see `keyroost`'s `Worker`), so "recorded
+//!   between begin and take" exactly matches "what this one job did".
+
+use std::cell::RefCell;
+
+thread_local! {
+    static TRACE: RefCell<Option<Vec<String>>> = const { RefCell::new(None) };
+}
+
+/// Start capturing trace lines recorded on this thread. Pairs with [`take`].
+/// A capture left open by a panicking job is harmless: the next `begin`
+/// simply discards it.
+pub fn begin() {
+    TRACE.with(|t| *t.borrow_mut() = Some(Vec::new()));
+}
+
+/// Stop capturing and return everything recorded since [`begin`]. `None` if
+/// no capture is active on this thread.
+pub fn take() -> Option<Vec<String>> {
+    TRACE.with(|t| t.borrow_mut().take())
+}
+
+fn capturing() -> bool {
+    TRACE.with(|t| t.borrow().is_some())
+}
+
+/// Record one `--debug` trace line. `debug` is the session's own flag: when
+/// on, the line prints to stderr immediately, same as always. Independently,
+/// if this thread has an active capture, the line is also appended there.
+/// `line` is built lazily so the common case — a non-`--debug` CLI run with
+/// no GUI capture active — never allocates or formats anything.
+pub(crate) fn line(debug: bool, f: impl FnOnce() -> String) {
+    if !debug && !capturing() {
+        return;
+    }
+    let s = f();
+    if debug {
+        eprintln!("{s}");
+    }
+    TRACE.with(|t| {
+        if let Some(buf) = t.borrow_mut().as_mut() {
+            buf.push(s);
+        }
+    });
+}

--- a/crates/keyroost/src/main.rs
+++ b/crates/keyroost/src/main.rs
@@ -7505,6 +7505,13 @@ impl App {
     }
 }
 
+/// `ViewportId` of the popped-out activity-log window — shared by the code that
+/// spawns it (`App::activity_log_window`) and the code that brings it to the
+/// front (the top bar's "Activity log" link while detached).
+fn activity_log_viewport_id() -> egui::ViewportId {
+    egui::ViewportId::from_hash_of("activity-log")
+}
+
 /// Current unix time as a float (for the OATH "copied" flash window).
 fn now_secs_f64() -> f64 {
     SystemTime::now()
@@ -8743,12 +8750,17 @@ impl App {
                             .on_hover_cursor(egui::CursorIcon::PointingHand)
                             .clicked()
                         {
-                            self.log_open = !self.log_open;
-                            // Closing from here always resets to the docked
-                            // drawer, so reopening never springs a stale
-                            // popped-out window back to life.
-                            if !self.log_open {
-                                self.log_detached = false;
+                            if self.log_detached {
+                                // The log is popped out into its own window;
+                                // the link brings that window forward rather
+                                // than toggling (and closing) the drawer that
+                                // isn't showing.
+                                ctx.send_viewport_cmd_to(
+                                    activity_log_viewport_id(),
+                                    egui::ViewportCommand::Focus,
+                                );
+                            } else {
+                                self.log_open = !self.log_open;
                             }
                         }
                         ui.add_space(10.0);
@@ -9126,7 +9138,7 @@ impl App {
     fn activity_log_window(&mut self, ctx: &egui::Context, p: &Palette) {
         let mut close_requested = false;
         ctx.show_viewport_immediate(
-            egui::ViewportId::from_hash_of("activity-log"),
+            activity_log_viewport_id(),
             egui::ViewportBuilder::default()
                 .with_title("keyroost \u{2014} Activity log")
                 .with_inner_size([620.0, 340.0])

--- a/crates/keyroost/src/main.rs
+++ b/crates/keyroost/src/main.rs
@@ -2642,6 +2642,27 @@ impl App {
     }
 
     fn log_kind(&mut self, severity: Severity, kind: LogKind, text: impl Into<String>) {
+        // The activity log is device-centric: nearly every entry reports
+        // something read from or done to the token currently in focus — a
+        // status sweep, a write, an auth attempt. Prefix that token's display
+        // name so the log stays legible when a session touches several keys.
+        // Fleet-level lines (device-scan counts, "selection moved on" reset
+        // notices) go through `log_global`, which skips the prefix.
+        let text = match self.selected_device() {
+            Some(d) => format!("{}: {}", d.title(), text.into()),
+            None => text.into(),
+        };
+        self.push_log(severity, kind, text);
+    }
+
+    /// Log without the selected-token prefix `log_kind` adds — for entries that
+    /// are about the device *fleet* or about a key that is no longer the
+    /// selection (so its name would be the wrong one to show).
+    fn log_global(&mut self, severity: Severity, kind: LogKind, text: impl Into<String>) {
+        self.push_log(severity, kind, text.into());
+    }
+
+    fn push_log(&mut self, severity: Severity, kind: LogKind, text: String) {
         // The trace captured for whichever job's apply closure is running
         // right now (see `Worker::spawn`), if any — attached to the first log
         // line that closure produces, then consumed so a later, unrelated log
@@ -2650,7 +2671,7 @@ impl App {
         self.log.push(LogLine {
             severity,
             kind,
-            text: text.into(),
+            text,
             trace,
         });
         // Keep the log bounded; oldest entries are least interesting.
@@ -5049,8 +5070,9 @@ impl App {
             } else {
                 String::new()
             };
-            app.log(
+            app.log_global(
                 Severity::Warn,
+                LogKind::User,
                 format!(
                     "a factory reset finished after the selection moved on \u{2014} wiped: \
                      {wiped_txt}; not wiped: {failed_txt}.{fido_txt} Re-select that key to see \
@@ -5438,8 +5460,9 @@ impl App {
             completion_still_valid(arm.for_device.as_ref(), self.selected_device.as_ref())
         }) {
             if self.reset_arm.take().is_some() {
-                self.log(
+                self.log_global(
                     Severity::Warn,
+                    LogKind::User,
                     "the armed reset was cancelled \u{2014} the key it was armed for is no longer \
                      the one selected. Re-open \u{201C}Reset key\u{201D} on the key you want to \
                      wipe.",
@@ -6187,8 +6210,9 @@ impl App {
                     // staggered burst that follows any of them (`pending_scans`)
                     // makes "which scan did the user actually ask for" moot in
                     // practice, so all of them log at the same, muted weight.
-                    app.log_bg(
+                    app.log_global(
                         Severity::Info,
+                        LogKind::Background,
                         format!(
                             "device scan: {} device{} found",
                             devices.len(),
@@ -6201,7 +6225,11 @@ impl App {
                     }
                 }
                 Err(e) => {
-                    app.log_bg(Severity::Warn, format!("device scan failed: {e}"));
+                    app.log_global(
+                        Severity::Warn,
+                        LogKind::Background,
+                        format!("device scan failed: {e}"),
+                    );
                     App::apply_device_scan_failure(app, e);
                 }
             })
@@ -6321,8 +6349,9 @@ impl App {
         // key — and the outcome would land in whatever report is on screen.
         // An armed ceremony must not outlive the selection it was armed for.
         if self.reset_arm.take().is_some() {
-            self.log(
+            self.log_global(
                 Severity::Warn,
+                LogKind::User,
                 "the armed reset was cancelled \u{2014} selecting another key ends the ceremony. \
                  Re-open \u{201C}Reset key\u{201D} on the key you want to wipe.",
             );
@@ -7409,11 +7438,18 @@ impl App {
                 return; // keep the field open so the user can correct it
             }
         }
-        let vendor = self
-            .devices
-            .iter()
-            .find(|d| d.serial == target.serial)
-            .map(|d| d.vendor.to_ascii_lowercase());
+        let live = self.devices.iter().find(|d| d.serial == target.serial);
+        let vendor = live.map(|d| d.vendor.to_ascii_lowercase());
+        // A key without an explicit friendly name still shows one — its model
+        // (see `DeviceView::title`). Resolving both sides of the change to a
+        // concrete display name means one message covers rename, first naming
+        // and clearing alike, with no special cases.
+        let implicit = live
+            .map(|d| d.model.clone())
+            .unwrap_or_else(|| "this key".to_string());
+        let old_display = target.name_at_open.clone().unwrap_or_else(|| implicit.clone());
+        let cleared = name.is_empty();
+        let new_display = if cleared { implicit } else { name.clone() };
         let mut keyring = keyroost_keyring::Keyring::load_default().unwrap_or_default();
         // Drop the target's prior name — by the name pinned at open, then by
         // serial as a belt-and-braces (covers a name changed under us). This
@@ -7440,7 +7476,18 @@ impl App {
             }
         }
         match keyring.save_default() {
-            Ok(_) => self.log(Severity::Ok, "name saved"),
+            // Name the before and after explicitly rather than leaning on the
+            // usual selected-token prefix: the device list still holds the old
+            // name here (the refresh below is what picks up the change), so the
+            // auto-prefix would show the pre-rename name.
+            Ok(_) => self.log_global(
+                Severity::Ok,
+                LogKind::User,
+                format!(
+                    "{new_display}: name {}, was {old_display}",
+                    if cleared { "cleared" } else { "saved" }
+                ),
+            ),
             Err(e) => self.log(Severity::Err, format!("save names: {e}")),
         }
         self.close_rename();

--- a/crates/keyroost/src/main.rs
+++ b/crates/keyroost/src/main.rs
@@ -14036,16 +14036,18 @@ impl App {
         // of bold labels, the active one underlined with a 2px accent. Clicking
         // a tab selects that slot; every action card below targets it.
         ui.add_space(14.0);
-        {
-            let top = ui.cursor().top();
-            let strip = egui::Rect::from_min_max(
-                egui::pos2(ui.max_rect().left(), top - 4.0),
-                egui::pos2(ui.max_rect().right(), top + 30.0),
-            );
-            ui.painter().rect_filled(strip, 0.0, p.surface);
-        }
-        ui.horizontal(|ui| {
+        // Opaque surface behind the tab labels. The strip wraps to more than one
+        // line when the window is too narrow to hold every tab on one row — the
+        // slot cards below would otherwise be pinned to the unwrapped width of
+        // this row and spill past the pane's right edge. Because the wrapped
+        // height isn't known until the row is laid out, reserve a paint slot
+        // here and fill it from the row's real rect afterwards.
+        let strip_bg = ui.painter().add(egui::Shape::Noop);
+        let strip_resp = ui.horizontal_wrapped(|ui| {
             ui.spacing_mut().item_spacing.x = 20.0;
+            // Rows are far enough apart that a wrapped second row clears the
+            // accent underline (drawn 6px below the row above) with margin.
+            ui.spacing_mut().item_spacing.y = 22.0;
             let tab = |ui: &mut egui::Ui, label: String, active: bool| -> bool {
                 let color = if active { p.txt } else { p.txt3 };
                 let resp = ui
@@ -14055,6 +14057,9 @@ impl App {
                                 .font(theme::f_sb(13.5))
                                 .color(color),
                         )
+                        // Each tab is one atom: it moves to the next row whole
+                        // rather than letting its own text break across two.
+                        .wrap_mode(egui::TextWrapMode::Extend)
                         .sense(egui::Sense::click()),
                     )
                     .on_hover_cursor(egui::CursorIcon::PointingHand);
@@ -14102,6 +14107,15 @@ impl App {
                 self.help_dot(ui, p, "piv-retired");
             }
         });
+        {
+            let row = strip_resp.response.rect;
+            let strip = egui::Rect::from_min_max(
+                egui::pos2(ui.max_rect().left(), row.top() - 4.0),
+                egui::pos2(ui.max_rect().right(), row.bottom() + 6.0),
+            );
+            ui.painter()
+                .set(strip_bg, egui::Shape::rect_filled(strip, 0.0, p.surface));
+        }
         // --- Retired-slot rail (only on the retired tab) --------------------
         // All twenty slots, listed the way the Molto2 view lists its profiles:
         // one row each, a filled dot on the right for the ones holding a key,

--- a/crates/keyroost/src/main.rs
+++ b/crates/keyroost/src/main.rs
@@ -7447,7 +7447,10 @@ impl App {
         let implicit = live
             .map(|d| d.model.clone())
             .unwrap_or_else(|| "this key".to_string());
-        let old_display = target.name_at_open.clone().unwrap_or_else(|| implicit.clone());
+        let old_display = target
+            .name_at_open
+            .clone()
+            .unwrap_or_else(|| implicit.clone());
         let cleared = name.is_empty();
         let new_display = if cleared { implicit } else { name.clone() };
         let mut keyring = keyroost_keyring::Keyring::load_default().unwrap_or_default();

--- a/crates/keyroost/src/main.rs
+++ b/crates/keyroost/src/main.rs
@@ -2010,6 +2010,11 @@ struct App {
     colorblind: bool,
     /// Whether the activity-log drawer is open.
     log_open: bool,
+    /// Whether the activity log is popped out into its own OS window (viewport)
+    /// instead of the docked bottom drawer. Set by the header's detach icon,
+    /// cleared by "Reattach"; the window's own close button clears this *and*
+    /// `log_open` (collapsing the log). Only meaningful while `log_open` is true.
+    log_detached: bool,
     /// Open help topic id, or `None` when the popover is closed.
     help_open: Option<&'static str>,
     /// Anchor point (the clicked "?" button's left-bottom) for the popover.
@@ -8163,6 +8168,57 @@ fn paint_x_icon(ui: &egui::Ui, center: egui::Pos2, color: egui::Color32) {
     );
 }
 
+/// The window body shared by the detach / reattach pair: a square shifted to the
+/// bottom-left with its top-right corner left open for the arrow. Drawn
+/// identically by both so the glyphs read as one control in two states. Of the
+/// 8pt top and right edges only 3pt is drawn — a deep `5.0` corner cut — so the
+/// frame stays well clear of the arrow that crosses that corner.
+fn paint_window_body(painter: &egui::Painter, center: egui::Pos2, s: egui::Stroke) {
+    let b = egui::Rect::from_min_size(center + egui::vec2(-6.0, -2.0), egui::vec2(8.0, 8.0));
+    painter.add(egui::Shape::line(
+        vec![
+            egui::pos2(b.right() - 5.0, b.top()),
+            b.left_top(),
+            b.left_bottom(),
+            b.right_bottom(),
+            egui::pos2(b.right(), b.top() + 5.0),
+        ],
+        s,
+    ));
+}
+
+/// A window frame with an arrow leaving its top-right corner — "pop this pane
+/// out into its own window". Mirrors the external-link affordance the top bar's
+/// "Learn \u{2197}" uses.
+fn paint_detach_icon(ui: &egui::Ui, center: egui::Pos2, color: egui::Color32) {
+    let s = egui::Stroke::new(1.3, color);
+    let painter = ui.painter();
+    paint_window_body(painter, center, s);
+    // Diagonal arrow crossing that corner, pointing out to the top-right.
+    let tip = center + egui::vec2(6.0, -6.0);
+    painter.line_segment([center + egui::vec2(-1.0, 1.0), tip], s);
+    painter.add(egui::Shape::line(
+        vec![tip + egui::vec2(-4.5, 0.0), tip, tip + egui::vec2(0.0, 4.5)],
+        s,
+    ));
+}
+
+/// The mirror of [`paint_detach_icon`]: same window frame, but the arrow flies
+/// *in* through the open corner — "dock this back into the main window". Its tip
+/// rests at the glyph centre, inside the body, pointing down-left; the head
+/// keeps the same clearance from the frame that the detach arrow does.
+fn paint_reattach_icon(ui: &egui::Ui, center: egui::Pos2, color: egui::Color32) {
+    let s = egui::Stroke::new(1.3, color);
+    let painter = ui.painter();
+    paint_window_body(painter, center, s);
+    let tip = center;
+    painter.line_segment([center + egui::vec2(6.0, -6.0), tip], s);
+    painter.add(egui::Shape::line(
+        vec![tip + egui::vec2(4.5, 0.0), tip, tip + egui::vec2(0.0, -4.5)],
+        s,
+    ));
+}
+
 /// Paint one selectable device row. The whole row is a single painter-drawn
 /// click target (no nested widgets), so clicking anywhere in it selects the
 /// device — fixing the "only the gaps are clickable" inconsistency.
@@ -8459,10 +8515,17 @@ impl eframe::App for App {
 
         self.top_bar(root_ui, &p);
         self.device_sidebar(root_ui, &p);
-        if self.log_open {
+        if self.log_open && !self.log_detached {
             self.activity_log(root_ui, &p);
         }
         self.central(root_ui, &p);
+
+        // Popped-out activity log: its own OS window, rendered every frame while
+        // detached. "Reattach" docks it back into the bottom drawer; the
+        // window's close button collapses the log entirely.
+        if self.log_open && self.log_detached {
+            self.activity_log_window(ctx, &p);
+        }
 
         // Modal dialogs (reused from the per-applet logic) + Molto2 import dialogs.
         self.render_reset_dialog(ctx);
@@ -8634,6 +8697,12 @@ impl App {
                             .clicked()
                         {
                             self.log_open = !self.log_open;
+                            // Closing from here always resets to the docked
+                            // drawer, so reopening never springs a stale
+                            // popped-out window back to life.
+                            if !self.log_open {
+                                self.log_detached = false;
+                            }
                         }
                         ui.add_space(10.0);
                         ui.hyperlink_to(
@@ -8999,104 +9068,171 @@ impl App {
             .size_range(96.0..=560.0)
             .frame(panel_frame(p.bar, 16.0, 10.0))
             .show(root_ui, |ui| {
-                ui.horizontal(|ui| {
-                    ui.label(
-                        egui::RichText::new("ACTIVITY LOG")
-                            .font(theme::f_bold(11.0))
-                            .color(p.txt3),
-                    );
+                self.activity_log_body(ui, p, false);
+            });
+    }
+
+    /// Popped-out activity log: the same body rendered in its own OS window.
+    /// Shown every frame while `log_detached`. Closing the window collapses the
+    /// log entirely (same end state as the docked "Collapse" button); the
+    /// header's "Reattach" button docks it back into the drawer instead.
+    fn activity_log_window(&mut self, ctx: &egui::Context, p: &Palette) {
+        let mut close_requested = false;
+        ctx.show_viewport_immediate(
+            egui::ViewportId::from_hash_of("activity-log"),
+            egui::ViewportBuilder::default()
+                .with_title("keyroost \u{2014} Activity log")
+                .with_inner_size([620.0, 340.0])
+                .with_min_inner_size([340.0, 140.0]),
+            |ctx, _class| {
+                egui::CentralPanel::default()
+                    .frame(panel_frame(p.bar, 16.0, 10.0))
+                    .show(ctx, |ui| {
+                        self.activity_log_body(ui, p, true);
+                    });
+                if ctx.input(|i| i.viewport().close_requested()) {
+                    close_requested = true;
+                }
+            },
+        );
+        if close_requested {
+            // The window's close button collapses the log outright, rather
+            // than dropping it back into the docked drawer.
+            self.log_open = false;
+            self.log_detached = false;
+        }
+    }
+
+    /// The activity log's contents — header row plus the scrolling entry list —
+    /// shared by the docked drawer and the popped-out window. `detached` picks
+    /// the outer-right window control: the detach icon (plus "Collapse") when
+    /// docked, its mirror image — the reattach icon — when popped out.
+    fn activity_log_body(&mut self, ui: &mut egui::Ui, p: &Palette, detached: bool) {
+        ui.horizontal(|ui| {
+            ui.label(
+                egui::RichText::new("ACTIVITY LOG")
+                    .font(theme::f_bold(11.0))
+                    .color(p.txt3),
+            );
+            ui.add_space(6.0);
+            theme::pill(ui, "live", p.ok, p.ok_soft());
+            ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                // Window control at the outer right in both states: an icon-only
+                // affordance (detach glyph / its mirror) rather than a verb in
+                // the row of text actions. The hit box is a full button-height
+                // 32px tall so `Align::Center` lines the 18px glyph up with the
+                // adjacent buttons and the "APDU trace" checkbox — a bare 18px
+                // rect, allocated first in this row, centres against the row
+                // before the buttons have grown it and ends up sitting high.
+                let (wrect, wresp) =
+                    ui.allocate_exact_size(egui::vec2(18.0, 32.0), egui::Sense::click());
+                if detached {
+                    paint_reattach_icon(ui, wrect.center(), p.txt2);
+                    if wresp
+                        .on_hover_text("Dock back into the main window")
+                        .on_hover_cursor(egui::CursorIcon::PointingHand)
+                        .clicked()
+                    {
+                        self.log_detached = false;
+                    }
+                } else {
+                    paint_detach_icon(ui, wrect.center(), p.txt2);
+                    if wresp
+                        .on_hover_text("Open in a separate window")
+                        .on_hover_cursor(egui::CursorIcon::PointingHand)
+                        .clicked()
+                    {
+                        self.log_detached = true;
+                    }
                     ui.add_space(6.0);
-                    theme::pill(ui, "live", p.ok, p.ok_soft());
-                    ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
-                        if theme::button(ui, p, BtnKind::Ghost, "Collapse").clicked() {
-                            self.log_open = false;
-                        }
-                        ui.add_space(4.0);
-                        if theme::button(ui, p, BtnKind::Ghost, "Copy").clicked() {
-                            // Traces ride along, indented under the entry they
-                            // belong to — the point of the APDU trace is
-                            // having the exact wire exchange to paste, not
-                            // just the summary.
-                            let all = self
-                                .log
-                                .iter()
-                                .map(|l| match &l.trace {
-                                    Some(t) if !t.is_empty() => format!(
-                                        "{}\n{}",
-                                        l.text,
-                                        t.iter()
-                                            .map(|apdu| format!("    {apdu}"))
-                                            .collect::<Vec<_>>()
-                                            .join("\n")
-                                    ),
-                                    _ => l.text.clone(),
-                                })
-                                .collect::<Vec<_>>()
-                                .join("\n");
-                            ui.ctx().copy_text(all);
-                            // The user copied non-secret log text over the
-                            // code; a pending auto-clear would clobber it.
-                            self.clipboard_clear_at = None;
-                        }
-                        ui.add_space(10.0);
-                        // Runtime toggle for the worker thread's APDU capture
-                        // (see `Worker::spawn`) — no CLI flag, no restart:
-                        // flip it, and the very next device operation's trace
-                        // shows up under its log entry.
-                        let mut trace_on =
-                            self.apdu_trace.load(std::sync::atomic::Ordering::Relaxed);
-                        if ui.checkbox(&mut trace_on, "APDU trace").changed() {
-                            self.apdu_trace
-                                .store(trace_on, std::sync::atomic::Ordering::Relaxed);
-                        }
-                    });
-                });
-                ui.add_space(6.0);
-                egui::ScrollArea::vertical()
-                    .stick_to_bottom(true)
-                    .auto_shrink([false, false])
-                    .show(ui, |ui| {
-                        for line in self.log.iter_mut() {
-                            let base = match line.severity {
-                                Severity::Ok => p.ok,
-                                Severity::Warn => p.warn,
-                                Severity::Err => p.err,
-                                Severity::Info => p.txt2,
-                            };
-                            // User actions render exactly as every explicit
-                            // Molto2 action always has: full-strength severity
-                            // color, no prefix. Background entries — a device
-                            // scan, a tab's initial status sweep, a re-read
-                            // that follows a write — are alpha-muted toward
-                            // the panel and get a leading "·", so the
-                            // distinction survives colorblind palettes too and
-                            // never reads as though the user just did
-                            // something.
-                            let (color, prefix, size) = match line.kind {
-                                LogKind::User => (base, "", 12.0),
-                                LogKind::Background => (theme::tint(base, 130), "\u{b7} ", 11.5),
-                            };
+                    if theme::button(ui, p, BtnKind::Ghost, "Collapse").clicked() {
+                        self.log_open = false;
+                    }
+                }
+                ui.add_space(4.0);
+                if theme::button(ui, p, BtnKind::Ghost, "Copy").clicked() {
+                    // Traces ride along, indented under the entry they
+                    // belong to — the point of the APDU trace is
+                    // having the exact wire exchange to paste, not
+                    // just the summary.
+                    let all = self
+                        .log
+                        .iter()
+                        .map(|l| match &l.trace {
+                            Some(t) if !t.is_empty() => format!(
+                                "{}\n{}",
+                                l.text,
+                                t.iter()
+                                    .map(|apdu| format!("    {apdu}"))
+                                    .collect::<Vec<_>>()
+                                    .join("\n")
+                            ),
+                            _ => l.text.clone(),
+                        })
+                        .collect::<Vec<_>>()
+                        .join("\n");
+                    ui.ctx().copy_text(all);
+                    // The user copied non-secret log text over the
+                    // code; a pending auto-clear would clobber it.
+                    self.clipboard_clear_at = None;
+                }
+                ui.add_space(10.0);
+                // Runtime toggle for the worker thread's APDU capture
+                // (see `Worker::spawn`) — no CLI flag, no restart:
+                // flip it, and the very next device operation's trace
+                // shows up under its log entry.
+                let mut trace_on = self.apdu_trace.load(std::sync::atomic::Ordering::Relaxed);
+                if ui.checkbox(&mut trace_on, "APDU trace").changed() {
+                    self.apdu_trace
+                        .store(trace_on, std::sync::atomic::Ordering::Relaxed);
+                }
+            });
+        });
+        ui.add_space(6.0);
+        egui::ScrollArea::vertical()
+            .stick_to_bottom(true)
+            .auto_shrink([false, false])
+            .show(ui, |ui| {
+                for line in self.log.iter_mut() {
+                    let base = match line.severity {
+                        Severity::Ok => p.ok,
+                        Severity::Warn => p.warn,
+                        Severity::Err => p.err,
+                        Severity::Info => p.txt2,
+                    };
+                    // User actions render exactly as every explicit
+                    // Molto2 action always has: full-strength severity
+                    // color, no prefix. Background entries — a device
+                    // scan, a tab's initial status sweep, a re-read
+                    // that follows a write — are alpha-muted toward
+                    // the panel and get a leading "·", so the
+                    // distinction survives colorblind palettes too and
+                    // never reads as though the user just did
+                    // something.
+                    let (color, prefix, size) = match line.kind {
+                        LogKind::User => (base, "", 12.0),
+                        LogKind::Background => (theme::tint(base, 130), "\u{b7} ", 11.5),
+                    };
+                    ui.label(
+                        egui::RichText::new(format!("{prefix}{}", line.text))
+                            .font(theme::f_mono(size))
+                            .color(color),
+                    );
+                    // APDU trace ("APDU trace" checkbox above):
+                    // printed exactly like the CLI's own `--debug`
+                    // output — the same formatted lines, captured
+                    // verbatim (see `keyroost_transport::trace`) —
+                    // indented under the entry they belong to.
+                    if let Some(trace) = line.trace.as_ref() {
+                        for apdu in trace {
                             ui.label(
-                                egui::RichText::new(format!("{prefix}{}", line.text))
-                                    .font(theme::f_mono(size))
-                                    .color(color),
+                                egui::RichText::new(format!("    {apdu}"))
+                                    .font(theme::f_mono(10.5))
+                                    .color(p.txt3),
                             );
-                            // APDU trace ("APDU trace" checkbox above):
-                            // printed exactly like the CLI's own `--debug`
-                            // output — the same formatted lines, captured
-                            // verbatim (see `keyroost_transport::trace`) —
-                            // indented under the entry they belong to.
-                            if let Some(trace) = line.trace.as_ref() {
-                                for apdu in trace {
-                                    ui.label(
-                                        egui::RichText::new(format!("    {apdu}"))
-                                            .font(theme::f_mono(10.5))
-                                            .color(p.txt3),
-                                    );
-                                }
-                            }
                         }
-                    });
+                    }
+                }
             });
     }
 

--- a/crates/keyroost/src/main.rs
+++ b/crates/keyroost/src/main.rs
@@ -1754,13 +1754,29 @@ struct Worker {
 }
 
 impl Worker {
-    fn spawn(ctx: egui::Context) -> Self {
+    /// `apdu_trace`: shared with the "APDU trace" checkbox in the activity
+    /// log pane (see `App::activity_log`), read fresh at the start of every
+    /// job rather than fixed at spawn time, so toggling it takes effect on
+    /// the very next device operation. When on for a given job, that job's
+    /// APDU trace is captured (see `keyroost_transport::trace`) and handed to
+    /// its apply closure via `App::pending_trace`, for the next `log`/`log_bg`
+    /// call inside it to attach. One capture per job — this thread runs jobs
+    /// one at a time, start to finish, so "everything recorded between begin
+    /// and take" is exactly "everything this job's device I/O did".
+    fn spawn(
+        ctx: egui::Context,
+        apdu_trace: std::sync::Arc<std::sync::atomic::AtomicBool>,
+    ) -> Self {
         let (job_tx, job_rx) = std::sync::mpsc::channel::<Job>();
         let (result_tx, result_rx) = std::sync::mpsc::channel::<ApplyFn>();
         std::thread::Builder::new()
             .name("keyroost-worker".into())
             .spawn(move || {
                 while let Ok(job) = job_rx.recv() {
+                    let debug = apdu_trace.load(std::sync::atomic::Ordering::Relaxed);
+                    if debug {
+                        keyroost_transport::trace::begin();
+                    }
                     // A panicking job must not kill the worker: that would
                     // disconnect the result channel and wedge the busy guard
                     // (spawn_job would reject every future job forever). Catch
@@ -1775,6 +1791,14 @@ impl Worker {
                                  re-plug the key if it stops responding",
                             );
                         }) as ApplyFn,
+                    };
+                    let apply = match debug.then(keyroost_transport::trace::take).flatten() {
+                        Some(trace) if !trace.is_empty() => Box::new(move |app: &mut App| {
+                            app.pending_trace = Some(trace);
+                            apply(app);
+                            app.pending_trace = None; // in case `apply` never logged
+                        }) as ApplyFn,
+                        _ => apply,
                     };
                     if result_tx.send(apply).is_err() {
                         break; // UI gone
@@ -1801,6 +1825,13 @@ fn main() -> eframe::Result<()> {
     if std::env::var_os("KEYROOST_X11").is_some() {
         std::env::remove_var("WAYLAND_DISPLAY");
     }
+
+    // Backs the "APDU trace" checkbox in the activity log pane (see
+    // `App::activity_log`): shared with the worker thread so a toggle takes
+    // effect on the very next device operation, off by default. Not a CLI
+    // flag — this is a runtime setting the user flips from the pane, not
+    // something decided once at launch.
+    let apdu_trace = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
 
     let options = eframe::NativeOptions {
         viewport: egui::ViewportBuilder::default()
@@ -1858,11 +1889,12 @@ fn main() -> eframe::Result<()> {
                     accent: accent_idx,
                     colorblind,
                 }),
-                worker: Some(Worker::spawn(cc.egui_ctx.clone())),
+                worker: Some(Worker::spawn(cc.egui_ctx.clone(), apdu_trace.clone())),
                 egui_ctx: Some(cc.egui_ctx.clone()),
                 devices_dirty,
                 reader_watch: Some(reader_watch),
                 mds: ui::mds::MdsDb::load_bundled(),
+                apdu_trace,
                 ..Default::default()
             };
             Ok(Box::new(app))
@@ -1918,6 +1950,17 @@ struct App {
     draft: Draft,
     /// Rolling log of operations (newest last).
     log: Vec<LogLine>,
+    /// Backs the "APDU trace" checkbox in the activity log pane. Shared with
+    /// the worker thread (see `Worker::spawn`), which reads it fresh at the
+    /// start of every job — toggling the checkbox takes effect on the very
+    /// next device operation, not just future app runs.
+    apdu_trace: std::sync::Arc<std::sync::atomic::AtomicBool>,
+    /// The APDU trace captured for the job whose result is being applied
+    /// right now, if the checkbox was on and that job recorded anything.
+    /// Consumed (and cleared) by the first `log`/`log_bg` call in the apply closure;
+    /// `Worker::spawn` also clears it after the apply closure returns, so it
+    /// never bleeds into an unrelated, later log line.
+    pending_trace: Option<Vec<String>>,
     /// otpauth:// import dialog state.
     import_dialog: ImportDialog,
     /// Bulk-import dialog state.
@@ -2388,7 +2431,14 @@ struct BulkDialog {
 
 struct LogLine {
     severity: Severity,
+    kind: LogKind,
     text: String,
+    /// The APDU trace behind this entry, captured on the worker thread while
+    /// the "APDU trace" checkbox (see `App::activity_log`) was on. `None`
+    /// with the checkbox off, for an entry with no device I/O behind it, or
+    /// when a job recorded nothing. Printed in full under the entry —
+    /// exactly the lines the CLI's own `--debug` would print.
+    trace: Option<Vec<String>>,
 }
 
 #[derive(Clone, Copy)]
@@ -2397,6 +2447,19 @@ enum Severity {
     Ok,
     Warn,
     Err,
+}
+
+/// Whether a log entry reports something the user directly asked for (a
+/// button click that writes to, authenticates against, or otherwise acts on
+/// a device) or something the app did on its own — a device scan, a status
+/// sweep triggered by opening a tab or by selecting a device, a re-read that
+/// follows a write to refresh the pane. Rendered with distinct weight (see
+/// `App::activity_log`) so a quiet background poll never reads as though the
+/// user had just done something.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum LogKind {
+    User,
+    Background,
 }
 
 impl App {
@@ -2475,7 +2538,11 @@ impl App {
             // execution if there's no egui context, e.g. in tests).
             self.busy_jobs = 0;
             self.busy_label = None;
-            self.worker = self.egui_ctx.clone().map(Worker::spawn);
+            let apdu_trace = self.apdu_trace.clone();
+            self.worker = self
+                .egui_ctx
+                .clone()
+                .map(|ctx| Worker::spawn(ctx, apdu_trace));
             self.log(
                 Severity::Err,
                 "the background worker stopped unexpectedly and was restarted",
@@ -2552,10 +2619,34 @@ impl App {
         }
     }
 
+    /// Log something the user directly asked for: a write, an auth attempt,
+    /// an export — anything that happened because of a specific click.
+    /// Rendered at full weight (see `activity_log`). This is the visualization
+    /// every explicit Molto2 action already used; every other module's
+    /// explicit actions should log through this same entry point.
     fn log(&mut self, severity: Severity, text: impl Into<String>) {
+        self.log_kind(severity, LogKind::User, text);
+    }
+
+    /// Log something the app did on its own — a device scan, a status sweep
+    /// triggered by opening a tab or selecting a device, a re-read that
+    /// follows a write to refresh the pane. Rendered muted (see
+    /// `activity_log`) so it never competes visually with a user action.
+    fn log_bg(&mut self, severity: Severity, text: impl Into<String>) {
+        self.log_kind(severity, LogKind::Background, text);
+    }
+
+    fn log_kind(&mut self, severity: Severity, kind: LogKind, text: impl Into<String>) {
+        // The trace captured for whichever job's apply closure is running
+        // right now (see `Worker::spawn`), if any — attached to the first log
+        // line that closure produces, then consumed so a later, unrelated log
+        // call in the same frame doesn't also claim it.
+        let trace = self.pending_trace.take().filter(|t| !t.is_empty());
         self.log.push(LogLine {
             severity,
+            kind,
             text: text.into(),
+            trace,
         });
         // Keep the log bounded; oldest entries are least interesting.
         if self.log.len() > 200 {
@@ -2703,7 +2794,7 @@ impl App {
                             }
                         }
                         if app.slot_meta.is_none() {
-                            app.resweep_slot_meta();
+                            app.resweep_slot_meta(LogKind::Background);
                         }
                         app.log(Severity::Ok, format!("profile #{} written", p));
                     }
@@ -2743,7 +2834,7 @@ impl App {
                             }
                         }
                         if app.slot_meta.is_none() {
-                            app.resweep_slot_meta();
+                            app.resweep_slot_meta(LogKind::Background);
                         }
                         app.log(Severity::Ok, format!("title written on slot #{}", p));
                     }
@@ -2776,7 +2867,7 @@ impl App {
                             }
                         }
                         if app.slot_meta.is_none() {
-                            app.resweep_slot_meta();
+                            app.resweep_slot_meta(LogKind::Background);
                         }
                         match outcome {
                             SeedDeleteOutcome::Deleted => app.log(
@@ -2930,20 +3021,27 @@ impl App {
 
     /// Re-read all 100 public blocks and replace the slot list. Recovers the
     /// metadata display when a write found no existing list to patch (the
-    /// open-time sweep had failed, leaving `slot_meta` `None`).
-    fn resweep_slot_meta(&mut self) {
+    /// open-time sweep had failed, leaving `slot_meta` `None`). `kind` should
+    /// be `User` when this runs because the user clicked "Refresh slots", and
+    /// `Background` for every other caller — a write's own fallback re-sweep,
+    /// or any future automatic trigger — so the activity log renders each the
+    /// way it actually happened.
+    fn resweep_slot_meta(&mut self, kind: LogKind) {
         let Some(mut s) = self.take_molto_session() else {
             return;
         };
         self.spawn_job("Refreshing slots\u{2026}", move || {
             let meta = (0..PROFILES)
                 .map(|p| s.read_public_data(p))
-                .collect::<Result<Vec<_>, _>>()
-                .ok();
+                .collect::<Result<Vec<_>, _>>();
             Box::new(move |app: &mut App| {
                 app.session = Some(s);
-                if let Some(m) = meta {
-                    app.slot_meta = Some(m);
+                match meta {
+                    Ok(m) => {
+                        app.log_kind(Severity::Ok, kind, format!("{} slots read", m.len()));
+                        app.slot_meta = Some(m);
+                    }
+                    Err(e) => app.log_kind(Severity::Warn, kind, format!("slot refresh: {e}")),
                 }
             })
         });
@@ -6078,12 +6176,29 @@ impl App {
                             .filter(|d| d.kind == DeviceKind::Key && !d.serial.is_empty())
                             .map(|d| d.serial.as_str()),
                     );
+                    // Background: every scan funnels through here, whether it
+                    // was kicked off by a hotplug event, the first-frame
+                    // auto-scan, or a "Refresh"/"Scan for devices" click — the
+                    // staggered burst that follows any of them (`pending_scans`)
+                    // makes "which scan did the user actually ask for" moot in
+                    // practice, so all of them log at the same, muted weight.
+                    app.log_bg(
+                        Severity::Info,
+                        format!(
+                            "device scan: {} device{} found",
+                            devices.len(),
+                            if devices.len() == 1 { "" } else { "s" }
+                        ),
+                    );
                     app.devices = devices;
                     if changed {
                         app.on_device_selected();
                     }
                 }
-                Err(e) => App::apply_device_scan_failure(app, e),
+                Err(e) => {
+                    app.log_bg(Severity::Warn, format!("device scan failed: {e}"));
+                    App::apply_device_scan_failure(app, e);
+                }
             })
         });
     }
@@ -6259,7 +6374,11 @@ impl App {
                 }
                 match result {
                     Ok((s, info, meta)) => {
-                        app.log(Severity::Ok, format!("opened Molto2 {}", info.serial));
+                        // Background: this fires automatically whenever a
+                        // Molto2 is selected, never from a click of the
+                        // user's own — same treatment as the device scan
+                        // that usually precedes it.
+                        app.log_bg(Severity::Ok, format!("opened Molto2 {}", info.serial));
                         // Enumeration's gentle probe usually fills these already;
                         // refresh them here as a fallback in case that read failed.
                         if let Some(id) = for_device.clone() {
@@ -6279,7 +6398,7 @@ impl App {
                         app.slot_meta = meta;
                         app.authenticated = false;
                     }
-                    Err(e) => app.log(Severity::Err, format!("open Molto2: {e}")),
+                    Err(e) => app.log_bg(Severity::Err, format!("open Molto2: {e}")),
                 }
             })
         });
@@ -6319,8 +6438,14 @@ impl App {
         });
     }
 
-    /// Read the selected card's read-only PIV status snapshot.
-    fn load_piv_status(&mut self) {
+    /// Read the selected card's read-only PIV status snapshot: status + every
+    /// slot's algorithm/subject/policy. `kind` should be `User` only when
+    /// this runs because the user clicked "Refresh" — the initial read when
+    /// the PIV tab is first opened, and the re-read every write triggers
+    /// afterwards to pick up what it changed, both pass `Background` so the
+    /// activity log renders them the way they actually happened (see
+    /// `LogKind`).
+    fn load_piv_status(&mut self, kind: LogKind) {
         self.piv.error = None;
         let Some(reader) = self.selected_oath_reader() else {
             return;
@@ -6373,19 +6498,30 @@ impl App {
                 }
                 match result {
                     Ok((Ok(status), slot_keys, slot_policies)) => {
+                        app.log_kind(
+                            Severity::Ok,
+                            kind,
+                            format!("PIV status read ({} slots)", slot_keys.len()),
+                        );
                         app.piv.status = Some(status);
                         app.piv.slot_keys = slot_keys;
                         app.piv.slot_policies = slot_policies;
                         app.piv.loaded = true;
                     }
-                    Ok((Err(e), _, _)) | Err(e) => app.piv.error = Some(e.to_string()),
+                    Ok((Err(e), _, _)) | Err(e) => {
+                        app.log_kind(Severity::Err, kind, format!("PIV status read: {e}"));
+                        app.piv.error = Some(e.to_string());
+                    }
                 }
             })
         });
     }
 
     /// Apply a PIV write result: on success store the notice and refreshed
-    /// status; on error store the message. Shared by every PIV write action.
+    /// status; on error store the message. Shared by every PIV write action —
+    /// also where every one of them logs, User-weight (the caller's `notice`
+    /// already says what happened in plain terms; a click landed here to
+    /// produce it).
     fn apply_piv_write(
         app: &mut App,
         result: Result<keyroost_transport::PivStatus, TransportError>,
@@ -6393,12 +6529,15 @@ impl App {
     ) {
         match result {
             Ok(status) => {
+                app.log(Severity::Ok, notice.clone());
                 app.piv.status = Some(status);
                 app.piv.error = None;
                 app.piv.notice = Some(notice);
                 // Re-read so per-slot key algorithms (and anything the write
-                // touched) reflect the new state without a manual Refresh.
-                app.load_piv_status();
+                // touched) reflect the new state without a manual Refresh —
+                // background: it's a side-effect re-read, not the action the
+                // user asked for (that's the log line just above).
+                app.load_piv_status(LogKind::Background);
                 // Any successful PIV write (delete, reset, move, ...) can change
                 // retired-slot occupancy; drop the cache so the retired tab
                 // re-reads fresh on its next open instead of showing stale
@@ -6415,6 +6554,7 @@ impl App {
                 }
             }
             Err(e) => {
+                app.log(Severity::Err, e.to_string());
                 app.piv.notice = None;
                 app.piv.error = Some(e.to_string());
             }
@@ -6599,6 +6739,10 @@ impl App {
                 wipe(&mut app.piv.mgmt_key_input);
                 match result {
                     Ok((pubkey, status)) => {
+                        app.log(
+                            Severity::Ok,
+                            format!("generated {} key in {}", alg.label(), slot.label()),
+                        );
                         app.piv.status = Some(status);
                         app.piv.error = None;
                         // Remember it for this app run so a later self-sign/CSR
@@ -6630,7 +6774,7 @@ impl App {
                         // generating and still doesn't), so without this
                         // refresh the pane would keep showing "empty" until
                         // some *other* write happened to trigger one.
-                        app.load_piv_status();
+                        app.load_piv_status(LogKind::Background);
                         // A retired slot's occupancy cache may now be stale
                         // (generation can target a retired slot); drop it so
                         // it re-reads fresh rather than keeping a cached
@@ -6642,6 +6786,7 @@ impl App {
                         app.piv.retired_occupancy = None;
                     }
                     Err(e) => {
+                        app.log(Severity::Err, e.to_string());
                         app.piv.notice = None;
                         app.piv.error = Some(e.to_string());
                     }
@@ -6903,8 +7048,21 @@ impl App {
                     return; // selection changed mid-read; discard
                 }
                 match result {
-                    Ok(v) => app.piv.retired_occupancy = Some(v),
-                    Err(e) => app.piv.error = Some(e.to_string()),
+                    Ok(v) => {
+                        // Background: this fires the first time the retired
+                        // slots section is expanded, or the move-key modal is
+                        // opened — neither is "the user asked to read retired
+                        // occupancy", it's incidental to something else.
+                        app.log_bg(
+                            Severity::Ok,
+                            format!("retired slot occupancy read ({} slots)", v.len()),
+                        );
+                        app.piv.retired_occupancy = Some(v);
+                    }
+                    Err(e) => {
+                        app.log_bg(Severity::Warn, format!("retired slot occupancy: {e}"));
+                        app.piv.error = Some(e.to_string());
+                    }
                 }
             })
         })
@@ -7037,10 +7195,15 @@ impl App {
                     wipe(&mut app.piv.sign_pin);
                     match result {
                         Ok(()) => {
+                            app.log(
+                                Severity::Ok,
+                                format!("certificate request signed for {}", slot.label()),
+                            );
                             app.piv.error = None;
                             app.piv.notice = Some("Certificate request signed and saved.".into());
                         }
                         Err(e) => {
+                            app.log(Severity::Err, e.to_string());
                             app.piv.notice = None;
                             app.piv.error = Some(e.to_string());
                         }
@@ -7085,10 +7248,15 @@ impl App {
             })();
             Box::new(move |app: &mut App| match result {
                 Ok(n) => {
+                    app.log(
+                        Severity::Ok,
+                        format!("exported {}-byte certificate from {}", n, slot.label()),
+                    );
                     app.piv.error = None;
                     app.piv.notice = Some(format!("Exported {}-byte DER certificate.", n));
                 }
                 Err(e) => {
+                    app.log(Severity::Err, e.to_string());
                     app.piv.notice = None;
                     app.piv.error = Some(e.to_string());
                 }
@@ -8823,7 +8991,12 @@ impl App {
     /// Global activity-log drawer (bottom), replacing the Molto2-only log.
     fn activity_log(&mut self, root_ui: &mut egui::Ui, p: &Palette) {
         egui::Panel::bottom("log")
-            .exact_size(180.0)
+            .resizable(true)
+            .default_size(180.0)
+            // Enough to still show the header when dragged down; capped so
+            // it can't swallow the whole window and crowd out the device
+            // pane above it.
+            .size_range(96.0..=560.0)
             .frame(panel_frame(p.bar, 16.0, 10.0))
             .show(root_ui, |ui| {
                 ui.horizontal(|ui| {
@@ -8840,16 +9013,41 @@ impl App {
                         }
                         ui.add_space(4.0);
                         if theme::button(ui, p, BtnKind::Ghost, "Copy").clicked() {
+                            // Traces ride along, indented under the entry they
+                            // belong to — the point of the APDU trace is
+                            // having the exact wire exchange to paste, not
+                            // just the summary.
                             let all = self
                                 .log
                                 .iter()
-                                .map(|l| l.text.clone())
+                                .map(|l| match &l.trace {
+                                    Some(t) if !t.is_empty() => format!(
+                                        "{}\n{}",
+                                        l.text,
+                                        t.iter()
+                                            .map(|apdu| format!("    {apdu}"))
+                                            .collect::<Vec<_>>()
+                                            .join("\n")
+                                    ),
+                                    _ => l.text.clone(),
+                                })
                                 .collect::<Vec<_>>()
                                 .join("\n");
                             ui.ctx().copy_text(all);
                             // The user copied non-secret log text over the
                             // code; a pending auto-clear would clobber it.
                             self.clipboard_clear_at = None;
+                        }
+                        ui.add_space(10.0);
+                        // Runtime toggle for the worker thread's APDU capture
+                        // (see `Worker::spawn`) — no CLI flag, no restart:
+                        // flip it, and the very next device operation's trace
+                        // shows up under its log entry.
+                        let mut trace_on =
+                            self.apdu_trace.load(std::sync::atomic::Ordering::Relaxed);
+                        if ui.checkbox(&mut trace_on, "APDU trace").changed() {
+                            self.apdu_trace
+                                .store(trace_on, std::sync::atomic::Ordering::Relaxed);
                         }
                     });
                 });
@@ -8858,18 +9056,45 @@ impl App {
                     .stick_to_bottom(true)
                     .auto_shrink([false, false])
                     .show(ui, |ui| {
-                        for line in &self.log {
-                            let color = match line.severity {
+                        for line in self.log.iter_mut() {
+                            let base = match line.severity {
                                 Severity::Ok => p.ok,
                                 Severity::Warn => p.warn,
                                 Severity::Err => p.err,
                                 Severity::Info => p.txt2,
                             };
+                            // User actions render exactly as every explicit
+                            // Molto2 action always has: full-strength severity
+                            // color, no prefix. Background entries — a device
+                            // scan, a tab's initial status sweep, a re-read
+                            // that follows a write — are alpha-muted toward
+                            // the panel and get a leading "·", so the
+                            // distinction survives colorblind palettes too and
+                            // never reads as though the user just did
+                            // something.
+                            let (color, prefix, size) = match line.kind {
+                                LogKind::User => (base, "", 12.0),
+                                LogKind::Background => (theme::tint(base, 130), "\u{b7} ", 11.5),
+                            };
                             ui.label(
-                                egui::RichText::new(&line.text)
-                                    .font(theme::f_mono(12.0))
+                                egui::RichText::new(format!("{prefix}{}", line.text))
+                                    .font(theme::f_mono(size))
                                     .color(color),
                             );
+                            // APDU trace ("APDU trace" checkbox above):
+                            // printed exactly like the CLI's own `--debug`
+                            // output — the same formatted lines, captured
+                            // verbatim (see `keyroost_transport::trace`) —
+                            // indented under the entry they belong to.
+                            if let Some(trace) = line.trace.as_ref() {
+                                for apdu in trace {
+                                    ui.label(
+                                        egui::RichText::new(format!("    {apdu}"))
+                                            .font(theme::f_mono(10.5))
+                                            .color(p.txt3),
+                                    );
+                                }
+                            }
                         }
                     });
             });
@@ -13305,7 +13530,7 @@ impl App {
     fn cap_piv(&mut self, ui: &mut egui::Ui, p: &Palette) {
         if !self.piv_tried && !self.busy() {
             self.piv_tried = true;
-            self.load_piv_status();
+            self.load_piv_status(LogKind::Background);
         }
         // Intents collected inside the UI closures and applied afterwards, so a
         // submit method's `&mut self` never overlaps a card's borrow.
@@ -14050,7 +14275,7 @@ impl App {
             self.piv.selected_slot = slot;
         }
         if do_refresh {
-            self.load_piv_status();
+            self.load_piv_status(LogKind::User);
         }
         // The three buttons open the centered credential modal; the modal itself
         // (rendered once per frame) runs the actual op. Opening wipes any stale
@@ -14295,7 +14520,7 @@ impl App {
                         // so it works without authenticating. Covers a factory
                         // reset (which clears the list) and a failed open-sweep.
                         if theme::button(ui, p, BtnKind::Default, "Refresh slots").clicked() {
-                            self.resweep_slot_meta();
+                            self.resweep_slot_meta(LogKind::User);
                         }
                         ui.add_space(6.0);
                         if theme::button(ui, p, BtnKind::Default, "Sync time on all").clicked() {
@@ -16299,7 +16524,7 @@ mod tests {
     #[test]
     fn panicking_job_clears_busy_and_worker_survives() {
         let mut app = App {
-            worker: Some(Worker::spawn(egui::Context::default())),
+            worker: Some(Worker::spawn(egui::Context::default(), Default::default())),
             ..Default::default()
         };
         // Silence the panic backtrace this test intentionally triggers.
@@ -16346,7 +16571,7 @@ mod tests {
     #[test]
     fn worker_round_trip_applies_result_and_clears_busy() {
         let mut app = App {
-            worker: Some(Worker::spawn(egui::Context::default())),
+            worker: Some(Worker::spawn(egui::Context::default(), Default::default())),
             ..Default::default()
         };
         app.spawn_job("test", || Box::new(|app: &mut App| app.slot = 42));
@@ -16371,7 +16596,7 @@ mod tests {
     #[test]
     fn spawn_job_ignored_while_busy() {
         let mut app = App {
-            worker: Some(Worker::spawn(egui::Context::default())),
+            worker: Some(Worker::spawn(egui::Context::default(), Default::default())),
             ..Default::default()
         };
         // Occupy the worker with a job whose result we don't drain.

--- a/crates/keyroost/src/main.rs
+++ b/crates/keyroost/src/main.rs
@@ -9150,6 +9150,12 @@ impl App {
                     }
                 }
                 ui.add_space(4.0);
+                if theme::button(ui, p, BtnKind::Ghost, "Clear").clicked() {
+                    // Drop every entry (and its APDU trace); the next device
+                    // operation starts the log fresh.
+                    self.log.clear();
+                }
+                ui.add_space(4.0);
                 if theme::button(ui, p, BtnKind::Ghost, "Copy").clicked() {
                     // Traces ride along, indented under the entry they
                     // belong to — the point of the APDU trace is


### PR DESCRIPTION
This PR wires the PIV module into the activity log. As part of this it also adds (optional) APDU tracing to the UI.

Four bonus features that come with this:
 - Include name of PIV APDU commands in trace
 - Detaching of activity log into separate window
 - Clearing of activity log
 - Fixes overflow in the PIV UI's key/cert pane when shrinking the window to its minimum