### PR TITLE
Add test feature for PIV private key operations

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -91,8 +91,11 @@ jobs:
           # publish must be done by hand before Trusted Publishing can take over.
           # keyroost-screengrab is the same shape: a new, dep-free crate only
           # keyroost uses, so it also needs a one-time hand publish first.
+          # keyroost-pivtest (new in the release after 0.9.0) depends only on
+          # keyroost-piv, so it follows it; same one-time hand publish first.
           for crate in keyroost-proto keyroost-hid keyroost-keyring keyroost-rsakey \
                        keyroost-ctap keyroost-oath keyroost-openpgp keyroost-piv \
+                       keyroost-pivtest \
                        keyroost-token2otp keyroost-token2prog keyroost-import \
                        keyroost-transport keyroost-resolve keyroost-qr \
                        keyroost-winwebauthn keyroost-screengrab \

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -812,6 +812,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f27ae1dd37df86211c42e150270f82743308803d90a6f6e6651cd730d5e1732f"
 
 [[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "digest",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -903,6 +930,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b14ccef22fc6f5a8f4d7d768562a182c04ce9a3b3157b91390b52ddfdf1a76"
 
 [[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der",
+ "digest",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+ "spki",
+]
+
+[[package]]
 name = "ecolor"
 version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -910,6 +951,30 @@ checksum = "6758be723a3f298bbfda4db75748bc2ba0abafe096b6383c7c32da264764fbc3"
 dependencies = [
  "bytemuck",
  "emath",
+]
+
+[[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8",
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "serde",
+ "sha2",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -1041,6 +1106,8 @@ dependencies = [
  "generic-array",
  "group",
  "hkdf",
+ "pem-rfc7468",
+ "pkcs8",
  "rand_core 0.6.4",
  "sec1",
  "subtle",
@@ -1201,6 +1268,12 @@ dependencies = [
  "rand_core 0.6.4",
  "subtle",
 ]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "find-msvc-tools"
@@ -1907,6 +1980,7 @@ dependencies = [
  "keyroost-keyring",
  "keyroost-oath",
  "keyroost-piv",
+ "keyroost-pivtest",
  "keyroost-proto",
  "keyroost-qr",
  "keyroost-resolve",
@@ -1995,6 +2069,19 @@ name = "keyroost-piv"
 version = "0.9.0"
 dependencies = [
  "keyroost-proto",
+ "zeroize",
+]
+
+[[package]]
+name = "keyroost-pivtest"
+version = "0.9.0"
+dependencies = [
+ "ed25519-dalek",
+ "keyroost-piv",
+ "p256",
+ "p384",
+ "rsa",
+ "x25519-dalek",
  "zeroize",
 ]
 
@@ -2104,6 +2191,7 @@ dependencies = [
  "keyroost-oath",
  "keyroost-openpgp",
  "keyroost-piv",
+ "keyroost-pivtest",
  "keyroost-proto",
  "keyroost-qr",
  "keyroost-resolve",
@@ -2742,8 +2830,22 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
 dependencies = [
+ "ecdsa",
  "elliptic-curve",
  "primeorder",
+ "sha2",
+]
+
+[[package]]
+name = "p384"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2",
 ]
 
 [[package]]
@@ -3230,6 +3332,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
 
 [[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac",
+ "subtle",
+]
+
+[[package]]
 name = "rfd"
 version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3408,6 +3520,7 @@ dependencies = [
  "base16ct",
  "der",
  "generic-array",
+ "pkcs8",
  "subtle",
  "zeroize",
 ]
@@ -4708,6 +4821,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acf4d1bc32aa46eec18caa634ec3cf4c05bfa151f12b93b510b15190f69a1ca8"
 
 [[package]]
+name = "x25519-dalek"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
+dependencies = [
+ "curve25519-dalek",
+ "rand_core 0.6.4",
+ "serde",
+ "zeroize",
+]
+
+[[package]]
 name = "xcursor"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4868,6 +4993,20 @@ name = "zeroize"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
 
 [[package]]
 name = "zerotrie"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
     "crates/keyroost-oath",
     "crates/keyroost-openpgp",
     "crates/keyroost-piv",
+    "crates/keyroost-pivtest",
     "crates/keyroost-token2otp",
     "crates/keyroost-token2prog",
     "crates/keyroost-rsakey",

--- a/changelog.d/added-127-piv-slot-self-test.md
+++ b/changelog.d/added-127-piv-slot-self-test.md
@@ -1,0 +1,10 @@
+- **PIV slot key self-test.** `keyroostctl piv test --slot <slot>` (and a
+  Test button in the GUI slot pane) proves a slot's private key works end to
+  end: keyroost builds a fixed challenge from the slot certificate's public
+  key, the card runs every operation the key type supports (decrypt for RSA,
+  key agreement for P-256/P-384/X25519, sign for RSA/ECDSA/Ed25519), and the
+  host verifies each result against that public key. Read-only on the card;
+  needs the PIN unless the slot's PIN policy is "never". The verification
+  side lives in a new `keyroost-pivtest` crate, which adds `p384`,
+  `ed25519-dalek` and `x25519-dalek` (RustCrypto/dalek) to the tree.
+  Contributed by @episource. ([#127])

--- a/crates/keyroost-piv/src/lib.rs
+++ b/crates/keyroost-piv/src/lib.rs
@@ -875,17 +875,30 @@ pub fn general_auth_mutual(
     )
 }
 
-/// The GENERAL AUTHENTICATE dynamic-authentication template body shared by
-/// [`general_auth_sign`] (single extended-length APDU) and
-/// [`general_auth_sign_chained`] (ISO 7816-4 command chaining): `7C L 82 00
-/// 81 <l> <payload>`.
-fn general_auth_sign_data(payload: &[u8]) -> Vec<u8> {
+/// The GENERAL AUTHENTICATE dynamic-authentication template body: `7C L 82 00
+/// <inner_tag> <l> <payload>` — an empty `0x82` ("give me the answer") plus
+/// the input in `inner_tag`. Signing / decryption put the data in `0x81`
+/// (see [`general_auth_sign_data`]); key agreement puts the peer public key
+/// in `0x85` (see [`general_auth_key_agree_data`]).
+fn general_auth_dyn_auth_data(inner_tag: u8, payload: &[u8]) -> Vec<u8> {
     let mut inner = Vec::with_capacity(payload.len() + 6);
     inner.extend_from_slice(&[0x82, 0x00]); // response tag, empty: "give me the answer"
-    push_tlv(&mut inner, &[0x81], payload); // challenge / data to sign
+    push_tlv(&mut inner, &[inner_tag], payload);
     let mut data = Vec::with_capacity(inner.len() + 4);
     push_tlv(&mut data, &[TAG_DYN_AUTH], &inner);
     data
+}
+
+/// The template body shared by [`general_auth_sign`] and
+/// [`general_auth_sign_chained`]: `7C L 82 00 81 <l> <payload>`.
+fn general_auth_sign_data(payload: &[u8]) -> Vec<u8> {
+    general_auth_dyn_auth_data(0x81, payload)
+}
+
+/// The template body shared by [`general_auth_key_agree`] and
+/// [`general_auth_key_agree_chained`]: `7C L 82 00 85 <l> <peer_public_key>`.
+fn general_auth_key_agree_data(peer_public_key: &[u8]) -> Vec<u8> {
+    general_auth_dyn_auth_data(0x85, peer_public_key)
 }
 
 /// GENERAL AUTHENTICATE in signing mode: ask a key slot to sign/decrypt
@@ -930,6 +943,47 @@ pub fn general_auth_sign_chained(
         key_alg.id(),
         key_ref,
         &general_auth_sign_data(payload),
+        max_chunk,
+        Some(0x00),
+    )
+}
+
+/// GENERAL AUTHENTICATE in key-establishment mode: ask an EC key slot to run
+/// ECDH against `peer_public_key` (SP 800-73-4 Part 2 §3.2.4 — the peer key
+/// goes in the dynamic-auth template's `0x85` "exponentiation" field). The
+/// card replies with `7C L 82 <l> <Z>`, where `Z` is the raw shared secret
+/// (the x-coordinate for the NIST curves, the 32-byte output for X25519).
+/// `peer_public_key` is `04 || X || Y` for P-256/P-384 or the raw 32-byte
+/// point for X25519; `key_alg` (P1) is the slot's algorithm, `key_ref` (P2)
+/// its slot.
+#[must_use]
+pub fn general_auth_key_agree(key_alg: KeyAlg, key_ref: u8, peer_public_key: &[u8]) -> Vec<u8> {
+    build_apdu_ext(
+        0x00,
+        Instruction::GeneralAuthenticate.code(),
+        key_alg.id(),
+        key_ref,
+        &general_auth_key_agree_data(peer_public_key),
+        Some(0),
+    )
+}
+
+/// Command-chaining form of [`general_auth_key_agree`], the same fallback
+/// [`general_auth_sign_chained`] is to [`general_auth_sign`] — for cards /
+/// readers that reject a single extended-`Lc` GENERAL AUTHENTICATE.
+#[must_use]
+pub fn general_auth_key_agree_chained(
+    key_alg: KeyAlg,
+    key_ref: u8,
+    peer_public_key: &[u8],
+    max_chunk: usize,
+) -> Vec<Vec<u8>> {
+    chain_apdu(
+        0x00,
+        Instruction::GeneralAuthenticate.code(),
+        key_alg.id(),
+        key_ref,
+        &general_auth_key_agree_data(peer_public_key),
         max_chunk,
         Some(0x00),
     )
@@ -2406,6 +2460,40 @@ mod tests {
         assert_eq!(&apdu[7..11], &[0x7C, 0x82, 0x01, 0x06]);
         assert_eq!(&apdu[apdu.len() - 2..], &[0x00, 0x00]);
         assert_eq!(apdu.len(), 7 + lc + 2);
+    }
+
+    #[test]
+    fn general_auth_key_agree_uses_tag_85() {
+        // Same shape as general_auth_sign but the peer key sits in 0x85, not 0x81:
+        // 00 87 11 9D 0A  7C 08 82 00 85 04 <peer>  00
+        let apdu = general_auth_key_agree(KeyAlg::EccP256, 0x9D, &[0x04, 0xAA, 0xBB, 0xCC]);
+        assert_eq!(
+            apdu,
+            vec![
+                0x00, 0x87, 0x11, 0x9D, 0x0A, 0x7C, 0x08, 0x82, 0x00, 0x85, 0x04, 0x04, 0xAA, 0xBB,
+                0xCC, 0x00,
+            ]
+        );
+        // A large payload forces the extended form; the 0x85 inner tag stays.
+        let apdu = general_auth_key_agree(KeyAlg::EccP256, 0x9D, &[0x04; 256]);
+        assert_eq!(&apdu[..5], &[0x00, 0x87, 0x11, 0x9D, 0x00]);
+        assert_eq!(&apdu[7..11], &[0x7C, 0x82, 0x01, 0x06]); // 7C len == sign's, 0x85 body
+        assert_eq!(apdu[13], 0x85);
+        assert_eq!(&apdu[apdu.len() - 2..], &[0x00, 0x00]);
+    }
+
+    #[test]
+    fn general_auth_key_agree_chained_matches_sign_chained_shape() {
+        let chunks =
+            general_auth_key_agree_chained(KeyAlg::EccP256, 0x9D, &[0x04, 0xAA, 0xBB, 0xCC], 254);
+        assert_eq!(chunks.len(), 1);
+        assert_eq!(
+            chunks[0],
+            vec![
+                0x00, 0x87, 0x11, 0x9D, 0x0A, 0x7C, 0x08, 0x82, 0x00, 0x85, 0x04, 0x04, 0xAA, 0xBB,
+                0xCC, 0x00,
+            ]
+        );
     }
 
     #[test]

--- a/crates/keyroost-piv/src/x509_parse.rs
+++ b/crates/keyroost-piv/src/x509_parse.rs
@@ -442,10 +442,13 @@ const OID_X25519: &str = "1.3.101.110";
 /// RSA modulus whose bit length doesn't land on one of PIV's four sizes): an
 /// unusual certificate shouldn't stop the caller from displaying whatever
 /// else (e.g. the Subject DN) it already parsed.
-pub fn parse_key_algorithm(cert_der: &[u8]) -> Result<Option<KeyAlg>, X509ParseError> {
-    // Certificate ::= SEQUENCE { tbsCertificate, signatureAlgorithm, signature }
+/// The whole DER encoding of a `Certificate`'s `subjectPublicKeyInfo`
+/// `SEQUENCE` (tag, length, and content), by walking `Certificate ::= SEQUENCE
+/// { tbsCertificate, signatureAlgorithm, signature }` into `tbsCertificate`
+/// and skipping the fields ahead of the SPKI. Shared by [`parse_key_algorithm`]
+/// and [`parse_certificate_public_key`].
+fn certificate_spki(cert_der: &[u8]) -> Result<&[u8], X509ParseError> {
     let (cert, _) = expect_tag(cert_der, 0x30)?;
-    // tbsCertificate ::= SEQUENCE { ... }
     let (tbs, _) = expect_tag(cert.content, 0x30)?;
     let mut rest = tbs.content;
 
@@ -463,8 +466,15 @@ pub fn parse_key_algorithm(cert_der: &[u8]) -> Result<Option<KeyAlg>, X509ParseE
     let (_, rest) = expect_tag(rest, 0x30)?;
     let (_, rest) = expect_tag(rest, 0x30)?;
     let (_, rest) = expect_tag(rest, 0x30)?;
+    // `rest` now starts at subjectPublicKeyInfo; take its whole TLV.
+    let (_, after_spki) = expect_tag(rest, 0x30)?;
+    Ok(&rest[..rest.len() - after_spki.len()])
+}
+
+pub fn parse_key_algorithm(cert_der: &[u8]) -> Result<Option<KeyAlg>, X509ParseError> {
+    let spki = certificate_spki(cert_der)?;
     // subjectPublicKeyInfo ::= SEQUENCE { algorithm AlgorithmIdentifier, subjectPublicKey BIT STRING }
-    let (spki, _) = expect_tag(rest, 0x30)?;
+    let (spki, _) = expect_tag(spki, 0x30)?;
     let (alg_id, after_alg_id) = expect_tag(spki.content, 0x30)?;
     let (spk, _) = expect_tag(after_alg_id, 0x03)?;
 
@@ -602,6 +612,21 @@ pub fn parse_subject_public_key_info(der: &[u8]) -> Result<(KeyAlg, PublicKey), 
         )),
         _ => Err(X509ParseError::Malformed),
     }
+}
+
+/// The algorithm and public key of a DER-encoded X.509 `Certificate`, from its
+/// `subjectPublicKeyInfo` — [`parse_key_algorithm`] plus the key material
+/// [`parse_subject_public_key_info`] recovers. Unlike `parse_key_algorithm`
+/// this errors (rather than `Ok(None)`) on an unrecognised key type: a caller
+/// that needs the key bytes has nothing to do with a key it can't read.
+///
+/// # Errors
+/// [`X509ParseError`] on a malformed certificate or a public-key OID/curve
+/// outside PIV's [`KeyAlg`] set.
+pub fn parse_certificate_public_key(
+    cert_der: &[u8],
+) -> Result<(KeyAlg, PublicKey), X509ParseError> {
+    parse_subject_public_key_info(certificate_spki(cert_der)?)
 }
 
 #[cfg(test)]

--- a/crates/keyroost-pivtest/Cargo.toml
+++ b/crates/keyroost-pivtest/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "keyroost-pivtest"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Host-side round-trip self-tests for a PIV slot key (decrypt / key-agree / sign)."
+
+[lints]
+workspace = true
+
+[dependencies]
+keyroost-piv = { path = "../keyroost-piv", version = "0.9.0" }
+# Public-key crypto for the *verification* side of each round trip — a
+# functional check that the card's private-key op produced something the
+# matching public key accepts. All test inputs are fixed compile-time
+# constants (see `data.rs`); this crate pulls in NO RNG. `rsa`/`p256` are
+# already in the workspace tree; `p384` / `ed25519-dalek` / `x25519-dalek`
+# were added for this feature (the user asked for those algorithms), and the
+# two dalek crates share one `curve25519-dalek` subtree.
+rsa = "0.9"
+p256 = { version = "0.13", features = ["ecdh"] }
+p384 = { version = "0.13", features = ["ecdh"] }
+ed25519-dalek = "2"
+x25519-dalek = "2"
+zeroize = "1"
+

--- a/crates/keyroost-pivtest/src/data.rs
+++ b/crates/keyroost-pivtest/src/data.rs
@@ -1,0 +1,53 @@
+//! The one source of every value a self-test feeds the card.
+//!
+//! No RNG: reproducibility matters more than unpredictability here (this is a
+//! functional check, not a KAT and not a security operation). Everything is
+//! sliced or cycled out of a single 512-bit array whose only real constraint
+//! is that **no byte is zero** — the RSA PKCS#1 v1.5 padding string must be
+//! all-nonzero, and a zero in an EC scalar's high bytes would just be wasted
+//! entropy.
+
+/// 64 bytes (512 bits), every byte non-zero, in four distinct 16-byte lines
+/// so a hex dump is easy to eyeball in an APDU trace.
+pub const TEST_INPUT: [u8; 64] = [
+    0xCA, 0xFE, 0xF0, 0x0D, 0xDE, 0xAD, 0xBE, 0xEF, 0xC0, 0xFF, 0xEE, 0x15, 0xBA, 0x5E, 0xBA, 0x11,
+    0x1D, 0xEA, 0xD1, 0xCE, 0xF1, 0x5C, 0xA1, 0x1F, 0x5E, 0xED, 0xFA, 0xCE, 0xB0, 0xA7, 0xC1, 0xA5,
+    0xD0, 0xD0, 0xCA, 0xCA, 0x0F, 0xF1, 0xCE, 0xB0, 0x07, 0x1E, 0xAD, 0xEF, 0x1E, 0x1D, 0x0F, 0xED,
+    0xFE, 0xED, 0xC0, 0xDE, 0x5A, 0x1A, 0xD1, 0x5C, 0x0D, 0xEF, 0xEC, 0xAB, 0x1E, 0xB1, 0x05, 0xC0,
+];
+
+/// The plaintext the Decrypt self-test round-trips through the card.
+pub const DECRYPT_PLAINTEXT: &[u8] = b"Hello World!";
+
+/// ASN.1 `DigestInfo` prefix for SHA-512 (`SEQUENCE { SEQUENCE { OID
+/// sha-512, NULL }, OCTET STRING (64) }` header) — the 19 bytes that precede
+/// the 64 hash bytes in a PKCS#1 v1.5 signature block. Kept as a literal so
+/// this crate needs no `sha2` dependency just to name a constant.
+pub const SHA512_DIGESTINFO_PREFIX: [u8; 19] = [
+    0x30, 0x51, 0x30, 0x0D, 0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x02, 0x03, 0x05,
+    0x00, 0x04, 0x40,
+];
+
+/// "Their" 32-byte private scalar for a P-256 / X25519 key-agree, and the
+/// first 32 bytes of a P-384 one. For the NIST curves byte 0 is forced to
+/// `0x00` by [`ec_scalar`] so the value is unconditionally in `1..n`; X25519
+/// clamps internally so it takes the bytes as-is.
+#[must_use]
+pub fn ec_scalar<const N: usize>(clamp_high_byte: bool) -> [u8; N] {
+    let mut s = [0u8; N];
+    s.copy_from_slice(&TEST_INPUT[..N]);
+    if clamp_high_byte {
+        s[0] = 0x00;
+    }
+    s
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_input_has_no_zero_byte() {
+        assert!(TEST_INPUT.iter().all(|&b| b != 0));
+    }
+}

--- a/crates/keyroost-pivtest/src/lib.rs
+++ b/crates/keyroost-pivtest/src/lib.rs
@@ -1,0 +1,569 @@
+//! Host-side round-trip self-tests for a PIV slot's private key.
+//!
+//! Each [`SelfTest`] exercises one private-key operation end to end: build a
+//! fixed challenge ([`prepare`]), hand its `card_input` to the card's GENERAL
+//! AUTHENTICATE (that part lives in `keyroost-transport`), then check the
+//! reply with [`Challenge::verify`] against the *public* key from the slot's
+//! certificate. A pass means the card really can decrypt / key-agree / sign
+//! with that slot and the matching public key accepts the result.
+//!
+//! This is a **functional** check, not a known-answer test and not a security
+//! operation: every input is a compile-time constant (see [`mod@data`]), so
+//! there is no RNG anywhere in this crate.
+//!
+//! Supported per operation:
+//!
+//! | operation   | RSA | P-256 | P-384 | Ed25519 | X25519 |
+//! |-------------|-----|-------|-------|---------|--------|
+//! | [`SelfTest::Decrypt`]  | ✔ |   |   |   |   |
+//! | [`SelfTest::KeyAgree`] |   | ✔ | ✔ |   | ✔ |
+//! | [`SelfTest::Sign`]     | ✔ | ✔ | ✔ | ✔ |   |
+
+#![forbid(unsafe_code)]
+
+mod data;
+
+use core::fmt;
+
+use data::{ec_scalar, DECRYPT_PLAINTEXT, SHA512_DIGESTINFO_PREFIX, TEST_INPUT};
+// `elliptic_curve` is shared by p256 and p384; one import covers both curves.
+pub use keyroost_piv::{KeyAlg, PublicKey};
+use p256::elliptic_curve::sec1::ToEncodedPoint;
+
+/// One private-key operation a PIV slot can be tested against.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SelfTest {
+    /// RSA: PKCS#1 v1.5-encrypt a known string to the slot's public key, have
+    /// the card decrypt it, check the plaintext comes back.
+    Decrypt,
+    /// ECDH (P-256 / P-384 / X25519): agree a shared secret two ways — the
+    /// card's private key against a fixed peer public key, and this host's
+    /// fixed peer private key against the slot's public key — and check they
+    /// match.
+    KeyAgree,
+    /// Sign a fixed digest / message on the card, verify the signature with
+    /// the slot's public key.
+    Sign,
+}
+
+impl SelfTest {
+    /// Short button/label text.
+    #[must_use]
+    pub const fn label(self) -> &'static str {
+        match self {
+            SelfTest::Decrypt => "Decrypt",
+            SelfTest::KeyAgree => "Key Agree",
+            SelfTest::Sign => "Sign",
+        }
+    }
+
+    /// All three, in display order.
+    #[must_use]
+    pub const fn all() -> [SelfTest; 3] {
+        [SelfTest::Decrypt, SelfTest::KeyAgree, SelfTest::Sign]
+    }
+
+    /// Whether this operation reads the card reply out of the key-agreement
+    /// exponentiation field (GENERAL AUTHENTICATE dynamic-auth tag `0x85`)
+    /// rather than the plain data field (`0x81`). The transport layer uses
+    /// this to pick the right builder.
+    #[must_use]
+    pub const fn is_key_agreement(self) -> bool {
+        matches!(self, SelfTest::KeyAgree)
+    }
+}
+
+/// Whether [`prepare`] can build a challenge for `op` against a key of `alg`.
+/// The GUI gates its buttons on this; [`prepare`] enforces it too.
+#[must_use]
+pub fn supports(op: SelfTest, alg: KeyAlg) -> bool {
+    let rsa = matches!(
+        alg,
+        KeyAlg::Rsa1024 | KeyAlg::Rsa2048 | KeyAlg::Rsa3072 | KeyAlg::Rsa4096
+    );
+    match op {
+        SelfTest::Decrypt => rsa,
+        SelfTest::KeyAgree => matches!(alg, KeyAlg::EccP256 | KeyAlg::EccP384 | KeyAlg::X25519),
+        SelfTest::Sign => rsa || matches!(alg, KeyAlg::EccP256 | KeyAlg::EccP384 | KeyAlg::Ed25519),
+    }
+}
+
+/// Why a self-test could not be built or did not pass.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TestError {
+    /// `op` is not defined for a key of this algorithm (see [`supports`]).
+    Unsupported(SelfTest, KeyAlg),
+    /// The slot's public key (from its certificate) is the wrong type or
+    /// malformed for this operation.
+    BadPublicKey(&'static str),
+    /// The card answered, but its reply is structurally wrong (not a PKCS#1
+    /// block, not DER, wrong length, …).
+    CardReply(&'static str),
+    /// The operation ran and produced a well-formed result that does **not**
+    /// match what the public key expects — the slot's key does not verify.
+    Mismatch(SelfTest),
+}
+
+impl fmt::Display for TestError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            TestError::Unsupported(op, alg) => {
+                write!(
+                    f,
+                    "{} self-test is not available for {} keys",
+                    op.label(),
+                    alg.label()
+                )
+            }
+            TestError::BadPublicKey(why) => write!(f, "slot public key unusable: {why}"),
+            TestError::CardReply(why) => write!(f, "card reply malformed: {why}"),
+            TestError::Mismatch(op) => {
+                write!(
+                    f,
+                    "{} self-test failed: the result did not verify against the slot's public key",
+                    op.label()
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for TestError {}
+
+/// A prepared self-test: what to send the card, plus what to check.
+pub struct Challenge {
+    op: SelfTest,
+    /// Bytes for the card's GENERAL AUTHENTICATE dynamic-authentication
+    /// template value — the data field (`0x81`) for [`SelfTest::Decrypt`] /
+    /// [`SelfTest::Sign`], the exponentiation field (`0x85`) for
+    /// [`SelfTest::KeyAgree`]. See [`SelfTest::is_key_agreement`].
+    pub card_input: Vec<u8>,
+    verifier: Verifier,
+}
+
+impl Challenge {
+    /// The operation this challenge is for.
+    #[must_use]
+    pub const fn op(&self) -> SelfTest {
+        self.op
+    }
+
+    /// Check the card's GENERAL AUTHENTICATE reply. `Ok(())` = the self-test
+    /// passed.
+    pub fn verify(&self, card_reply: &[u8]) -> Result<(), TestError> {
+        match &self.verifier {
+            Verifier::RsaEme => verify_rsa_eme(card_reply),
+            Verifier::Exact(want) => (card_reply == want.as_slice())
+                .then_some(())
+                .ok_or(TestError::Mismatch(SelfTest::KeyAgree)),
+            Verifier::RsaSig { modulus, exponent } => verify_rsa_sig(modulus, exponent, card_reply),
+            Verifier::EcdsaSig {
+                curve,
+                point,
+                digest_len,
+            } => verify_ecdsa(*curve, point, *digest_len, card_reply),
+            Verifier::Ed25519Sig { pubkey } => verify_ed25519(pubkey, card_reply),
+        }
+    }
+}
+
+enum Verifier {
+    /// Card returns `c^d mod n` = our PKCS#1 v1.5 EME block; strip the padding
+    /// and match the tail against [`DECRYPT_PLAINTEXT`].
+    RsaEme,
+    /// Card reply must equal these bytes verbatim (ECDH shared secret).
+    Exact(Vec<u8>),
+    /// RSA signature over `PKCS1v15(DigestInfo(SHA-512, TEST_INPUT[..64]))`.
+    RsaSig { modulus: Vec<u8>, exponent: Vec<u8> },
+    /// DER ECDSA signature over `TEST_INPUT[..digest_len]` as a prehash.
+    EcdsaSig {
+        curve: EcCurve,
+        point: Vec<u8>,
+        digest_len: usize,
+    },
+    /// Ed25519 signature over the whole of `TEST_INPUT`.
+    Ed25519Sig { pubkey: [u8; 32] },
+}
+
+#[derive(Clone, Copy)]
+enum EcCurve {
+    P256,
+    P384,
+}
+
+/// Build the challenge for `op` against a slot holding `(alg, pubkey)`, where
+/// `pubkey` is the slot certificate's public key.
+///
+/// # Errors
+/// [`TestError::Unsupported`] if `op` is not defined for `alg`;
+/// [`TestError::BadPublicKey`] if `pubkey` is the wrong type or malformed.
+pub fn prepare(op: SelfTest, alg: KeyAlg, pubkey: &PublicKey) -> Result<Challenge, TestError> {
+    if !supports(op, alg) {
+        return Err(TestError::Unsupported(op, alg));
+    }
+    match op {
+        SelfTest::Decrypt => prepare_decrypt(pubkey),
+        SelfTest::KeyAgree => prepare_key_agree(alg, pubkey),
+        SelfTest::Sign => prepare_sign(alg, pubkey),
+    }
+}
+
+// --- Decrypt --------------------------------------------------------------
+
+fn prepare_decrypt(pubkey: &PublicKey) -> Result<Challenge, TestError> {
+    let (modulus, exponent) = rsa_parts(pubkey)?;
+    let k = modulus.len();
+    let msg = DECRYPT_PLAINTEXT;
+    // EME-PKCS1-v1_5: 00 02 || PS (>= 8 non-zero bytes) || 00 || M
+    let ps_len =
+        k.checked_sub(msg.len() + 3)
+            .filter(|&l| l >= 8)
+            .ok_or(TestError::BadPublicKey(
+                "RSA modulus too small for the test message",
+            ))?;
+    let mut em = Vec::with_capacity(k);
+    em.push(0x00);
+    em.push(0x02);
+    em.extend(TEST_INPUT.iter().copied().cycle().take(ps_len)); // every byte non-zero
+    em.push(0x00);
+    em.extend_from_slice(msg);
+    debug_assert_eq!(em.len(), k);
+    let ciphertext = rsa_public_op(modulus, exponent, &em, k)?;
+    Ok(Challenge {
+        op: SelfTest::Decrypt,
+        card_input: ciphertext,
+        verifier: Verifier::RsaEme,
+    })
+}
+
+fn verify_rsa_eme(reply: &[u8]) -> Result<(), TestError> {
+    // Card returns c^d mod n = the EME block we built; some implementations
+    // drop the leading 0x00.
+    let body = match reply.first() {
+        Some(0x00) => &reply[1..],
+        _ => reply,
+    };
+    let body = body.strip_prefix(&[0x02]).ok_or(TestError::CardReply(
+        "decrypt result is not a PKCS#1 v1.5 block",
+    ))?;
+    let sep = body
+        .iter()
+        .position(|&b| b == 0x00)
+        .ok_or(TestError::CardReply(
+            "decrypt result has no padding separator",
+        ))?;
+    if sep < 8 {
+        return Err(TestError::CardReply("decrypt result padding too short"));
+    }
+    (&body[sep + 1..] == DECRYPT_PLAINTEXT)
+        .then_some(())
+        .ok_or(TestError::Mismatch(SelfTest::Decrypt))
+}
+
+// --- Key agreement ------------------------------------------------------
+
+fn prepare_key_agree(alg: KeyAlg, pubkey: &PublicKey) -> Result<Challenge, TestError> {
+    let point = ecc_point(pubkey)?;
+    let (card_input, shared) = match alg {
+        KeyAlg::EccP256 => {
+            let our = p256::PublicKey::from_sec1_bytes(point)
+                .map_err(|_| TestError::BadPublicKey("malformed P-256 public point"))?;
+            let their = p256::SecretKey::from_slice(&ec_scalar::<32>(true))
+                .map_err(|_| TestError::BadPublicKey("derived P-256 scalar out of range"))?;
+            let secret = p256::ecdh::diffie_hellman(their.to_nonzero_scalar(), our.as_affine());
+            (
+                their
+                    .public_key()
+                    .to_encoded_point(false)
+                    .as_bytes()
+                    .to_vec(),
+                secret.raw_secret_bytes().to_vec(),
+            )
+        }
+        KeyAlg::EccP384 => {
+            let our = p384::PublicKey::from_sec1_bytes(point)
+                .map_err(|_| TestError::BadPublicKey("malformed P-384 public point"))?;
+            let their = p384::SecretKey::from_slice(&ec_scalar::<48>(true))
+                .map_err(|_| TestError::BadPublicKey("derived P-384 scalar out of range"))?;
+            let secret = p384::ecdh::diffie_hellman(their.to_nonzero_scalar(), our.as_affine());
+            (
+                their
+                    .public_key()
+                    .to_encoded_point(false)
+                    .as_bytes()
+                    .to_vec(),
+                secret.raw_secret_bytes().to_vec(),
+            )
+        }
+        KeyAlg::X25519 => {
+            let our: [u8; 32] = point
+                .try_into()
+                .map_err(|_| TestError::BadPublicKey("X25519 public key must be 32 bytes"))?;
+            let scalar = ec_scalar::<32>(false);
+            (
+                x25519_dalek::x25519(scalar, x25519_dalek::X25519_BASEPOINT_BYTES).to_vec(),
+                x25519_dalek::x25519(scalar, our).to_vec(),
+            )
+        }
+        _ => return Err(TestError::Unsupported(SelfTest::KeyAgree, alg)),
+    };
+    Ok(Challenge {
+        op: SelfTest::KeyAgree,
+        card_input,
+        verifier: Verifier::Exact(shared),
+    })
+}
+
+// --- Sign --------------------------------------------------------------
+
+fn prepare_sign(alg: KeyAlg, pubkey: &PublicKey) -> Result<Challenge, TestError> {
+    match alg {
+        KeyAlg::Rsa1024 | KeyAlg::Rsa2048 | KeyAlg::Rsa3072 | KeyAlg::Rsa4096 => {
+            let (modulus, exponent) = rsa_parts(pubkey)?;
+            let k = modulus.len();
+            let mut t = Vec::with_capacity(SHA512_DIGESTINFO_PREFIX.len() + 64);
+            t.extend_from_slice(&SHA512_DIGESTINFO_PREFIX);
+            t.extend_from_slice(&TEST_INPUT[..64]);
+            // EMSA-PKCS1-v1_5: 00 01 || FF … (>= 8) || 00 || T
+            let pad =
+                k.checked_sub(t.len() + 3)
+                    .filter(|&l| l >= 8)
+                    .ok_or(TestError::BadPublicKey(
+                        "RSA modulus too small for a SHA-512 signature block",
+                    ))?;
+            let mut em = Vec::with_capacity(k);
+            em.push(0x00);
+            em.push(0x01);
+            em.resize(2 + pad, 0xFF);
+            em.push(0x00);
+            em.extend_from_slice(&t);
+            debug_assert_eq!(em.len(), k);
+            Ok(Challenge {
+                op: SelfTest::Sign,
+                card_input: em,
+                verifier: Verifier::RsaSig {
+                    modulus: modulus.to_vec(),
+                    exponent: exponent.to_vec(),
+                },
+            })
+        }
+        KeyAlg::EccP256 | KeyAlg::EccP384 => {
+            let point = ecc_point(pubkey)?;
+            let (curve, digest_len) = match alg {
+                KeyAlg::EccP256 => (EcCurve::P256, 32usize),
+                _ => (EcCurve::P384, 48usize),
+            };
+            // Validate the point up front so a bad cert fails at prepare time.
+            match curve {
+                EcCurve::P256 => {
+                    p256::ecdsa::VerifyingKey::from_sec1_bytes(point)
+                        .map_err(|_| TestError::BadPublicKey("malformed P-256 public point"))?;
+                }
+                EcCurve::P384 => {
+                    p384::ecdsa::VerifyingKey::from_sec1_bytes(point)
+                        .map_err(|_| TestError::BadPublicKey("malformed P-384 public point"))?;
+                }
+            }
+            Ok(Challenge {
+                op: SelfTest::Sign,
+                card_input: TEST_INPUT[..digest_len].to_vec(),
+                verifier: Verifier::EcdsaSig {
+                    curve,
+                    point: point.to_vec(),
+                    digest_len,
+                },
+            })
+        }
+        KeyAlg::Ed25519 => {
+            let point = ecc_point(pubkey)?;
+            let pk: [u8; 32] = point
+                .try_into()
+                .map_err(|_| TestError::BadPublicKey("Ed25519 public key must be 32 bytes"))?;
+            ed25519_dalek::VerifyingKey::from_bytes(&pk)
+                .map_err(|_| TestError::BadPublicKey("invalid Ed25519 public key"))?;
+            Ok(Challenge {
+                op: SelfTest::Sign,
+                card_input: TEST_INPUT.to_vec(),
+                verifier: Verifier::Ed25519Sig { pubkey: pk },
+            })
+        }
+        _ => Err(TestError::Unsupported(SelfTest::Sign, alg)),
+    }
+}
+
+fn verify_rsa_sig(modulus: &[u8], exponent: &[u8], sig: &[u8]) -> Result<(), TestError> {
+    let key = rsa::RsaPublicKey::new(
+        rsa::BigUint::from_bytes_be(modulus),
+        rsa::BigUint::from_bytes_be(exponent),
+    )
+    .map_err(|_| TestError::BadPublicKey("invalid RSA public key"))?;
+    let scheme = rsa::Pkcs1v15Sign {
+        hash_len: Some(64),
+        prefix: SHA512_DIGESTINFO_PREFIX.to_vec().into_boxed_slice(),
+    };
+    key.verify(scheme, &TEST_INPUT[..64], sig)
+        .map_err(|_| TestError::Mismatch(SelfTest::Sign))
+}
+
+fn verify_ecdsa(
+    curve: EcCurve,
+    point: &[u8],
+    digest_len: usize,
+    sig: &[u8],
+) -> Result<(), TestError> {
+    let digest = &TEST_INPUT[..digest_len];
+    match curve {
+        EcCurve::P256 => {
+            use p256::ecdsa::signature::hazmat::PrehashVerifier;
+            let vk = p256::ecdsa::VerifyingKey::from_sec1_bytes(point)
+                .map_err(|_| TestError::BadPublicKey("malformed P-256 public point"))?;
+            let s = p256::ecdsa::Signature::from_der(sig)
+                .map_err(|_| TestError::CardReply("ECDSA signature is not valid DER"))?;
+            vk.verify_prehash(digest, &s)
+                .map_err(|_| TestError::Mismatch(SelfTest::Sign))
+        }
+        EcCurve::P384 => {
+            use p384::ecdsa::signature::hazmat::PrehashVerifier;
+            let vk = p384::ecdsa::VerifyingKey::from_sec1_bytes(point)
+                .map_err(|_| TestError::BadPublicKey("malformed P-384 public point"))?;
+            let s = p384::ecdsa::Signature::from_der(sig)
+                .map_err(|_| TestError::CardReply("ECDSA signature is not valid DER"))?;
+            vk.verify_prehash(digest, &s)
+                .map_err(|_| TestError::Mismatch(SelfTest::Sign))
+        }
+    }
+}
+
+fn verify_ed25519(pubkey: &[u8; 32], sig: &[u8]) -> Result<(), TestError> {
+    let vk = ed25519_dalek::VerifyingKey::from_bytes(pubkey)
+        .map_err(|_| TestError::BadPublicKey("invalid Ed25519 public key"))?;
+    let s = ed25519_dalek::Signature::from_slice(sig)
+        .map_err(|_| TestError::CardReply("Ed25519 signature must be 64 bytes"))?;
+    vk.verify_strict(&TEST_INPUT, &s)
+        .map_err(|_| TestError::Mismatch(SelfTest::Sign))
+}
+
+// --- shared helpers ---------------------------------------------------
+
+fn rsa_parts(pk: &PublicKey) -> Result<(&[u8], &[u8]), TestError> {
+    match pk {
+        PublicKey::Rsa { modulus, exponent } => Ok((modulus, exponent)),
+        PublicKey::Ecc { .. } => Err(TestError::BadPublicKey("expected an RSA public key")),
+    }
+}
+
+fn ecc_point(pk: &PublicKey) -> Result<&[u8], TestError> {
+    match pk {
+        PublicKey::Ecc { point } => Ok(point),
+        PublicKey::Rsa { .. } => Err(TestError::BadPublicKey("expected an EC public key")),
+    }
+}
+
+/// `m^e mod n`, left-padded to `k` bytes. Validates the key shape through
+/// [`rsa::RsaPublicKey::new`] first.
+fn rsa_public_op(
+    modulus: &[u8],
+    exponent: &[u8],
+    m: &[u8],
+    k: usize,
+) -> Result<Vec<u8>, TestError> {
+    let n = rsa::BigUint::from_bytes_be(modulus);
+    let e = rsa::BigUint::from_bytes_be(exponent);
+    rsa::RsaPublicKey::new(n.clone(), e.clone())
+        .map_err(|_| TestError::BadPublicKey("invalid RSA public key"))?;
+    let c = rsa::BigUint::from_bytes_be(m).modpow(&e, &n);
+    let be = c.to_bytes_be();
+    Ok(if be.len() >= k {
+        be
+    } else {
+        let mut out = vec![0u8; k - be.len()];
+        out.extend_from_slice(&be);
+        out
+    })
+}
+
+// --- full run: every applicable operation -----------------------------
+
+/// How one operation went in a [`run`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Outcome {
+    /// Ran, and the reply verified against the slot's public key.
+    Passed,
+    /// Ran, but the reply did not verify (or the card / challenge errored) —
+    /// carries a short reason.
+    Failed(String),
+    /// Not run: this operation doesn't apply to the slot key's algorithm
+    /// (carried so a report can name it).
+    Skipped(KeyAlg),
+}
+
+impl Outcome {
+    /// Whether this is a real failure (a `Skipped` op is not).
+    #[must_use]
+    pub fn is_failure(&self) -> bool {
+        matches!(self, Outcome::Failed(_))
+    }
+}
+
+/// Run every [`SelfTest`] against a slot holding `(alg, pubkey)` — `pubkey`
+/// being the slot certificate's public key — in `Decrypt` → `KeyAgree` →
+/// `Sign` order.
+///
+/// For each *applicable* operation, [`prepare`] builds the GENERAL
+/// AUTHENTICATE input, `card(op, input)` performs the card's private-key op
+/// and returns the raw reply, and [`Challenge::verify`] checks it. `card` also
+/// owns any per-op PIN dance (a PIN-per-use slot needs a fresh VERIFY before
+/// each op). Operations the key algorithm doesn't support are returned as
+/// [`Outcome::Skipped`] and `card` is not called for them.
+///
+/// Always returns one entry per [`SelfTest::all`]; never errors (a card error
+/// mid-op becomes that op's [`Outcome::Failed`]).
+pub fn run<F, E>(alg: KeyAlg, pubkey: &PublicKey, mut card: F) -> Vec<(SelfTest, Outcome)>
+where
+    F: FnMut(SelfTest, &[u8]) -> Result<Vec<u8>, E>,
+    E: core::fmt::Display,
+{
+    SelfTest::all()
+        .into_iter()
+        .map(|op| {
+            if !supports(op, alg) {
+                return (op, Outcome::Skipped(alg));
+            }
+            let outcome = (|| -> Result<(), String> {
+                let ch = prepare(op, alg, pubkey).map_err(|e| e.to_string())?;
+                let reply = card(op, &ch.card_input).map_err(|e| e.to_string())?;
+                ch.verify(&reply).map_err(|e| e.to_string())
+            })();
+            (
+                op,
+                match outcome {
+                    Ok(()) => Outcome::Passed,
+                    Err(e) => Outcome::Failed(e),
+                },
+            )
+        })
+        .collect()
+}
+
+/// One human-readable line per operation:
+/// `<op>: passed`, `<op>: FAILED \u{2014} <reason>`, or
+/// `<op>: skipped \u{2014} not supported for <alg> keys`.
+#[must_use]
+pub fn format_report(results: &[(SelfTest, Outcome)]) -> String {
+    results
+        .iter()
+        .map(|(op, r)| match r {
+            Outcome::Passed => format!("{}: passed", op.label()),
+            Outcome::Failed(e) => format!("{}: FAILED \u{2014} {e}", op.label()),
+            Outcome::Skipped(alg) => format!(
+                "{}: skipped \u{2014} not supported for {} keys",
+                op.label(),
+                alg.label()
+            ),
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/keyroost-pivtest/src/tests.rs
+++ b/crates/keyroost-pivtest/src/tests.rs
@@ -1,0 +1,325 @@
+//! Round-trip tests: take a fixed "card" key of each type, play the card's
+//! private-key op against [`prepare`]'s output, and check
+//! [`Challenge::verify`] passes — then that a corrupted reply fails.
+//!
+//! No RNG here either. The elliptic-curve "card" keys are fixed scalars
+//! derived from [`TEST_INPUT`] (read back-to-front, so they differ from the
+//! challenge's own ephemeral key); the RSA "card" key is one throwaway
+//! PKCS#8 constant, since an RSA key can't be built from a scalar.
+
+use super::*;
+use rsa::pkcs8::DecodePrivateKey;
+use rsa::traits::{PrivateKeyParts, PublicKeyParts};
+
+/// A fixed "card" private scalar for the round-trip tests, distinct from the
+/// challenge's ephemeral key (which reads [`TEST_INPUT`] front-to-back) so a
+/// key-agreement test exercises two genuinely different keys. Byte 0 is `0x01`
+/// so the value is a valid, small scalar on every NIST curve; X25519 clamps
+/// internally and Ed25519 accepts any 32 bytes.
+fn card_scalar<const N: usize>() -> [u8; N] {
+    let mut s = [0u8; N];
+    for (i, b) in s.iter_mut().enumerate() {
+        *b = TEST_INPUT[TEST_INPUT.len() - 1 - i];
+    }
+    s[0] = 0x01;
+    s
+}
+
+// --- RSA -----------------------------------------------------------------
+
+/// One throwaway RSA-1024 key (PKCS#8), generated once for these tests. Not
+/// used anywhere near real key material — it exists only to play the card's
+/// `x^d mod n` in the decrypt / sign round trips.
+const CARD_RSA_1024_PKCS8: &str = "\
+-----BEGIN PRIVATE KEY-----
+MIICdgIBADANBgkqhkiG9w0BAQEFAASCAmAwggJcAgEAAoGBAK2p0JyMO9AViq/C
+tx75dMJJbh/zP+BRzY24JN9hCZH5OB2TNCRm5F99o4LBNVfWFl7jzM0ujmfbLdVw
+1j+8UAfVzRPcn0ZBUB9BkWUEQIJLKMhgb5vQ1EsNdVkZ22tzym5r9PE7dMPI39aH
+4qxP9ya0d9ojW8wM7qjDHZukQqC3AgMBAAECgYB4G3BqNRrRCXUHpjWcOI8mKD7/
+3e6ZqDnwACGQVL6XtLO40KxJWNgtqulBb3sDKtACBK8KYV6gOZhzfDzRi94UyYOn
+qM0Vm+hJBuulbMdzZb8eu7i6r4dan2pYwfa5r1Y2ANbdr9gnkfSMAuggbGi4kzgJ
+G6ZnyDzYeG6ESxv38QJBANLoaBauYqlsFQYXJCueGtebzJWtJHiRs61eGaOokt0x
+gDfz3IG5ldaV267ct8RB4Rgd47dMhikwzGgHHG+Mq/UCQQDSyujb7hLznUyrE+Mz
+UDPYQErtOgJFqrGiUyNVQzdCXTZphP31zcxqqGzq0ywnE81X2W97hsxxesgMvrNi
+TLp7AkA5kci/0DAMMP14IR71bP3EtrlcbduTsanK+/Ghs6ULDbUDEOSy4FafMV66
+13Kt9pGbxKTg5tmEKtbQ2ogPhuV1AkEAraSvTDUDcaGbvbZFTEj+XF8iGefWZVNm
+v0Rjb+JODCJDJ4uBtVIR2a7jAlJxJcO/PWYF2ylBEx5E25LgrNJuLwJAVZzywiC+
+BtVqYRn838qTnnlTryNJ4D4djKEftqgTCyQeZHjJ5293fy/zAkUrfrDqHm+ueeY9
+O/jnL7juIyD8/g==
+-----END PRIVATE KEY-----";
+
+fn card_rsa() -> rsa::RsaPrivateKey {
+    rsa::RsaPrivateKey::from_pkcs8_pem(CARD_RSA_1024_PKCS8).expect("fixed test RSA key parses")
+}
+
+fn rsa_pub(key: &rsa::RsaPrivateKey) -> PublicKey {
+    PublicKey::Rsa {
+        modulus: key.n().to_bytes_be(),
+        exponent: key.e().to_bytes_be(),
+    }
+}
+
+/// Raw RSA primitive `x^exp mod n`, left-padded to `k` — the operation a PIV
+/// card performs for both decrypt and sign.
+fn rsa_raw(x: &[u8], exp: &rsa::BigUint, n: &rsa::BigUint, k: usize) -> Vec<u8> {
+    let y = rsa::BigUint::from_bytes_be(x).modpow(exp, n);
+    let be = y.to_bytes_be();
+    if be.len() >= k {
+        be
+    } else {
+        let mut out = vec![0u8; k - be.len()];
+        out.extend_from_slice(&be);
+        out
+    }
+}
+
+#[test]
+fn decrypt_round_trips_rsa() {
+    let key = card_rsa();
+    let k = key.n().to_bytes_be().len();
+    let ch = prepare(SelfTest::Decrypt, KeyAlg::Rsa1024, &rsa_pub(&key)).unwrap();
+    let reply = rsa_raw(&ch.card_input, key.d(), key.n(), k);
+    ch.verify(&reply).unwrap();
+
+    let mut bad = reply.clone();
+    *bad.last_mut().unwrap() ^= 0x01;
+    assert!(matches!(
+        ch.verify(&bad),
+        Err(TestError::Mismatch(_) | TestError::CardReply(_))
+    ));
+}
+
+#[test]
+fn sign_round_trips_rsa() {
+    let key = card_rsa();
+    let k = key.n().to_bytes_be().len();
+    let ch = prepare(SelfTest::Sign, KeyAlg::Rsa1024, &rsa_pub(&key)).unwrap();
+    let sig = rsa_raw(&ch.card_input, key.d(), key.n(), k);
+    ch.verify(&sig).unwrap();
+
+    let mut bad = sig.clone();
+    bad[k / 2] ^= 0x01;
+    assert!(matches!(ch.verify(&bad), Err(TestError::Mismatch(_))));
+}
+
+// --- Key agreement -----------------------------------------------------
+
+#[test]
+fn key_agree_round_trips_p256() {
+    let card = p256::SecretKey::from_slice(&card_scalar::<32>()).unwrap();
+    let pubkey = PublicKey::Ecc {
+        point: card
+            .public_key()
+            .to_encoded_point(false)
+            .as_bytes()
+            .to_vec(),
+    };
+    let ch = prepare(SelfTest::KeyAgree, KeyAlg::EccP256, &pubkey).unwrap();
+    let their = p256::PublicKey::from_sec1_bytes(&ch.card_input).unwrap();
+    let reply = p256::ecdh::diffie_hellman(card.to_nonzero_scalar(), their.as_affine())
+        .raw_secret_bytes()
+        .to_vec();
+    ch.verify(&reply).unwrap();
+    assert!(ch.verify(&reply[..reply.len() - 1]).is_err());
+}
+
+#[test]
+fn key_agree_round_trips_p384() {
+    let card = p384::SecretKey::from_slice(&card_scalar::<48>()).unwrap();
+    let pubkey = PublicKey::Ecc {
+        point: card
+            .public_key()
+            .to_encoded_point(false)
+            .as_bytes()
+            .to_vec(),
+    };
+    let ch = prepare(SelfTest::KeyAgree, KeyAlg::EccP384, &pubkey).unwrap();
+    let their = p384::PublicKey::from_sec1_bytes(&ch.card_input).unwrap();
+    let reply = p384::ecdh::diffie_hellman(card.to_nonzero_scalar(), their.as_affine())
+        .raw_secret_bytes()
+        .to_vec();
+    ch.verify(&reply).unwrap();
+}
+
+#[test]
+fn key_agree_round_trips_x25519() {
+    let card_scalar = card_scalar::<32>();
+    let pubkey = PublicKey::Ecc {
+        point: x25519_dalek::x25519(card_scalar, x25519_dalek::X25519_BASEPOINT_BYTES).to_vec(),
+    };
+    let ch = prepare(SelfTest::KeyAgree, KeyAlg::X25519, &pubkey).unwrap();
+    let their: [u8; 32] = ch.card_input.clone().try_into().unwrap();
+    let reply = x25519_dalek::x25519(card_scalar, their).to_vec();
+    ch.verify(&reply).unwrap();
+
+    let mut bad = reply.clone();
+    bad[0] ^= 0x01;
+    assert!(matches!(ch.verify(&bad), Err(TestError::Mismatch(_))));
+}
+
+// --- Sign ------------------------------------------------------------
+
+#[test]
+fn sign_round_trips_p256() {
+    use p256::ecdsa::signature::hazmat::PrehashSigner;
+    let sk = p256::ecdsa::SigningKey::from_slice(&card_scalar::<32>()).unwrap();
+    let pubkey = PublicKey::Ecc {
+        point: sk
+            .verifying_key()
+            .to_encoded_point(false)
+            .as_bytes()
+            .to_vec(),
+    };
+    let ch = prepare(SelfTest::Sign, KeyAlg::EccP256, &pubkey).unwrap();
+    let sig: p256::ecdsa::Signature = sk.sign_prehash(&ch.card_input).unwrap();
+    ch.verify(sig.to_der().as_bytes()).unwrap();
+
+    // A signature over a different digest is well-formed DER but must not verify.
+    let other: p256::ecdsa::Signature = sk.sign_prehash(&[0x11; 32]).unwrap();
+    assert!(matches!(
+        ch.verify(other.to_der().as_bytes()),
+        Err(TestError::Mismatch(_))
+    ));
+}
+
+#[test]
+fn sign_round_trips_p384() {
+    use p384::ecdsa::signature::hazmat::PrehashSigner;
+    let sk = p384::ecdsa::SigningKey::from_slice(&card_scalar::<48>()).unwrap();
+    let pubkey = PublicKey::Ecc {
+        point: sk
+            .verifying_key()
+            .to_encoded_point(false)
+            .as_bytes()
+            .to_vec(),
+    };
+    let ch = prepare(SelfTest::Sign, KeyAlg::EccP384, &pubkey).unwrap();
+    let sig: p384::ecdsa::Signature = sk.sign_prehash(&ch.card_input).unwrap();
+    ch.verify(sig.to_der().as_bytes()).unwrap();
+}
+
+#[test]
+fn sign_round_trips_ed25519() {
+    use ed25519_dalek::Signer;
+    let sk = ed25519_dalek::SigningKey::from_bytes(&card_scalar::<32>());
+    let pubkey = PublicKey::Ecc {
+        point: sk.verifying_key().to_bytes().to_vec(),
+    };
+    let ch = prepare(SelfTest::Sign, KeyAlg::Ed25519, &pubkey).unwrap();
+    // Ed25519 signs the whole message, which is exactly `card_input`.
+    let sig = sk.sign(&ch.card_input);
+    ch.verify(&sig.to_bytes()).unwrap();
+
+    let mut bad = sig.to_bytes();
+    bad[0] ^= 0x01;
+    assert!(matches!(ch.verify(&bad), Err(TestError::Mismatch(_))));
+}
+
+// --- Gating --------------------------------------------------------
+
+#[test]
+fn supports_matrix() {
+    assert!(supports(SelfTest::Decrypt, KeyAlg::Rsa2048));
+    assert!(!supports(SelfTest::Decrypt, KeyAlg::EccP256));
+    assert!(supports(SelfTest::KeyAgree, KeyAlg::EccP384));
+    assert!(supports(SelfTest::KeyAgree, KeyAlg::X25519));
+    assert!(!supports(SelfTest::KeyAgree, KeyAlg::Ed25519));
+    assert!(supports(SelfTest::Sign, KeyAlg::Ed25519));
+    assert!(!supports(SelfTest::Sign, KeyAlg::X25519));
+}
+
+#[test]
+fn prepare_rejects_unsupported_combo() {
+    let pubkey = PublicKey::Ecc {
+        point: vec![0x04; 65],
+    };
+    assert!(matches!(
+        prepare(SelfTest::Decrypt, KeyAlg::EccP256, &pubkey),
+        Err(TestError::Unsupported(SelfTest::Decrypt, KeyAlg::EccP256))
+    ));
+}
+
+// --- full run: every applicable op, others skipped --------------------
+
+#[test]
+fn run_rsa_covers_decrypt_and_sign_skips_key_agree() {
+    let key = card_rsa();
+    let n = key.n().clone();
+    let d = key.d().clone();
+    let k = key.n().to_bytes_be().len();
+    let results = run(
+        KeyAlg::Rsa1024,
+        &rsa_pub(&key),
+        |_op, input| -> Result<Vec<u8>, String> { Ok(rsa_raw(input, &d, &n, k)) },
+    );
+    assert_eq!(
+        results,
+        vec![
+            (SelfTest::Decrypt, Outcome::Passed),
+            (SelfTest::KeyAgree, Outcome::Skipped(KeyAlg::Rsa1024)),
+            (SelfTest::Sign, Outcome::Passed),
+        ]
+    );
+    let report = format_report(&results);
+    assert!(report.contains("Decrypt: passed"));
+    assert!(report.contains("Key Agree: skipped \u{2014} not supported for RSA-1024 keys"));
+    assert!(!results.iter().any(|(_, r)| r.is_failure()));
+}
+
+#[test]
+fn run_p256_covers_key_agree_and_sign_skips_decrypt() {
+    use p256::ecdsa::signature::hazmat::PrehashSigner;
+    let secret = p256::SecretKey::from_slice(&card_scalar::<32>()).unwrap();
+    let sk = p256::ecdsa::SigningKey::from_slice(&card_scalar::<32>()).unwrap();
+    let pubkey = PublicKey::Ecc {
+        point: secret
+            .public_key()
+            .to_encoded_point(false)
+            .as_bytes()
+            .to_vec(),
+    };
+    let results = run(
+        KeyAlg::EccP256,
+        &pubkey,
+        |op, input| -> Result<Vec<u8>, String> {
+            if op.is_key_agreement() {
+                let their = p256::PublicKey::from_sec1_bytes(input).unwrap();
+                Ok(
+                    p256::ecdh::diffie_hellman(secret.to_nonzero_scalar(), their.as_affine())
+                        .raw_secret_bytes()
+                        .to_vec(),
+                )
+            } else {
+                let sig: p256::ecdsa::Signature = sk.sign_prehash(input).unwrap();
+                Ok(sig.to_der().as_bytes().to_vec())
+            }
+        },
+    );
+    assert_eq!(
+        results,
+        vec![
+            (SelfTest::Decrypt, Outcome::Skipped(KeyAlg::EccP256)),
+            (SelfTest::KeyAgree, Outcome::Passed),
+            (SelfTest::Sign, Outcome::Passed),
+        ]
+    );
+}
+
+#[test]
+fn run_reports_a_card_failure_as_failed_not_a_panic() {
+    let key = card_rsa();
+    let results = run(
+        KeyAlg::Rsa1024,
+        &rsa_pub(&key),
+        |_op, _input| -> Result<Vec<u8>, String> { Err("card said no".to_string()) },
+    );
+    assert!(matches!(
+        results[0],
+        (SelfTest::Decrypt, Outcome::Failed(_))
+    ));
+    assert_eq!(
+        results[1],
+        (SelfTest::KeyAgree, Outcome::Skipped(KeyAlg::Rsa1024))
+    );
+    assert!(results.iter().any(|(_, r)| r.is_failure()));
+}

--- a/crates/keyroost-transport/src/piv.rs
+++ b/crates/keyroost-transport/src/piv.rs
@@ -1122,36 +1122,89 @@ impl PivSession {
         prepared: &[u8],
     ) -> Result<Vec<u8>, TransportError> {
         let key_ref = slot.key_ref();
-        let apdu = piv::general_auth_sign(alg, key_ref, prepared);
+        self.general_auth_dyn_auth(
+            "piv sign",
+            &piv::general_auth_sign(alg, key_ref, prepared),
+            &piv::general_auth_sign_chained(alg, key_ref, prepared, CHAIN_CHUNK),
+        )
+    }
+
+    /// Ask `slot`'s RSA private key to raw-decrypt `ciphertext` (a `k`-byte
+    /// PKCS#1 block) via GENERAL AUTHENTICATE. Wire-identical to [`Self::sign`]
+    /// — the card does the same raw RSA private-key operation for both, and
+    /// the input rides the same dynamic-auth `0x81` field — but named
+    /// separately so a decrypt call site reads as one. Needs a verified PIN
+    /// immediately prior, same as `sign`.
+    pub fn decrypt(
+        &mut self,
+        slot: Slot,
+        alg: KeyAlg,
+        ciphertext: &[u8],
+    ) -> Result<Vec<u8>, TransportError> {
+        let key_ref = slot.key_ref();
+        self.general_auth_dyn_auth(
+            "piv decrypt",
+            &piv::general_auth_sign(alg, key_ref, ciphertext),
+            &piv::general_auth_sign_chained(alg, key_ref, ciphertext, CHAIN_CHUNK),
+        )
+    }
+
+    /// Run ECDH on `slot`'s private key against `peer_public_key` via GENERAL
+    /// AUTHENTICATE key-establishment (dynamic-auth tag `0x85`).
+    /// `peer_public_key` is `04 || X || Y` for P-256/P-384 or the raw 32-byte
+    /// point for X25519; the reply is the raw shared secret `Z` (the
+    /// x-coordinate for the NIST curves). Needs a verified PIN immediately
+    /// prior, same as [`Self::sign`].
+    pub fn key_agree(
+        &mut self,
+        slot: Slot,
+        alg: KeyAlg,
+        peer_public_key: &[u8],
+    ) -> Result<Vec<u8>, TransportError> {
+        let key_ref = slot.key_ref();
+        self.general_auth_dyn_auth(
+            "piv key-agree",
+            &piv::general_auth_key_agree(alg, key_ref, peer_public_key),
+            &piv::general_auth_key_agree_chained(alg, key_ref, peer_public_key, CHAIN_CHUNK),
+        )
+    }
+
+    /// The GENERAL AUTHENTICATE transmit shared by [`Self::sign`],
+    /// [`Self::decrypt`], and [`Self::key_agree`]: send `single` once, and if
+    /// it used extended-length encoding and the card rejected it (`SW != 9000`),
+    /// retry with the `chained` APDU sequence. Returns the response's `0x82`
+    /// dynamic-auth value. The fallback only fires when the first attempt
+    /// actually used extended-length encoding, so a genuine error on a
+    /// short-form command (bad PIN state, wrong key, …) isn't retried.
+    fn general_auth_dyn_auth(
+        &mut self,
+        label: &'static str,
+        single: &[u8],
+        chained: &[Vec<u8>],
+    ) -> Result<Vec<u8>, TransportError> {
         let (data, sw) = if self.chain_upfront() {
             trace::line(self.debug, || {
                 format!(
-                    "! piv sign: command chaining up front ({})",
+                    "! {label}: command chaining up front ({})",
                     self.chain_reason()
                 )
             });
-            self.transmit_chain(
-                "piv sign",
-                &piv::general_auth_sign_chained(alg, key_ref, prepared, CHAIN_CHUNK),
-            )?
+            self.transmit_chain(label, chained)?
         } else {
-            let (data, sw) = self.transmit_full(&apdu)?;
-            if sw == piv::SW_OK || !uses_extended_length(&apdu) {
+            let (data, sw) = self.transmit_full(single)?;
+            if sw == piv::SW_OK || !uses_extended_length(single) {
                 (data, sw)
             } else {
                 trace::line(self.debug, || {
                     format!(
-                        "! piv sign: extended length rejected (SW={sw:04X}); retrying with \
+                        "! {label}: extended length rejected (SW={sw:04X}); retrying with \
                          command chaining"
                     )
                 });
-                self.transmit_chain(
-                    "piv sign",
-                    &piv::general_auth_sign_chained(alg, key_ref, prepared, CHAIN_CHUNK),
-                )?
+                self.transmit_chain(label, chained)?
             }
         };
-        ok_or_write("piv sign", sw)?;
+        ok_or_write(label, sw)?;
         piv::parse_general_auth(&data, 0x82)
             .map(<[u8]>::to_vec)
             .map_err(TransportError::PivParse)

--- a/crates/keyroost/Cargo.toml
+++ b/crates/keyroost/Cargo.toml
@@ -23,6 +23,7 @@ keyroost-transport = { path = "../keyroost-transport", version = "0.9.0" }
 keyroost-token2prog = { path = "../keyroost-token2prog", version = "0.9.0" }
 keyroost-token2otp = { path = "../keyroost-token2otp", version = "0.9.0" }
 keyroost-piv = { path = "../keyroost-piv", version = "0.9.0" }
+keyroost-pivtest = { path = "../keyroost-pivtest", version = "0.9.0" }
 keyroost-hid = { path = "../keyroost-hid", version = "0.9.0" }
 keyroost-ctap = { path = "../keyroost-ctap", version = "0.9.0" }
 keyroost-keyring = { path = "../keyroost-keyring", version = "0.9.0" }

--- a/crates/keyroost/src/main.rs
+++ b/crates/keyroost/src/main.rs
@@ -1350,6 +1350,11 @@ enum PivCredKind {
     DeleteKey,
     MoveKey,
     NewChuid,
+    /// Run every key self-test the selected slot's algorithm supports
+    /// (decrypt / key-agree / sign, in that order). Needs the PIN (unless the
+    /// slot's PIN policy is `never`); no management key, and nothing on the
+    /// card changes.
+    SelfTest,
 }
 
 impl PivCredKind {
@@ -1369,6 +1374,7 @@ impl PivCredKind {
             PivCredKind::DeleteKey => "Delete key",
             PivCredKind::MoveKey => "Move key",
             PivCredKind::NewChuid => "New CHUID",
+            PivCredKind::SelfTest => "Key self-test",
         }
     }
     /// Label for the modal's primary Submit button. Shorter than the title for
@@ -1385,6 +1391,7 @@ impl PivCredKind {
             PivCredKind::DeleteKey => "Delete",
             PivCredKind::MoveKey => "Move",
             PivCredKind::NewChuid => "Write",
+            PivCredKind::SelfTest => "Run",
             _ => self.title(),
         }
     }
@@ -1405,6 +1412,7 @@ impl PivCredKind {
             PivCredKind::DeleteKey => "Deleting key\u{2026}",
             PivCredKind::MoveKey => "Moving key\u{2026}",
             PivCredKind::NewChuid => "Writing a new CHUID\u{2026}",
+            PivCredKind::SelfTest => "Running self-test\u{2026}",
         }
     }
     /// True when this flow collects the *current* management key (and therefore
@@ -1434,6 +1442,10 @@ struct PivCredModal {
     kind: PivCredKind,
     busy: bool,
     result: Option<Result<(), String>>,
+    /// A multi-line report shown under the success line — currently only the
+    /// per-operation pass list from a `SelfTest` run that fully passed. A
+    /// failing run puts its report in `result`'s `Err` instead.
+    detail: Option<String>,
 }
 
 impl PivCredModal {
@@ -1442,6 +1454,7 @@ impl PivCredModal {
             kind,
             busy: false,
             result: None,
+            detail: None,
         }
     }
 }
@@ -7098,6 +7111,95 @@ impl App {
         )
     }
 
+    /// The selected slot's `(PIN policy, touch policy)` from the last
+    /// `status_detailed` read, or `None` when the card didn't report one.
+    fn piv_selected_slot_policy(
+        &self,
+    ) -> Option<(keyroost_piv::PinPolicy, keyroost_piv::TouchPolicy)> {
+        let sel = self.piv.selected_slot.to_slot();
+        self.piv
+            .slot_policies
+            .iter()
+            .find(|(s, _)| *s == sel)
+            .and_then(|(_, pol)| *pol)
+    }
+
+    /// The selected slot's key algorithm (from the last `status_detailed`
+    /// read) and whether it holds a certificate — the two facts the Test row
+    /// gates its button on.
+    fn piv_selected_test_target(&self) -> (Option<keyroost_piv::KeyAlg>, bool) {
+        let sel = self.piv.selected_slot.to_slot();
+        let entry = self.piv.slot_keys.iter().find(|(s, _, _)| *s == sel);
+        let alg = entry.and_then(|(_, a, _)| *a);
+        let has_cert = entry.is_some_and(|(_, _, dn)| dn.is_some())
+            || self
+                .piv
+                .status
+                .as_ref()
+                .is_some_and(|st| st.slots.iter().any(|s| s.slot == sel && s.cert_present));
+        (alg, has_cert)
+    }
+
+    /// Run every self-test the selected slot's key algorithm supports
+    /// (decrypt, then key-agree, then sign): build a fixed challenge from the
+    /// slot certificate's public key ([`keyroost_pivtest`]), run the
+    /// private-key op on the card, and verify the reply against that public
+    /// key. Read-only on the card — no write, no management key. The PIN is
+    /// verified unless the slot's PIN policy is `never` and the field is
+    /// blank. Each operation's pass/fail is reported together.
+    fn piv_self_test(&mut self) {
+        let Some(name) = self.selected_oath_reader() else {
+            return;
+        };
+        let pin = zeroize::Zeroizing::new(self.piv.sign_pin.clone());
+        let slot = self.piv.selected_slot.to_slot();
+        let policy = self.piv_selected_slot_policy();
+        let pin_required = policy.map(|(p, _)| p) != Some(keyroost_piv::PinPolicy::Never);
+        let want_touch = matches!(
+            policy.map(|(_, t)| t),
+            Some(keyroost_piv::TouchPolicy::Always | keyroost_piv::TouchPolicy::Cached)
+        );
+        self.piv.notice = None;
+        let label = if want_touch {
+            "Running self-test\u{2026} \u{2014} touch the key"
+        } else {
+            "Running self-test\u{2026}"
+        };
+        self.spawn_job(label, move || {
+            let outcome = run_piv_self_test(&name, slot, pin_required, pin.as_bytes());
+            Box::new(move |app: &mut App| {
+                wipe(&mut app.piv.sign_pin);
+                let (all_ok, text) = match &outcome {
+                    // Skipped ops don't count as failures.
+                    Ok(results) => (
+                        !results.iter().any(|(_, r)| r.is_failure()),
+                        keyroost_pivtest::format_report(results),
+                    ),
+                    Err(e) => (false, e.clone()),
+                };
+                if all_ok {
+                    app.log(
+                        Severity::Ok,
+                        format!("PIV self-test on {} passed", slot.label()),
+                    );
+                    app.piv.error = None;
+                    app.piv.notice = Some(text.clone());
+                } else {
+                    app.log(
+                        Severity::Err,
+                        format!("PIV self-test on {} failed", slot.label()),
+                    );
+                    app.piv.notice = None;
+                    app.piv.error = Some(text.clone());
+                }
+                if let Some(m) = app.piv.cred_modal.as_mut() {
+                    m.detail = all_ok.then_some(text);
+                }
+                Self::apply_piv_cred_result(app);
+            })
+        });
+    }
+
     /// Normalize the certificate-subject field: a bare name becomes `CN=name`;
     /// anything containing `=` is taken as a full distinguished name.
     fn piv_subject(&self) -> Option<String> {
@@ -7625,7 +7727,8 @@ fn piv_cred_mismatch(piv: &PivState, kind: PivCredKind) -> Option<&'static str> 
         | PivCredKind::DeleteCert
         | PivCredKind::DeleteKey
         | PivCredKind::MoveKey
-        | PivCredKind::NewChuid => return None,
+        | PivCredKind::NewChuid
+        | PivCredKind::SelfTest => return None,
     };
     if confirm.is_empty() || new == confirm {
         None
@@ -7653,7 +7756,65 @@ fn piv_cred_success(kind: PivCredKind) -> &'static str {
         PivCredKind::DeleteKey => "Key deleted",
         PivCredKind::MoveKey => "Key moved",
         PivCredKind::NewChuid => "New CHUID written",
+        PivCredKind::SelfTest => "Self-test complete",
     }
+}
+
+/// Run every [`keyroost_pivtest::SelfTest`] against the card on `reader`
+/// (delegating the orchestration to [`keyroost_pivtest::run`]). Operations the
+/// slot's key algorithm doesn't do come back `keyroost_pivtest::Outcome::Skipped`
+/// (which carries the algorithm, so [`keyroost_pivtest::format_report`] can name
+/// it) and are shown in the dialog like the others.
+///
+/// `Err` is a *setup* failure (couldn't open the card, no certificate in the
+/// slot, unreadable key, PIN rejected) — nothing was tested.
+fn run_piv_self_test(
+    reader: &str,
+    slot: keyroost_piv::Slot,
+    pin_required: bool,
+    pin: &[u8],
+) -> Result<Vec<(keyroost_pivtest::SelfTest, keyroost_pivtest::Outcome)>, String> {
+    let mut s = keyroost_transport::PivSession::open(reader).map_err(|e| e.to_string())?;
+    let cert = s
+        .read_certificate(slot)
+        .map_err(|e| e.to_string())?
+        .ok_or_else(|| format!("{} has no certificate to test against", slot.label()))?;
+    let (alg, pubkey) = keyroost_piv::x509_parse::parse_certificate_public_key(&cert)
+        .map_err(|e| format!("could not read the slot certificate's key: {e}"))?;
+
+    if !keyroost_pivtest::SelfTest::all()
+        .into_iter()
+        .any(|op| keyroost_pivtest::supports(op, alg))
+    {
+        return Err(format!("no self-test applies to a {} key", alg.label()));
+    }
+
+    // Verify once up front so a wrong PIN fails the whole run (one retry, not
+    // one per op). PIN-per-use slots (9C) drop the verified state after each
+    // GENERAL AUTHENTICATE, so the per-op closure re-verifies before every
+    // op after the first that actually runs.
+    if pin_required || !pin.is_empty() {
+        s.verify_pin(pin).map_err(|e| e.to_string())?;
+    }
+    let mut ran = 0usize;
+    Ok(keyroost_pivtest::run(
+        alg,
+        &pubkey,
+        |op, input| -> Result<Vec<u8>, String> {
+            if pin_required && ran > 0 {
+                s.verify_pin(pin).map_err(|e| e.to_string())?;
+            }
+            ran += 1;
+            if op.is_key_agreement() {
+                s.key_agree(slot, alg, input)
+            } else if op == keyroost_pivtest::SelfTest::Decrypt {
+                s.decrypt(slot, alg, input)
+            } else {
+                s.sign(slot, alg, input)
+            }
+            .map_err(|e| e.to_string())
+        },
+    ))
 }
 
 /// Slots a key may be moved to: every standard + retired slot that is empty
@@ -12455,6 +12616,18 @@ impl App {
         };
         let busy = self.piv.cred_modal.as_ref().is_some_and(|m| m.busy);
         let result = self.piv.cred_modal.as_ref().and_then(|m| m.result.clone());
+        let detail = self.piv.cred_modal.as_ref().and_then(|m| m.detail.clone());
+        // The self-test spinner asks for a touch when the selected slot's
+        // touch policy needs one (mirrors the Generate-key spinner wording).
+        let busy_text = if kind == PivCredKind::SelfTest
+            && matches!(
+                self.piv_selected_slot_policy().map(|(_, t)| t),
+                Some(keyroost_piv::TouchPolicy::Always | keyroost_piv::TouchPolicy::Cached)
+            ) {
+            format!("{} \u{2014} touch the key", kind.busy_label())
+        } else {
+            kind.busy_label().to_owned()
+        };
 
         let mut want_submit = false;
         let mut want_close = false;
@@ -12516,6 +12689,13 @@ impl App {
                             .font(theme::f_sb(13.0))
                             .color(p.ok),
                     );
+                    // Per-operation breakdown (self-test): one line each.
+                    if let Some(d) = &detail {
+                        ui.add_space(6.0);
+                        for line in d.lines() {
+                            card_note(ui, p, line);
+                        }
+                    }
                     ui.add_space(16.0);
                     if theme::button(ui, p, BtnKind::Primary, "Done").clicked() {
                         want_close = true;
@@ -12626,6 +12806,26 @@ impl App {
                         PivCredKind::RequestCsr => {
                             pin_field(ui, p, "PIN", &mut self.piv.sign_pin);
                             card_note(ui, p, "The PIN authorizes the on-card signature.");
+                        }
+                        PivCredKind::SelfTest => {
+                            pin_field(ui, p, "PIN", &mut self.piv.sign_pin);
+                            if self.piv_selected_slot_policy().map(|(pin, _)| pin)
+                                == Some(keyroost_piv::PinPolicy::Never)
+                            {
+                                card_note(
+                                    ui,
+                                    p,
+                                    "This slot's PIN policy is \u{201c}never\u{201d} \u{2014} \
+                                     you can leave the PIN blank.",
+                                );
+                            }
+                            card_note(
+                                ui,
+                                p,
+                                "Runs every self-test the slot's key supports (decrypt / \
+                                 key-agree / sign) and verifies each result against the \
+                                 certificate's public key. Nothing on the card changes.",
+                            );
                         }
                         PivCredKind::SetRetries => {
                             self.piv_modal_mgmt_field(ui, p, kind);
@@ -12798,7 +12998,7 @@ impl App {
                         if busy {
                             ui.add(egui::Spinner::new());
                             ui.label(
-                                egui::RichText::new(kind.busy_label())
+                                egui::RichText::new(busy_text.as_str())
                                     .font(theme::f_reg(12.5))
                                     .color(p.txt2),
                             );
@@ -12858,6 +13058,7 @@ impl App {
                 PivCredKind::DeleteKey => self.piv_delete_key(),
                 PivCredKind::MoveKey => self.piv_move_key(),
                 PivCredKind::NewChuid => self.piv_new_chuid(),
+                PivCredKind::SelfTest => self.piv_self_test(),
             }
             // If the op didn't actually queue, unstick the modal. This happens
             // either because the worker was busy (no error set — just retry on
@@ -13737,6 +13938,7 @@ impl App {
         let mut open_delete_cert = false;
         let mut open_delete_key = false;
         let mut open_move_key = false;
+        let mut open_self_test = false;
         let mut open_new_chuid = false;
         let mut click_retired_tab = false;
         let mut arm_reset = false;
@@ -14435,6 +14637,42 @@ impl App {
                     }
                 });
             });
+
+            // --- Test: one button that runs every self-test the selected
+            // slot's key supports (decrypt / key-agree / sign, in that order)
+            // and reports each result. Read-only — the card operates but
+            // nothing is written. Live only when the slot holds a certificate
+            // with a key type keyroost can test.
+            ui.add_space(12.0);
+            ui.horizontal(|ui| {
+                ui.label(
+                    egui::RichText::new("Test")
+                        .font(theme::f_sb(13.5))
+                        .color(p.txt),
+                );
+                ui.add_space(6.0);
+                self.help_dot(ui, p, "piv-test");
+                let (test_alg, test_has_cert) = self.piv_selected_test_target();
+                ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                    if test_has_cert && test_alg.is_some() {
+                        if theme::button(ui, p, BtnKind::Default, "Test\u{2026}").clicked() {
+                            open_self_test = true;
+                        }
+                    } else {
+                        let why = if !test_has_cert {
+                            "Needs a certificate in this slot."
+                        } else {
+                            "The slot's key type is unknown."
+                        };
+                        ui.add_enabled_ui(false, |ui| {
+                            theme::button(ui, p, BtnKind::Default, "Test\u{2026}")
+                        })
+                        .inner
+                        .on_disabled_hover_text(why);
+                    }
+                });
+            });
+
             if !can_delete_key {
                 ui.add_space(4.0);
                 note(ui, "Key deletion needs YubiKey 5.7+.");
@@ -14534,6 +14772,10 @@ impl App {
         if open_delete_key {
             self.piv_cred_modal_close();
             self.piv.cred_modal = Some(PivCredModal::new(PivCredKind::DeleteKey));
+        }
+        if open_self_test {
+            self.piv_cred_modal_close();
+            self.piv.cred_modal = Some(PivCredModal::new(PivCredKind::SelfTest));
         }
         if open_move_key {
             self.piv_cred_modal_close();
@@ -17192,6 +17434,7 @@ mod tests {
             kind: PivCredKind::ChangePin,
             busy: true,
             result: None,
+            detail: None,
         });
         app.piv.error = None;
         App::apply_piv_cred_result(&mut app);

--- a/crates/keyroost/src/ui/help.rs
+++ b/crates/keyroost/src/ui/help.rs
@@ -24,7 +24,7 @@ pub struct Help {
 /// Look up help content by topic id. Topic ids (use these as the `?` keys):
 ///   device, fido2, pin, passkeys, oath, pgp, pgp-keys, pgp-card-details, piv,
 ///   molto, custkey, reset, piv-generate, piv-certificate, piv-import,
-///   piv-export, piv-delete, piv-admin
+///   piv-export, piv-delete, piv-test, piv-admin, piv-move, piv-retired
 pub fn help(topic: &str) -> Option<&'static Help> {
     Some(match topic {
         "device" => &Help {
@@ -131,6 +131,11 @@ pub fn help(topic: &str) -> Option<&'static Help> {
             title: "Delete from the slot",
             body: "Clearing the certificate leaves the key in place; erasing the private key removes it for good (and needs a YubiKey 5.7 or newer). Both are permanent and can't be undone.",
             slug: "/piv#delete",
+        },
+        "piv-test" => &Help {
+            title: "Test the slot's key",
+            body: "Checks that the slot's private key actually works: keyroost builds a small fixed challenge from the slot certificate's public key, has the card run every operation the key type supports (decrypt for RSA; key-agree for ECDH curves; sign for RSA / ECDSA / Ed25519), and verifies each result against that same public key. It reports each operation's pass or fail. It needs the PIN unless the slot's PIN policy is \u{201c}never\u{201d}, and it changes nothing on the card.",
+            slug: "/piv#test",
         },
         "piv-admin" => &Help {
             title: "Card administration",

--- a/crates/keyroostctl/Cargo.toml
+++ b/crates/keyroostctl/Cargo.toml
@@ -18,6 +18,7 @@ path = "src/main.rs"
 keyroost-proto = { path = "../keyroost-proto", version = "0.9.0" }
 keyroost-transport = { path = "../keyroost-transport", version = "0.9.0" }
 keyroost-piv = { path = "../keyroost-piv", version = "0.9.0" }
+keyroost-pivtest = { path = "../keyroost-pivtest", version = "0.9.0" }
 keyroost-hid = { path = "../keyroost-hid", version = "0.9.0" }
 keyroost-ctap = { path = "../keyroost-ctap", version = "0.9.0" }
 keyroost-keyring = { path = "../keyroost-keyring", version = "0.9.0" }

--- a/crates/keyroostctl/src/main.rs
+++ b/crates/keyroostctl/src/main.rs
@@ -178,6 +178,27 @@ mod json_out {
         pub cert_len: usize,
     }
 
+    /// `keyroostctl piv --json test`.
+    #[derive(Serialize)]
+    pub struct PivTestJson {
+        pub slot: String,
+        pub algorithm: String,
+        /// `true` when no operation failed (skipped ops don't count).
+        pub ok: bool,
+        pub operations: Vec<PivTestOpJson>,
+    }
+
+    /// One operation in [`PivTestJson::operations`].
+    #[derive(Serialize)]
+    pub struct PivTestOpJson {
+        pub operation: String,
+        /// `"passed"`, `"failed"`, or `"skipped"`.
+        pub result: String,
+        /// Present only for `"failed"` — a short reason.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub detail: Option<String>,
+    }
+
     /// `keyroostctl openpgp --json status`.
     #[derive(Serialize)]
     pub struct OpenpgpStatusJson {
@@ -971,6 +992,23 @@ enum PivCmd {
         load_pubkey: Option<std::path::PathBuf>,
         #[command(flatten)]
         keygen: InlineKeyGen,
+    },
+    /// Exercise a slot's private key end to end: for every operation the key's
+    /// algorithm supports (decrypt for RSA, key-agree for ECDH curves, sign
+    /// for RSA / ECDSA / Ed25519), run a fixed challenge on the card and
+    /// verify the result against the slot certificate's public key. Reports
+    /// each operation's pass / fail / skipped. Read-only — nothing on the card
+    /// changes. Needs the PIN unless the slot's PIN policy is `never`
+    /// (then omit `--pin-env` / `--pin-stdin`).
+    Test {
+        #[arg(long, value_name = "SUBSTR")]
+        reader: Option<String>,
+        #[arg(long, value_enum)]
+        slot: CliPivSlot,
+        #[arg(long, value_name = "VAR", conflicts_with = "pin_stdin")]
+        pin_env: Option<String>,
+        #[arg(long)]
+        pin_stdin: bool,
     },
     /// Write a fresh, randomly-generated CHUID (Card Holder Unique
     /// Identifier). Needs the management key. Windows' PIV minidriver caches
@@ -6465,6 +6503,94 @@ fn run_piv(cmd: &PivCmd, debug: bool) -> Result<(), Box<dyn std::error::Error>> 
             }
         }
 
+        PivCmd::Test {
+            reader,
+            slot,
+            pin_env,
+            pin_stdin,
+        } => {
+            let piv_slot = slot.to_slot();
+            // The PIN is optional: a slot whose PIN policy is `never` (usually
+            // 9e) needs none. When given, verify it once up front so a wrong
+            // PIN fails before any op and costs just one retry.
+            let pin = if pin_env.is_some() || *pin_stdin {
+                Some(read_secret("PIN", pin_env.as_deref(), *pin_stdin)?)
+            } else {
+                None
+            };
+
+            let mut s = open_piv(reader.as_deref(), debug)?;
+            let cert = s.read_certificate(piv_slot)?.ok_or_else(|| {
+                format!("{} has no certificate to test against", piv_slot.label())
+            })?;
+            let (alg, pubkey) = keyroost_piv::x509_parse::parse_certificate_public_key(&cert)
+                .map_err(|e| format!("could not read the slot certificate's key: {e}"))?;
+
+            if !keyroost_pivtest::SelfTest::all()
+                .into_iter()
+                .any(|op| keyroost_pivtest::supports(op, alg))
+            {
+                return Err(format!("no self-test applies to a {} key", alg.label()).into());
+            }
+
+            if let Some(pin) = &pin {
+                s.verify_pin(pin.as_bytes())?;
+            }
+            eprintln!(
+                "\u{2192} Testing {} ({}) on the card (touch if it blinks)\u{2026}",
+                piv_slot.label(),
+                alg.label()
+            );
+
+            let mut ran = 0usize;
+            let results = keyroost_pivtest::run(alg, &pubkey, |op, input| {
+                // PIN-per-use slots (9c) drop the verified state after each
+                // GENERAL AUTHENTICATE — re-verify before every op past the
+                // first that actually runs.
+                if let (Some(pin), true) = (&pin, ran > 0) {
+                    s.verify_pin(pin.as_bytes())?;
+                }
+                ran += 1;
+                if op.is_key_agreement() {
+                    s.key_agree(piv_slot, alg, input)
+                } else if op == keyroost_pivtest::SelfTest::Decrypt {
+                    s.decrypt(piv_slot, alg, input)
+                } else {
+                    s.sign(piv_slot, alg, input)
+                }
+            });
+
+            let all_ok = !results.iter().any(|(_, r)| r.is_failure());
+            if json_output() {
+                emit_json(&json_out::PivTestJson {
+                    slot: piv_slot.label().to_string(),
+                    algorithm: alg.label().to_string(),
+                    ok: all_ok,
+                    operations: results
+                        .iter()
+                        .map(|(op, r)| json_out::PivTestOpJson {
+                            operation: op.label().to_string(),
+                            result: match r {
+                                keyroost_pivtest::Outcome::Passed => "passed",
+                                keyroost_pivtest::Outcome::Skipped(_) => "skipped",
+                                keyroost_pivtest::Outcome::Failed(_) => "failed",
+                            }
+                            .to_string(),
+                            detail: match r {
+                                keyroost_pivtest::Outcome::Failed(e) => Some(e.clone()),
+                                _ => None,
+                            },
+                        })
+                        .collect(),
+                })?;
+            } else {
+                println!("{}", keyroost_pivtest::format_report(&results));
+            }
+            if !all_ok {
+                return Err("one or more self-tests failed".into());
+            }
+        }
+
         PivCmd::NewChuid {
             reader,
             mgmt_key_env,
@@ -9993,6 +10119,46 @@ mod cli_tests {
                 assert_eq!(to.to_slot().key_ref(), 0x82);
             }
             _ => panic!("expected piv move-key"),
+        }
+    }
+
+    #[test]
+    fn piv_test_parses_slot_and_optional_pin() {
+        // No PIN source — valid (PIN-never slots).
+        match parse(&["keyroostctl", "piv", "test", "--slot", "9e"])
+            .unwrap()
+            .command
+        {
+            Some(Cmd::Piv {
+                cmd:
+                    PivCmd::Test {
+                        slot,
+                        pin_env,
+                        pin_stdin,
+                        ..
+                    },
+            }) => {
+                assert_eq!(slot.to_slot().key_ref(), 0x9E);
+                assert!(pin_env.is_none() && !pin_stdin);
+            }
+            _ => panic!("expected piv test"),
+        }
+        match parse(&[
+            "keyroostctl",
+            "piv",
+            "test",
+            "--slot",
+            "9a",
+            "--pin-env",
+            "KR_PIN",
+        ])
+        .unwrap()
+        .command
+        {
+            Some(Cmd::Piv {
+                cmd: PivCmd::Test { pin_env, .. },
+            }) => assert_eq!(pin_env.as_deref(), Some("KR_PIN")),
+            _ => panic!("expected piv test"),
         }
     }
 

--- a/docs/piv.html
+++ b/docs/piv.html
@@ -183,8 +183,8 @@ keyroostctl piv move-key --from 82 --to 9d --mgmt-key-stdin   # bring it back</c
 keyroostctl piv test --slot 9e                 # PIN policy "never" — omit the PIN
 keyroostctl --json piv test --slot 9c --pin-env PIV_PIN</code></pre>
     <p class="kr-muted">The command prints one line per operation —
-      <code>decrypt: passed</code>, <code>sign: FAILED — …</code>,
-      <code>key-agree: skipped — not supported for …</code> — and exits non-zero if any
+      <code>Decrypt: passed</code>, <code>Sign: FAILED — …</code>,
+      <code>Key Agree: skipped — not supported for …</code> — and exits non-zero if any
       operation failed. With <code>--json</code> it emits
       <code>{ slot, algorithm, ok, operations: [ { operation, result } … ] }</code> instead.
       A slot with no certificate, or a key type keyroost can't verify, is an error — nothing

--- a/docs/piv.html
+++ b/docs/piv.html
@@ -126,8 +126,8 @@
         request (CSR)</strong> for a certificate authority — signed by the card itself, the
         private key never leaves it — imports and exports certificates, changes the PIN,
         PUK, retry counts and management key, moves a key between slots, clears a slot's
-        certificate or key, writes a fresh CHUID, and resets
-        the applet. The same controls are in the desktop app's PIV pane.</p>
+        certificate or key, tests that a slot's key still works, writes a fresh CHUID, and
+        resets the applet. The same controls are in the desktop app's PIV pane.</p>
     </div>
 <pre><code>keyroostctl piv status
 keyroostctl piv generate-key --slot 9a --algorithm eccp256 --mgmt-key-stdin
@@ -163,6 +163,32 @@ keyroostctl piv delete-key  --slot 9a --mgmt-key-stdin --yes   # YubiKey 5.7+</c
       desktop app offers the same thing as <strong>Move key…</strong>.</p>
 <pre><code>keyroostctl piv move-key --from 9d --to 82 --mgmt-key-stdin   # archive a rotated key
 keyroostctl piv move-key --from 82 --to 9d --mgmt-key-stdin   # bring it back</code></pre>
+    <span id="test"></span>
+    <p><strong>Testing a slot's key.</strong> <code>test</code> proves a slot's private key
+      still works end to end, without changing anything on the card. keyroost reads the
+      slot's certificate, takes its public key, and builds a fixed challenge from it; the
+      card then runs every private-key operation the key's algorithm supports and keyroost
+      verifies each result against that same public key. The operations depend on the key
+      type — <strong>decrypt</strong> for RSA, <strong>key-agree</strong> (ECDH) for
+      P-256&nbsp;/&nbsp;P-384&nbsp;/&nbsp;X25519, and <strong>sign</strong> for
+      RSA&nbsp;/&nbsp;ECDSA&nbsp;/&nbsp;Ed25519 — and an operation the key can't do is
+      reported as <em>skipped</em>, not failed. It needs the PIN unless the slot's PIN
+      policy is <code>never</code> (typically <code>9E</code>), in which case leave the PIN
+      flags off; a PIN-per-use slot such as <code>9C</code> is re-verified before each
+      operation. The challenge is deterministic — sliced from one built-in constant — so a
+      run is fully reproducible and pulls in no randomness. The desktop app offers the same
+      thing as <strong>Test…</strong> in the slot pane, just below Delete; the button is
+      live only when the slot holds a certificate with a key type keyroost can test.</p>
+<pre><code>keyroostctl piv test --slot 9a --pin-stdin
+keyroostctl piv test --slot 9e                 # PIN policy "never" — omit the PIN
+keyroostctl --json piv test --slot 9c --pin-env PIV_PIN</code></pre>
+    <p class="kr-muted">The command prints one line per operation —
+      <code>decrypt: passed</code>, <code>sign: FAILED — …</code>,
+      <code>key-agree: skipped — not supported for …</code> — and exits non-zero if any
+      operation failed. With <code>--json</code> it emits
+      <code>{ slot, algorithm, ok, operations: [ { operation, result } … ] }</code> instead.
+      A slot with no certificate, or a key type keyroost can't verify, is an error — nothing
+      is tested.</p>
     <span id="new-chuid"></span>
     <p><strong>Writing a new CHUID.</strong> <code>new-chuid</code> writes a fresh Card Holder
       Unique Identifier with a randomly-generated GUID (or one you supply with


### PR DESCRIPTION
This PR adds a test feature for PIV private key operations. The test run's all private key operations supported by the slot's key algorithm (decrypt, sign, key agree) using well-known challenge data and checks the result against the expectations. This permits validating that private key operations including pin/touch capabilities actually work as intended.