### PR TITLE
Land the Nix flake: credit, install docs, and current package descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,9 @@ Beyond the maintainers, keyroost is grateful for community contributions:
   distro-neutrality disclaimer, install-command corrections and an intro
   rewrite ([#35](https://github.com/framefilter/keyroost/issues/35),
   [#45](https://github.com/framefilter/keyroost/issues/45)).
+- **[@MakeShiftArtist](https://github.com/MakeShiftArtist)** — the Nix flake:
+  `keyroost` and `keyroostctl` packages plus a development shell, tested on
+  x86_64 Linux ([#109](https://github.com/framefilter/keyroost/pull/109)).
 - **[@episource](https://github.com/episource)** — the project's most prolific
   external contributor: Nitrokey 3 PIV support and `piv new-chuid`
   ([#102](https://github.com/framefilter/keyroost/pull/102)), short-APDU
@@ -388,6 +391,19 @@ rules. Use any AUR helper (or `makepkg`):
 
 ```bash
 yay -S keyroost-bin
+```
+
+### Nix (flake)
+
+The repository is a flake exposing `keyroost` (the default package),
+`keyroostctl` and a development shell. Builds from source. Contributed and
+tested on x86_64 Linux; other systems are declared but unverified
+([#109](https://github.com/framefilter/keyroost/pull/109)).
+
+```bash
+nix run github:framefilter/keyroost            # GUI
+nix run github:framefilter/keyroost#keyroostctl -- --help
+nix profile install github:framefilter/keyroost
 ```
 
 ### winget (Windows)

--- a/changelog.d/added-109-nix-flake.md
+++ b/changelog.d/added-109-nix-flake.md
@@ -1,0 +1,4 @@
+- **Nix flake.** The repository now builds as a flake: `keyroost` (the
+  default package), `keyroostctl`, and a development shell, with the GUI's
+  X11/Wayland libraries wired into the binary's rpath on Linux. Tested on
+  x86_64 Linux. Contributed by @MakeShiftArtist. ([#109])

--- a/crates/keyroost-transport/Cargo.toml
+++ b/crates/keyroost-transport/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
-description = "PC/SC transport for the Token2 Molto2 / Molto2v2 programmable TOTP token."
+description = "PC/SC transport and applet sessions for hardware security keys: Token2 Molto2, OATH, OpenPGP, PIV, and CCID serial lookup."
 
 [lints]
 workspace = true

--- a/crates/keyroost-transport/src/lib.rs
+++ b/crates/keyroost-transport/src/lib.rs
@@ -1,8 +1,10 @@
-//! PC/SC transport for the Token2 Molto2.
+//! PC/SC transport and applet sessions for hardware security keys.
 //!
-//! This crate is the bridge between `keyroost-proto` (pure byte builders) and
-//! the real device. It handles reader discovery, APDU exchange, and the
-//! challenge-response auth handshake.
+//! This crate is the bridge between the pure byte-layer crates
+//! (`keyroost-proto`, `keyroost-oath`, `keyroost-openpgp`, `keyroost-piv`)
+//! and the real device. It handles reader discovery, APDU exchange, and the
+//! per-applet sessions — the Molto2 challenge-response auth handshake below,
+//! plus the OATH, OpenPGP and PIV sessions in their own modules.
 //!
 //! ```no_run
 //! use keyroost_transport::{Session, TransportError};

--- a/crates/keyroost/Cargo.toml
+++ b/crates/keyroost/Cargo.toml
@@ -8,7 +8,7 @@ edition.workspace = true
 rust-version = "1.92"
 license.workspace = true
 repository.workspace = true
-description = "Desktop GUI for programming Token2 Molto2 / Molto2v2 TOTP tokens."
+description = "Desktop GUI for managing hardware security keys: FIDO2, OATH, OpenPGP, PIV, and Token2 programmable TOTP tokens."
 
 [lints]
 workspace = true

--- a/crates/keyroostctl/Cargo.toml
+++ b/crates/keyroostctl/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
-description = "Command-line tool for programming Token2 Molto2 / Molto2v2 TOTP tokens."
+description = "Command-line tool for managing hardware security keys: FIDO2, OATH, OpenPGP, PIV, and Token2 programmable TOTP tokens."
 
 [lints]
 workspace = true

--- a/crates/keyroostctl/src/main.rs
+++ b/crates/keyroostctl/src/main.rs
@@ -1,6 +1,8 @@
-//! keyroostctl — CLI for programming Token2 Molto2 / Molto2v2 TOTP tokens.
+//! keyroostctl — CLI for managing hardware security keys: FIDO2, OATH,
+//! OpenPGP, PIV, and Token2 programmable TOTP tokens.
 //!
-//! Drop-in replacement for `molto2.py` with a cleaner subcommand layout.
+//! Started as a replacement for the Molto2 vendor script with a cleaner
+//! subcommand layout; each applet now has its own command group.
 
 use std::process::ExitCode;
 use std::time::{SystemTime, UNIX_EPOCH};

--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,5 @@
 {
-  description = "Vendor Neutral, Rust-Based Management UI and CLI for U2F/FIDO2 and other hardware security keys ";
+  description = "Independent, vendor-neutral GUI and CLI for managing hardware security keys (FIDO2, OATH, OpenPGP, PIV, Token2 TOTP tokens)";
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     flake-parts.url = "github:hercules-ci/flake-parts";
@@ -82,7 +82,7 @@
               '';
 
               meta = {
-                description = "Desktop GUI for programming Token2 Molto2 / Molto2v2 TOTP tokens.";
+                description = keyroostCargo.package.description;
                 homepage = "https://github.com/framefilter/keyroost";
                 license = with pkgs.lib.licenses; [
                   mit
@@ -120,7 +120,7 @@
               '';
 
               meta = {
-                description = "Command-line tool for programming Token2 Molto2 / Molto2v2 TOTP tokens.";
+                description = keyroostctlCargo.package.description;
                 homepage = "https://github.com/framefilter/keyroost";
                 license = with pkgs.lib.licenses; [
                   mit


### PR DESCRIPTION
Follow-up to #109, which merged without the landing items the review checklist asks for.

- README: Contributors entry for @MakeShiftArtist (first contribution) and a "Nix (flake)" subsection under Install.
- changelog.d fragment for the flake.
- The flake's package metadata copied the two binaries' Cargo descriptions, which still described the project as a Molto2-only programmer. The flake now reads `meta.description` from each crate's Cargo.toml so the two cannot drift, its own description drops a trailing space and matches the README tagline, and the stale descriptions for keyroost, keyroostctl and keyroost-transport (plus their crate doc headers) are brought up to date.

No functional code changes. Nix is not available on the maintainer machine, so the flake edits are verified by inspection only; `nix flake check` on a Nix host would confirm the metadata still evaluates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XpyGDFxYw5DSD97HXBAc2q
