### PR TITLE
docs(devices): mark the Swissbit iShield Key 2 Pro as PIV-partial pending #113

### DIFF
--- a/docs/devices.html
+++ b/docs/devices.html
@@ -104,10 +104,12 @@
           contributed by episource. The OpenPGP applet is detected but not yet
           exercised by this project.</td></tr>
       <tr><td><strong>Swissbit iShield Key 2 Pro</strong></td>
-        <td>PIV</td>
-        <td>Answers the Yubico version extension with four bytes instead of
-          three; keyroost keeps the reply as sent. PIV verified by episource on
-          their own card. Other applets not yet exercised by this project.</td></tr>
+        <td>PIV (partial)</td>
+        <td>Key generation and certificate handling verified by episource on
+          their own card. Slot status is not yet trustworthy: the card reports
+          every slot's key type as ECC P-384 (#113). Answers the Yubico version
+          extension with four bytes instead of three; keyroost keeps the reply
+          as sent. Other applets not yet exercised by this project.</td></tr>
     </table>
     </div>
   </section>


### PR DESCRIPTION
episource asked on #111 that the card not be called fully verified while slot status reads every key type as ECC P-384 (#113). The row now says what was verified and what was not.

re #113

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SQv9x6xi3CxXs2PvXohaFu