### PR TITLE
docs: changelog and Learn-page line for #116

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- **`piv self-sign` and `piv request-cert` can generate the key first.**
+  `--generate-key` folds a fresh `generate-key` into the signing command,
+  with the same `--algorithm`, `--pin-policy` and `--touch-policy` options,
+  so cards without GET METADATA no longer need the `--save-pubkey` /
+  `--load-pubkey` detour. Contributed by @episource. ([#116])
 - **The activity log now covers PIV.** User actions and background reads
   are told apart, and with tracing on each APDU appears by name (for example
   `GET DATA 5FC105`) with the same redaction as `--debug`. The log can be
@@ -979,6 +984,7 @@ multi-vendor hardware-security-key manager, then took its neutral name. Highligh
 [#107]: https://github.com/framefilter/keyroost/issues/107
 [#110]: https://github.com/framefilter/keyroost/pull/110
 [#114]: https://github.com/framefilter/keyroost/pull/114
+[#116]: https://github.com/framefilter/keyroost/pull/116
 [Unreleased]: https://github.com/framefilter/keyroost/compare/v0.8.0...HEAD
 [0.8.0]: https://github.com/framefilter/keyroost/compare/v0.7.8...v0.8.0
 [0.7.8]: https://github.com/framefilter/keyroost/compare/v0.7.7...v0.7.8

--- a/docs/piv.html
+++ b/docs/piv.html
@@ -138,6 +138,10 @@ keyroostctl piv request-cert --slot 9a --subject "CN=Alice,O=Example" \
     <p class="kr-muted">When two <code>--*-stdin</code> flags appear on one command, keyroost
       reads them as consecutive lines in the order the operation needs them — for
       <code>self-sign</code> that is the management key first, then the PIN.</p>
+    <p>Both commands take <code>--generate-key</code> to generate the slot's key in the
+      same step (with the same <code>--algorithm</code>, <code>--pin-policy</code> and
+      <code>--touch-policy</code> options as <code>generate-key</code>), which spares
+      cards without GET METADATA the save-pubkey / load-pubkey detour.</p>
     <span id="delete"></span>
     <p><strong>Clearing a slot.</strong> <code>delete-cert</code> removes only the slot's
       X.509 certificate object and leaves the private key in place — standard PIV, so it


### PR DESCRIPTION
The --generate-key convenience on self-sign / request-cert merged without a changelog entry or a Learn-page mention; this adds both, credited to @episource.

re #116

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SQv9x6xi3CxXs2PvXohaFu